### PR TITLE
Consider IE in compatibility view only if Trident version is present

### DIFF
--- a/lib/user_agent/browsers/internet_explorer.rb
+++ b/lib/user_agent/browsers/internet_explorer.rb
@@ -37,7 +37,7 @@ class UserAgent
       end
 
       def compatibility_view?
-        version < real_version
+        !trident_version.nil? && version < real_version
       end
 
       # Before version 4.0, Chrome Frame declared itself (unversioned) in a comment;

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -470,3 +470,15 @@ describe "Chrome Frame from version 4.0 on" do
     end
   end
 end
+
+describe "UserAgent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)")
+  end
+
+  it_should_behave_like "Internet Explorer browser"
+
+  it "should not be considered to be in compatibility view" do
+    expect(@useragent).not_to be_compatibility_view
+  end
+end


### PR DESCRIPTION
If none of the comments contain "Trident", `trident_version` is `nil`
causing an `ArgumentError` when comparing it with `version`. Based on
previous definition of `compatibility_view?`[(1)], consider
the browser to be in compatibility mode if the `trident_version` is
specified in the comments and if `version < real_version`.

User agents causing the error were from browsers using the IE engine:
* Acoo Browser: `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)`
* Sleipnir using the IE layout engine: `Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR * 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30)`

[(1)]: https://github.com/gshutler/useragent/blob/79350016aea525719b28ffe45a35d79f35584ca6/lib/user_agent/browsers/internet_explorer.rb#L20-L22