### PR TITLE
set 'Android' as platform for Chrome on Android

### DIFF
--- a/lib/user_agent/browsers/chrome.rb
+++ b/lib/user_agent/browsers/chrome.rb
@@ -37,6 +37,8 @@ class UserAgent
           'Windows'
         elsif application.comment.any? { |c| c =~ /CrOS/ }
           'ChromeOS'
+        elsif application.comment.any? { |c| c =~ /Android/ }
+          'Android'
         else
           application.comment[0]
         end

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -149,8 +149,8 @@ describe "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535
     expect(@useragent.browser).to eq("Chrome")
   end
 
-  it "should return 'Linux' as its platform" do
-    expect(@useragent.platform).to eq("Linux")
+  it "should return 'Android' as its platform" do
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "should return 'Android 4.2' as its os" do


### PR DESCRIPTION
It looks like `UserAgent::Browsers::Chrome#platform` behaves different from `UserAgent::Browsers::Webkit#platform` for Android user agents. Whereas Webkit returns 'Android' for android devices, Chrome returns 'Linux'. Pulling over the android conditional check from the webkit platform method to the chrome platform method fixes the issue. 

Webkit on Android
```
irb(main):001:0> webkit = UserAgent.parse('Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1')
=> [#<UserAgent:0x007fcb2b281768 @product="Mozilla", @version=#<UserAgent::Version 5.0>, @comment=["Linux", "U", "Android 2.3.5", "en-us", "HTC Vision Build/GRI40"]>, #<UserAgent:0x007fcb2b280db8 @product="AppleWebKit", @version=#<UserAgent::Version 533.1>, @comment=["KHTML, like Gecko"]>, #<UserAgent:0x007fcb2b2806d8 @product="Version", @version=#<UserAgent::Version 4.0>, @comment=nil>, #<UserAgent:0x007fcb2b280110 @product="Mobile", @version=#<UserAgent::Version >, @comment=nil>, #<UserAgent:0x007fcb2b2801b0 @product="Safari", @version=#<UserAgent::Version 533.1>, @comment=nil>]

irb(main):002:0> webkit.platform
=> "Android"
```

Chrome on Android
```
irb(main):003:0> chrome = UserAgent.parse('Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19')
=> [#<UserAgent:0x007fcb2baca898 @product="Mozilla", @version=#<UserAgent::Version 5.0>, @comment=["Linux", "Android 4.0.4", "Galaxy Nexus Build/IMM76B"]>, #<UserAgent:0x007fcb2bac9f38 @product="AppleWebKit", @version=#<UserAgent::Version 535.19>, @comment=["KHTML, like Gecko"]>, #<UserAgent:0x007fcb2bac9628 @product="Chrome", @version=#<UserAgent::Version 18.0.1025.133>, @comment=nil>, #<UserAgent:0x007fcb2bac8d68 @product="Mobile", @version=#<UserAgent::Version >, @comment=nil>, #<UserAgent:0x007fcb2bac8958 @product="Safari", @version=#<UserAgent::Version 535.19>, @comment=nil>]

irb(main):004:0> chrome.platform
=> "Linux"
```