### PR TITLE
add Trident/8.0 IE11 variant

### DIFF
--- a/lib/user_agent/browsers/internet_explorer.rb
+++ b/lib/user_agent/browsers/internet_explorer.rb
@@ -2,6 +2,7 @@ class UserAgent
   module Browsers
     class InternetExplorer < Base
       TRIDENT_ENGINES = {
+        "Trident/8.0" => "11.0",
         "Trident/7.0" => "11.0",
         "Trident/6.0" => "10.0",
         "Trident/5.0" => "9.0",

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -126,6 +126,24 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) 
   end
 end
 
+describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko")
+  end
+
+  it_should_behave_like "Internet Explorer browser"
+
+  it "should return '11.0' as its version" do
+    expect(@useragent.version).to eq("11.0")
+  end
+
+  it "should return '11.0' as its real version" do
+    expect(@useragent.real_version).to eq("11.0")
+  end
+
+  it { expect(@useragent).not_to be_compatibility_view }
+end
+
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'" do
   before do
     @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)")


### PR DESCRIPTION
Cover an additional IE11 Trident engine that I am seeing in the wild.