### PR TITLE
Replace 'gsub' with 'tr'

### DIFF
--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -60,7 +60,7 @@ class UserAgent
         str = if product = detect_product('Version')
           product.version
         elsif os =~ /iOS ([\d\.]+)/ && browser == "Safari"
-          $1.gsub(/_/, '.')
+          $1.tr('_', '.')
         else
           BuildVersions[build.to_s]
         end

--- a/lib/user_agent/operating_systems.rb
+++ b/lib/user_agent/operating_systems.rb
@@ -39,7 +39,7 @@ class UserAgent
           if $1.nil?
             "iOS"
           else
-            version = $1.gsub('_', '.')
+            version = $1.tr('_', '.')
             "iOS #{version}"
           end
         end
@@ -50,7 +50,7 @@ class UserAgent
           if $1.nil?
             "OS X"
           else
-            version = $1.gsub('_', '.')
+            version = $1.tr('_', '.')
             "OS X #{version}"
           end
         end


### PR DESCRIPTION
`String#tr` is faster than `String#gsub` for single character substitutions. This can speed up the `normalize_ios` and `normalize_mac_os_x` methods.

[Benchmark results](https://github.com/gshutler/useragent/files/235599/user_agent_bm.rb.txt):
```
Warming up --------------------------------------
   useragent w/ gsub    27.867k i/100ms
Calculating -------------------------------------
   useragent w/ gsub    315.496k (± 4.6%) i/s -      3.177M in  10.091106s

Pausing here -- run Ruby again to measure the next benchmark...
Warming up --------------------------------------
     useragent w/ tr    37.998k i/100ms
Calculating -------------------------------------
     useragent w/ tr    436.572k (± 3.9%) i/s -      4.370M in  10.025919s

Comparison:
     useragent w/ tr:   436571.6 i/s
   useragent w/ gsub:   315495.6 i/s - 1.38x slower
```