### PR TITLE
Bots with multiple browsers need to be detected

### DIFF
--- a/lib/user_agent/browsers/base.rb
+++ b/lib/user_agent/browsers/base.rb
@@ -69,7 +69,11 @@ class UserAgent
         # shitty bot.
         if application.nil?
           true
-
+        # Sometimes the user agent value contains multiple browsers for 
+        # some reason, but still includes a bot mention. These are bots, but 
+        # not sure why they are submitting multiple browsers at once.
+        elsif to_str =~ /.*(Googlebot|bingbot|AdsBot-Google-Mobile|YandexMobileBot).*/i
+          true
         # Match common case when bots refer to themselves as bots in
         # the application comment. There are no standards for how bots
         # should call themselves so its not an exhaustive method.

--- a/spec/browsers/bot_user_agent_spec.rb
+++ b/spec/browsers/bot_user_agent_spec.rb
@@ -21,3 +21,19 @@ describe "UserAgent: 'Twitterbot/1.0'" do
 
   it { expect(@useragent).to be_bot}
 end
+
+describe "UserAgent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)")
+  end
+
+  it { expect(@useragent).to be_bot}
+end
+
+describe "UserAgent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+  end
+  
+  it { expect(@useragent).to be_bot}
+end


### PR DESCRIPTION
# Why?
Turns out some bots are showing multiple browsers. This is not supported with the current gem code.

# What?
Do a simple check for the bot in the user agent text.

# How do we know these exist?
[Banana Stand](https://www.bananastand.io) is processing millions of page visits per day and we noticed that bots with these types of user agents are slipping through our filters. They are not super common, but we've noticed about 500 pop up in 48 hours so they're common _enough_.