### PR TITLE
Add Wechat Browser support

### DIFF
--- a/lib/user_agent/browsers.rb
+++ b/lib/user_agent/browsers.rb
@@ -1,4 +1,5 @@
 require 'user_agent/browsers/base'
+require 'user_agent/browsers/wechat_browser'
 require 'user_agent/browsers/chrome'
 require 'user_agent/browsers/edge'
 require 'user_agent/browsers/gecko'
@@ -21,6 +22,7 @@ class UserAgent
     }.freeze
 
     ALL = [
+      WechatBrowser,
       Edge,
       InternetExplorer,
       Opera,

--- a/lib/user_agent/browsers/wechat_browser.rb
+++ b/lib/user_agent/browsers/wechat_browser.rb
@@ -1,0 +1,50 @@
+class UserAgent
+  module Browsers
+    class WechatBrowser < Base
+      def self.extend?(agent)
+        agent.detect { |useragent|
+          useragent.product =~ /MicroMessenger/i
+        }
+      end
+
+      def browser
+        'Wechat Browser'
+      end
+
+      def version
+        micro_messenger.version
+      end
+
+      def platform
+        return unless application
+
+        if application.comment[0] =~ /iPhone/
+          'iPhone'
+        elsif application.comment.any? { |c| c =~ /Android/ }
+          'Android'
+        else
+          application.comment[0]
+        end
+      end
+
+      def os
+        return unless application
+
+        if application.comment[0] =~ /Windows NT/
+          OperatingSystems.normalize_os(application.comment[0])
+        elsif application.comment[2].nil?
+          OperatingSystems.normalize_os(application.comment[1])
+        elsif application.comment[1] =~ /Android/
+          OperatingSystems.normalize_os(application.comment[1])
+        else
+          OperatingSystems.normalize_os(application.comment[2])
+        end
+      end
+
+      def micro_messenger
+        detect { |useragent| useragent.product =~ /MicroMessenger/i }
+      end
+
+    end
+  end
+end

--- a/spec/browsers/wechat_browser_user_agent_spec.rb
+++ b/spec/browsers/wechat_browser_user_agent_spec.rb
@@ -1,0 +1,46 @@
+require 'user_agent'
+
+describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN'" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN")
+  end
+
+  it "should return WechatBrowser" do
+    expect(@useragent.browser).to eq("Wechat Browser")
+  end
+
+  it "should return '6.3.16' as its version" do
+    expect(@useragent.version).to eq("6.3.16")
+  end
+
+  it "should return 'iPhone' as its platform" do
+    expect(@useragent.platform).to eq("iPhone")
+  end
+
+  it "should return 'iOS 9.3.1' as its os" do
+    expect(@useragent.os).to eq("iOS 9.3.1")
+  end
+end
+
+describe "UserAgent: 'Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN'" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN")
+  end
+
+  it "should return WechatBrowser" do
+    expect(@useragent.browser).to eq("Wechat Browser")
+  end
+
+  it "should return '6.3.16.49_r03ae324.780' as its version" do
+    expect(@useragent.version).to eq("6.3.16.49_r03ae324.780")
+  end
+
+  it "should return 'Android' as its platform" do
+    expect(@useragent.platform).to eq("Android")
+  end
+
+  it "should return 'Android 4.4.4' as its os" do
+    expect(@useragent.os).to eq("Android 4.4.4")
+  end
+end
+


### PR DESCRIPTION
WeChat is a super app in China, and the browser in WeChat is much different with other webkit based browser.  It’s useful to detect it for user