### PR TITLE
Rubocop enforcement and simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+coverage/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Style/HashSyntax:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Naming/UncommunicativeMethodParamName:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,6 @@ Style/StringLiterals:
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Style/TrailingCommaInHashLiteral:
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
+
+# RSpec/MultipleDescribes:
+#  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ Style/Documentation:
 
 Naming/UncommunicativeMethodParamName:
   Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,3 @@ Style/TrailingCommaInHashLiteral:
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
-
-# RSpec/MultipleDescribes:
-#  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,23 @@
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,5 @@ RSpec::Core::RakeTask.new do |t|
   t.ruby_opts = ["-w"]
 end
 
-task default: %i[spec rubocop]
-task release: :spec
+task :default => %i[spec rubocop]
+task :release => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
-require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
+require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
 RSpec::Core::RakeTask.new do |t|
-  t.ruby_opts = ['-w']
+  t.ruby_opts = ["-w"]
 end
 
 task default: %i[spec rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
-require 'bundler'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
-Bundler::GemHelper.install_tasks
+RuboCop::RakeTask.new
 
 RSpec::Core::RakeTask.new do |t|
-  t.ruby_opts = ["-w"]
+  t.ruby_opts = ['-w']
 end
 
-task :default => :spec
-task :release => :spec
+task default: %i[spec rubocop]
+task release: :spec

--- a/lib/user_agent.rb
+++ b/lib/user_agent.rb
@@ -1,7 +1,7 @@
-require 'user_agent/comparable'
-require 'user_agent/browsers'
-require 'user_agent/operating_systems'
-require 'user_agent/version'
+require "user_agent/comparable"
+require "user_agent/browsers"
+require "user_agent/operating_systems"
+require "user_agent/version"
 
 class UserAgent
   # http://www.texsoft.it/index.php?m=sw.php.useragent
@@ -12,10 +12,10 @@ class UserAgent
     (\s\(([^\)]*)\)|,gzip\(gfe\))? # Comment
   }x
 
-  DEFAULT_USER_AGENT = 'Mozilla/4.0 (compatible)'.freeze
+  DEFAULT_USER_AGENT = "Mozilla/4.0 (compatible)".freeze
 
   def self.parse(string)
-    string = DEFAULT_USER_AGENT if string.nil? || string.strip == ''
+    string = DEFAULT_USER_AGENT if string.nil? || string.strip == ""
 
     agents = Browsers::Base.new
     while (m = string.to_s.match(MATCHER))
@@ -28,7 +28,7 @@ class UserAgent
   attr_reader :product, :version, :comment
 
   def initialize(product, version = nil, comment = nil)
-    raise ArgumentError, 'expected a value for product' unless product
+    raise ArgumentError, "expected a value for product" unless product
     @product = product
 
     @version = if version && !version.empty?
@@ -38,7 +38,7 @@ class UserAgent
                end
 
     @comment = if comment.respond_to?(:split)
-                 comment.split('; ')
+                 comment.split("; ")
                else
                  comment
                end

--- a/lib/user_agent.rb
+++ b/lib/user_agent.rb
@@ -10,17 +10,15 @@ class UserAgent
     ([^/\s]+)                      # Product
     /?([^\s,]*)                    # Version
     (\s\(([^\)]*)\)|,gzip\(gfe\))? # Comment
-  }x.freeze
+  }x
 
-  DEFAULT_USER_AGENT = "Mozilla/4.0 (compatible)"
+  DEFAULT_USER_AGENT = 'Mozilla/4.0 (compatible)'.freeze
 
   def self.parse(string)
-    if string.nil? || string.strip == ""
-      string = DEFAULT_USER_AGENT
-    end
+    string = DEFAULT_USER_AGENT if string.nil? || string.strip == ''
 
     agents = Browsers::Base.new
-    while m = string.to_s.match(MATCHER)
+    while (m = string.to_s.match(MATCHER))
       agents << new(m[1], m[2], m[4])
       string = string[m[0].length..-1].strip
     end
@@ -30,23 +28,20 @@ class UserAgent
   attr_reader :product, :version, :comment
 
   def initialize(product, version = nil, comment = nil)
-    if product
-      @product = product
-    else
-      raise ArgumentError, "expected a value for product"
-    end
+    raise ArgumentError, 'expected a value for product' unless product
+    @product = product
 
-    if version && !version.empty?
-      @version = Version.new(version)
-    else
-      @version = Version.new
-    end
+    @version = if version && !version.empty?
+                 Version.new(version)
+               else
+                 Version.new
+               end
 
-    if comment.respond_to?(:split)
-      @comment = comment.split("; ")
-    else
-      @comment = comment
-    end
+    @comment = if comment.respond_to?(:split)
+                 comment.split('; ')
+               else
+                 comment
+               end
   end
 
   include Comparable
@@ -77,11 +72,11 @@ class UserAgent
 
   def to_str
     if @product && !@version.nil? && @comment
-      "#{@product}/#{@version} (#{@comment.join("; ")})"
+      "#{@product}/#{@version} (#{@comment.join('; ')})"
     elsif @product && !@version.nil?
       "#{@product}/#{@version}"
     elsif @product && @comment
-      "#{@product} (#{@comment.join("; ")})"
+      "#{@product} (#{@comment.join('; ')})"
     else
       @product
     end

--- a/lib/user_agent/browsers.rb
+++ b/lib/user_agent/browsers.rb
@@ -1,25 +1,25 @@
-require 'user_agent/browsers/base'
-require 'user_agent/browsers/chrome'
-require 'user_agent/browsers/edge'
-require 'user_agent/browsers/gecko'
-require 'user_agent/browsers/internet_explorer'
-require 'user_agent/browsers/opera'
-require 'user_agent/browsers/webkit'
-require 'user_agent/browsers/wechat_browser'
-require 'user_agent/browsers/windows_media_player'
-require 'user_agent/browsers/itunes'
-require 'user_agent/browsers/apple_core_media'
-require 'user_agent/browsers/libavformat'
-require 'user_agent/browsers/playstation'
-require 'user_agent/browsers/podcast_addict'
-require 'user_agent/browsers/vivaldi'
+require "user_agent/browsers/base"
+require "user_agent/browsers/chrome"
+require "user_agent/browsers/edge"
+require "user_agent/browsers/gecko"
+require "user_agent/browsers/internet_explorer"
+require "user_agent/browsers/opera"
+require "user_agent/browsers/webkit"
+require "user_agent/browsers/wechat_browser"
+require "user_agent/browsers/windows_media_player"
+require "user_agent/browsers/itunes"
+require "user_agent/browsers/apple_core_media"
+require "user_agent/browsers/libavformat"
+require "user_agent/browsers/playstation"
+require "user_agent/browsers/podcast_addict"
+require "user_agent/browsers/vivaldi"
 
 class UserAgent
   module Browsers
     SECURITY = {
-      'N' => :none,
-      'U' => :strong,
-      'I' => :weak
+      "N" => :none,
+      "U" => :strong,
+      "I" => :weak
     }.freeze
 
     ALL = [

--- a/lib/user_agent/browsers.rb
+++ b/lib/user_agent/browsers.rb
@@ -16,10 +16,10 @@ require 'user_agent/browsers/vivaldi'
 
 class UserAgent
   module Browsers
-    Security = {
-      "N" => :none,
-      "U" => :strong,
-      "I" => :weak
+    SECURITY = {
+      'N' => :none,
+      'U' => :strong,
+      'I' => :weak
     }.freeze
 
     ALL = [
@@ -36,7 +36,7 @@ class UserAgent
       Gecko,
       WindowsMediaPlayer,
       AppleCoreMedia,
-      Libavformat,
+      Libavformat
     ].freeze
 
     def self.all

--- a/lib/user_agent/browsers.rb
+++ b/lib/user_agent/browsers.rb
@@ -39,6 +39,11 @@ class UserAgent
       Libavformat
     ].freeze
 
+    def self.Security # rubocop:disable Naming/MethodName
+      warn("#{__method__} is deprecated. Please use SECURITY instead")
+      SECURITY
+    end
+
     def self.all
       ALL
     end

--- a/lib/user_agent/browsers.rb
+++ b/lib/user_agent/browsers.rb
@@ -36,7 +36,7 @@ class UserAgent
       Gecko,
       WindowsMediaPlayer,
       AppleCoreMedia,
-      Libavformat
+      Libavformat,
     ].freeze
 
     def self.Security # rubocop:disable Naming/MethodName

--- a/lib/user_agent/browsers.rb
+++ b/lib/user_agent/browsers.rb
@@ -19,7 +19,7 @@ class UserAgent
     SECURITY = {
       "N" => :none,
       "U" => :strong,
-      "I" => :weak
+      "I" => :weak,
     }.freeze
 
     ALL = [

--- a/lib/user_agent/browsers.rb
+++ b/lib/user_agent/browsers.rb
@@ -39,8 +39,13 @@ class UserAgent
       Libavformat,
     ].freeze
 
+    @security_warned = false
+
     def self.Security # rubocop:disable Naming/MethodName
-      warn("#{__method__} is deprecated. Please use SECURITY instead")
+      unless @security_warned
+        warn("#{__method__} is deprecated. Please use SECURITY instead")
+        @security_warned = true
+      end
       SECURITY
     end
 

--- a/lib/user_agent/browsers/apple_core_media.rb
+++ b/lib/user_agent/browsers/apple_core_media.rb
@@ -7,11 +7,11 @@ class UserAgent
       end
 
       def browser
-        "AppleCoreMedia"
+        'AppleCoreMedia'
       end
 
       def application
-        self.reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
+        reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
       end
 
       def platform
@@ -25,7 +25,7 @@ class UserAgent
       end
 
       def security
-        Security[application.comment[1]]
+        SECURITY[application.comment[1]]
       end
 
       def os

--- a/lib/user_agent/browsers/apple_core_media.rb
+++ b/lib/user_agent/browsers/apple_core_media.rb
@@ -3,11 +3,11 @@ class UserAgent
     # CoreMedia is a framework on iOS and is used by various iOS apps to playback media.
     class AppleCoreMedia < Base
       def self.extend?(agent)
-        agent.detect { |useragent| useragent.product == 'AppleCoreMedia' }
+        agent.detect { |useragent| useragent.product == "AppleCoreMedia" }
       end
 
       def browser
-        'AppleCoreMedia'
+        "AppleCoreMedia"
       end
 
       def application
@@ -18,7 +18,7 @@ class UserAgent
         return unless application
 
         if application.comment[0] =~ /Windows/
-          'Windows'
+          "Windows"
         else
           application.comment[0]
         end

--- a/lib/user_agent/browsers/base.rb
+++ b/lib/user_agent/browsers/base.rb
@@ -93,11 +93,11 @@ class UserAgent
         return unless application
 
         hash = {
-          browser: browser,
-          platform: platform,
-          os: os,
-          mobile: mobile?,
-          bot: bot?
+          :browser => browser,
+          :platform => platform,
+          :os => os,
+          :mobile => mobile?,
+          :bot => bot?
         }
 
         hash[:version] = (version.to_a if version)

--- a/lib/user_agent/browsers/base.rb
+++ b/lib/user_agent/browsers/base.rb
@@ -5,7 +5,7 @@ class UserAgent
 
       def <=>(other)
         if respond_to?(:browser) && other.respond_to?(:browser) &&
-            browser == other.browser
+           browser == other.browser
           version <=> Version.new(other.version)
         else
           false
@@ -21,7 +21,7 @@ class UserAgent
       end
 
       def to_str
-        join(" ")
+        join(' ')
       end
 
       def application
@@ -52,6 +52,10 @@ class UserAgent
         detect_product(method) || super
       end
 
+      def respond_to_missing?(symbol, include_all = false)
+        detect_product(symbol) ? true : super
+      end
+
       def mobile?
         if detect_product('Mobile') || detect_comment('Mobile')
           true
@@ -78,7 +82,7 @@ class UserAgent
         # list will be rejected.
         elsif detect_comment_match(/bot/i)
           true
-        elsif product = application.product
+        elsif (product = application.product)
           product.include?('bot')
         else
           false
@@ -89,42 +93,37 @@ class UserAgent
         return unless application
 
         hash = {
-          :browser => browser,
-          :platform => platform,
-          :os => os,
-          :mobile => mobile?,
-          :bot => bot?,
+          browser: browser,
+          platform: platform,
+          os: os,
+          mobile: mobile?,
+          bot: bot?
         }
 
-        if version
-          hash[:version] = version.to_a
-        else
-          hash[:version] = nil
-        end
+        hash[:version] = (version.to_a if version)
 
-        if comment = application.comment
-          hash[:comment] = comment.dup
-        else
-          hash[:comment] = nil
-        end
+        hash[:comment] = if (comment = application.comment)
+                           comment.dup
+                         end
 
         hash
       end
 
       private
-        def detect_product(product)
-          detect { |useragent| useragent.product.to_s.downcase == product.to_s.downcase }
-        end
 
-        def detect_comment(comment)
-          detect { |useragent| useragent.detect_comment { |c| c == comment } }
-        end
+      def detect_product(product)
+        detect { |useragent| useragent.product.to_s.casecmp(product.to_s).zero? }
+      end
 
-        def detect_comment_match(regexp)
-          comment_match = nil
-          detect { |useragent| useragent.detect_comment { |c| comment_match = c.match(regexp) } }
-          comment_match
-        end
+      def detect_comment(comment)
+        detect { |useragent| useragent.detect_comment { |c| c == comment } }
+      end
+
+      def detect_comment_match(regexp)
+        comment_match = nil
+        detect { |useragent| useragent.detect_comment { |c| comment_match = c.match(regexp) } }
+        comment_match
+      end
     end
   end
 end

--- a/lib/user_agent/browsers/base.rb
+++ b/lib/user_agent/browsers/base.rb
@@ -21,7 +21,7 @@ class UserAgent
       end
 
       def to_str
-        join(' ')
+        join(" ")
       end
 
       def application
@@ -57,7 +57,7 @@ class UserAgent
       end
 
       def mobile?
-        if detect_product('Mobile') || detect_comment('Mobile')
+        if detect_product("Mobile") || detect_comment("Mobile")
           true
         elsif os =~ /Android/
           true
@@ -83,7 +83,7 @@ class UserAgent
         elsif detect_comment_match(/bot/i)
           true
         elsif (product = application.product)
-          product.include?('bot')
+          product.include?("bot")
         else
           false
         end

--- a/lib/user_agent/browsers/base.rb
+++ b/lib/user_agent/browsers/base.rb
@@ -97,7 +97,7 @@ class UserAgent
           :platform => platform,
           :os => os,
           :mobile => mobile?,
-          :bot => bot?
+          :bot => bot?,
         }
 
         hash[:version] = (version.to_a if version)

--- a/lib/user_agent/browsers/chrome.rb
+++ b/lib/user_agent/browsers/chrome.rb
@@ -11,6 +11,11 @@ class UserAgent
         Iron
       ].freeze
 
+      def ChromeBrowsers # rubocop:disable Naming/MethodName
+        warn("#{__method__} is deprecated. Please use CHROME_BROWSERS instead")
+        CHROME_BROWSERS
+      end
+
       def browser
         CHROME_BROWSERS.detect { |browser| respond_to?(browser) } || "Chrome"
       end

--- a/lib/user_agent/browsers/chrome.rb
+++ b/lib/user_agent/browsers/chrome.rb
@@ -12,7 +12,7 @@ class UserAgent
       ].freeze
 
       def browser
-        CHROME_BROWSERS.detect { |browser| respond_to?(browser) } || 'Chrome'
+        CHROME_BROWSERS.detect { |browser| respond_to?(browser) } || "Chrome"
       end
 
       def build
@@ -21,7 +21,7 @@ class UserAgent
 
       # Prior to Safari 3, the user agent did not include a version number
       def version
-        str = if detect_product('CriOs')
+        str = if detect_product("CriOs")
                 crios.version
               else
                 chrome.version
@@ -38,18 +38,18 @@ class UserAgent
         return unless application
 
         if application.comment[0] =~ /Windows/
-          'Windows'
+          "Windows"
         elsif application.comment.any? { |c| c =~ /CrOS/ }
-          'ChromeOS'
+          "ChromeOS"
         elsif application.comment.any? { |c| c =~ /Android/ }
-          'Android'
+          "Android"
         else
           application.comment[0]
         end
       end
 
       def webkit
-        detect { |useragent| useragent.product == 'AppleWebKit' }
+        detect { |useragent| useragent.product == "AppleWebKit" }
       end
 
       def os

--- a/lib/user_agent/browsers/chrome.rb
+++ b/lib/user_agent/browsers/chrome.rb
@@ -2,17 +2,17 @@ class UserAgent
   module Browsers
     class Chrome < Base
       def self.extend?(agent)
-        agent.detect { |useragent|
-          %w(Chrome CriOS).include?(useragent.product)
-        }
+        agent.detect do |useragent|
+          %w[Chrome CriOS].include?(useragent.product)
+        end
       end
 
-      ChromeBrowsers = %w(
+      CHROME_BROWSERS = %w[
         Iron
-      ).freeze
+      ].freeze
 
       def browser
-        ChromeBrowsers.detect { |browser| respond_to?(browser) } || 'Chrome'
+        CHROME_BROWSERS.detect { |browser| respond_to?(browser) } || 'Chrome'
       end
 
       def build
@@ -21,17 +21,17 @@ class UserAgent
 
       # Prior to Safari 3, the user agent did not include a version number
       def version
-        str = if detect_product("CriOs")
-          crios.version
-        else
-          chrome.version
-        end
+        str = if detect_product('CriOs')
+                crios.version
+              else
+                chrome.version
+              end
 
         Version.new(str)
       end
 
       def application
-        self.reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
+        reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
       end
 
       def platform
@@ -49,7 +49,7 @@ class UserAgent
       end
 
       def webkit
-        detect { |useragent| useragent.product == "AppleWebKit" }
+        detect { |useragent| useragent.product == 'AppleWebKit' }
       end
 
       def os

--- a/lib/user_agent/browsers/chrome.rb
+++ b/lib/user_agent/browsers/chrome.rb
@@ -11,8 +11,15 @@ class UserAgent
         Iron
       ].freeze
 
+      def chrome_browsers_warned
+        @chrome_browsers_warned ||= false
+      end
+
       def ChromeBrowsers # rubocop:disable Naming/MethodName
-        warn("#{__method__} is deprecated. Please use CHROME_BROWSERS instead")
+        unless chrome_browsers_warned
+          warn("#{__method__} is deprecated. Please use CHROME_BROWSERS instead")
+          @chrome_browsers_warned = true
+        end
         CHROME_BROWSERS
       end
 

--- a/lib/user_agent/browsers/edge.rb
+++ b/lib/user_agent/browsers/edge.rb
@@ -4,11 +4,11 @@ class UserAgent
       OS_REGEXP = /Windows NT [\d\.]+|Windows Phone (OS )?[\d\.]+/
 
       def self.extend?(agent)
-        agent.last && agent.last.product == "Edge"
+        agent.last && agent.last.product == 'Edge'
       end
 
       def browser
-        "Edge"
+        'Edge'
       end
 
       def version
@@ -16,7 +16,7 @@ class UserAgent
       end
 
       def platform
-        "Windows"
+        'Windows'
       end
 
       def os

--- a/lib/user_agent/browsers/edge.rb
+++ b/lib/user_agent/browsers/edge.rb
@@ -4,11 +4,11 @@ class UserAgent
       OS_REGEXP = /Windows NT [\d\.]+|Windows Phone (OS )?[\d\.]+/
 
       def self.extend?(agent)
-        agent.last && agent.last.product == 'Edge'
+        agent.last && agent.last.product == "Edge"
       end
 
       def browser
-        'Edge'
+        "Edge"
       end
 
       def version
@@ -16,7 +16,7 @@ class UserAgent
       end
 
       def platform
-        'Windows'
+        "Windows"
       end
 
       def os

--- a/lib/user_agent/browsers/gecko.rb
+++ b/lib/user_agent/browsers/gecko.rb
@@ -13,6 +13,11 @@ class UserAgent
         Seamonkey
       ].freeze
 
+      def GeckoBrowsers # rubocop:disable Naming/MethodName
+        warn("#{__method__} is deprecated. Please use GECKO_BROWSERS instead")
+        GECKO_BROWSERS
+      end
+
       def browser
         GECKO_BROWSERS.detect { |browser| respond_to?(browser) } || super
       end

--- a/lib/user_agent/browsers/gecko.rb
+++ b/lib/user_agent/browsers/gecko.rb
@@ -2,7 +2,7 @@ class UserAgent
   module Browsers
     class Gecko < Base
       def self.extend?(agent)
-        agent.application && agent.application.product == 'Mozilla'
+        agent.application && agent.application.product == "Mozilla"
       end
 
       GECKO_BROWSERS = %w[
@@ -24,10 +24,10 @@ class UserAgent
 
       def platform
         if (comment = application.comment) # rubocop:disable Style/GuardClause
-          if comment[0] == 'compatible' || comment[0] == 'Mobile'
+          if comment[0] == "compatible" || comment[0] == "Mobile"
             nil
           elsif /^Windows / =~ comment[0]
-            'Windows'
+            "Windows"
           else
             comment[0]
           end
@@ -40,11 +40,11 @@ class UserAgent
 
       def os
         if (comment = application.comment) # rubocop:disable Style/GuardClause
-          i = if comment[1] == 'U'
+          i = if comment[1] == "U"
                 2
               elsif /^Windows / =~ comment[0] || /^Android/ =~ comment[0]
                 0
-              elsif comment[0] == 'Mobile'
+              elsif comment[0] == "Mobile"
                 nil
               else
                 1

--- a/lib/user_agent/browsers/gecko.rb
+++ b/lib/user_agent/browsers/gecko.rb
@@ -2,19 +2,19 @@ class UserAgent
   module Browsers
     class Gecko < Base
       def self.extend?(agent)
-        agent.application && agent.application.product == "Mozilla"
+        agent.application && agent.application.product == 'Mozilla'
       end
 
-      GeckoBrowsers = %w(
+      GECKO_BROWSERS = %w[
         PaleMoon
         Firefox
         Camino
         Iceweasel
         Seamonkey
-      ).freeze
+      ].freeze
 
       def browser
-        GeckoBrowsers.detect { |browser| respond_to?(browser) } || super
+        GECKO_BROWSERS.detect { |browser| respond_to?(browser) } || super
       end
 
       def version
@@ -23,7 +23,7 @@ class UserAgent
       end
 
       def platform
-        if comment = application.comment
+        if (comment = application.comment) # rubocop:disable Style/GuardClause
           if comment[0] == 'compatible' || comment[0] == 'Mobile'
             nil
           elsif /^Windows / =~ comment[0]
@@ -35,11 +35,11 @@ class UserAgent
       end
 
       def security
-        Security[application.comment[1]] || :strong
+        SECURITY[application.comment[1]] || :strong
       end
 
       def os
-        if comment = application.comment
+        if (comment = application.comment) # rubocop:disable Style/GuardClause
           i = if comment[1] == 'U'
                 2
               elsif /^Windows / =~ comment[0] || /^Android/ =~ comment[0]
@@ -51,15 +51,13 @@ class UserAgent
               end
 
           return nil if i.nil?
-          
+
           OperatingSystems.normalize_os(comment[i])
         end
       end
 
       def localization
-        if comment = application.comment
-          comment[3]
-        end
+        application.comment[3] if application.comment
       end
     end
   end

--- a/lib/user_agent/browsers/gecko.rb
+++ b/lib/user_agent/browsers/gecko.rb
@@ -13,8 +13,15 @@ class UserAgent
         Seamonkey
       ].freeze
 
+      def gecko_browser_warned
+        @gecko_browser_warned ||= false
+      end
+
       def GeckoBrowsers # rubocop:disable Naming/MethodName
-        warn("#{__method__} is deprecated. Please use GECKO_BROWSERS instead")
+        unless gecko_browser_warned
+          warn("#{__method__} is deprecated. Please use GECKO_BROWSERS instead")
+          @gecko_browser_warned = true
+        end
         GECKO_BROWSERS
       end
 

--- a/lib/user_agent/browsers/internet_explorer.rb
+++ b/lib/user_agent/browsers/internet_explorer.rb
@@ -2,22 +2,22 @@ class UserAgent
   module Browsers
     class InternetExplorer < Base
       TRIDENT_ENGINES = {
-        "Trident/8.0" => "11.0",
-        "Trident/7.0" => "11.0",
-        "Trident/6.0" => "10.0",
-        "Trident/5.0" => "9.0",
-        "Trident/4.0" => "8.0",
+        'Trident/8.0' => '11.0',
+        'Trident/7.0' => '11.0',
+        'Trident/6.0' => '10.0',
+        'Trident/5.0' => '9.0',
+        'Trident/4.0' => '8.0'
       }.freeze
 
       def self.extend?(agent)
         agent.application &&
-        agent.application.comment &&
-        (agent.application.comment[1] =~ /MSIE/ ||
-         agent.application.comment.join('; ') =~ /Trident.+rv:/)
+          agent.application.comment &&
+          (agent.application.comment[1] =~ /MSIE/ ||
+           agent.application.comment.join('; ') =~ /Trident.+rv:/)
       end
 
       def browser
-        "Internet Explorer"
+        'Internet Explorer'
       end
 
       def version
@@ -26,7 +26,7 @@ class UserAgent
       end
 
       def trident_version
-        if trident = application.comment.detect { |c| c['Trident/'] }
+        if (trident = application.comment.detect { |c| c['Trident/'] }) # rubocop:disable Style/GuardClause
           trident_version = TRIDENT_ENGINES.fetch(trident, trident)
           Version.new(trident_version)
         end
@@ -44,14 +44,14 @@ class UserAgent
       # as of 4.0 it can declare itself versioned in a comment
       # or as a separate product with a version
       def chromeframe
-        cf = application.comment.include?("chromeframe") || detect_product("chromeframe")
+        cf = application.comment.include?('chromeframe') || detect_product('chromeframe')
         return cf if cf
         cf_comment = application.comment.detect { |c| c['chromeframe/'] }
         cf_comment ? UserAgent.new(*cf_comment.split('/', 2)) : nil
       end
 
       def platform
-        "Windows"
+        'Windows'
       end
 
       def os

--- a/lib/user_agent/browsers/internet_explorer.rb
+++ b/lib/user_agent/browsers/internet_explorer.rb
@@ -2,31 +2,31 @@ class UserAgent
   module Browsers
     class InternetExplorer < Base
       TRIDENT_ENGINES = {
-        'Trident/8.0' => '11.0',
-        'Trident/7.0' => '11.0',
-        'Trident/6.0' => '10.0',
-        'Trident/5.0' => '9.0',
-        'Trident/4.0' => '8.0'
+        "Trident/8.0" => "11.0",
+        "Trident/7.0" => "11.0",
+        "Trident/6.0" => "10.0",
+        "Trident/5.0" => "9.0",
+        "Trident/4.0" => "8.0"
       }.freeze
 
       def self.extend?(agent)
         agent.application &&
           agent.application.comment &&
           (agent.application.comment[1] =~ /MSIE/ ||
-           agent.application.comment.join('; ') =~ /Trident.+rv:/)
+           agent.application.comment.join("; ") =~ /Trident.+rv:/)
       end
 
       def browser
-        'Internet Explorer'
+        "Internet Explorer"
       end
 
       def version
-        str = application.comment.join('; ')[/(MSIE\s|rv:)([\d\.]+)/, 2]
+        str = application.comment.join("; ")[/(MSIE\s|rv:)([\d\.]+)/, 2]
         Version.new(str)
       end
 
       def trident_version
-        if (trident = application.comment.detect { |c| c['Trident/'] }) # rubocop:disable Style/GuardClause
+        if (trident = application.comment.detect { |c| c["Trident/"] }) # rubocop:disable Style/GuardClause
           trident_version = TRIDENT_ENGINES.fetch(trident, trident)
           Version.new(trident_version)
         end
@@ -44,18 +44,18 @@ class UserAgent
       # as of 4.0 it can declare itself versioned in a comment
       # or as a separate product with a version
       def chromeframe
-        cf = application.comment.include?('chromeframe') || detect_product('chromeframe')
+        cf = application.comment.include?("chromeframe") || detect_product("chromeframe")
         return cf if cf
-        cf_comment = application.comment.detect { |c| c['chromeframe/'] }
-        cf_comment ? UserAgent.new(*cf_comment.split('/', 2)) : nil
+        cf_comment = application.comment.detect { |c| c["chromeframe/"] }
+        cf_comment ? UserAgent.new(*cf_comment.split("/", 2)) : nil
       end
 
       def platform
-        'Windows'
+        "Windows"
       end
 
       def os
-        OperatingSystems.normalize_os(application.comment.join('; ').match(/Windows NT [\d\.]+|Windows Phone (OS )?[\d\.]+/).to_s)
+        OperatingSystems.normalize_os(application.comment.join("; ").match(/Windows NT [\d\.]+|Windows Phone (OS )?[\d\.]+/).to_s)
       end
     end
   end

--- a/lib/user_agent/browsers/internet_explorer.rb
+++ b/lib/user_agent/browsers/internet_explorer.rb
@@ -6,7 +6,7 @@ class UserAgent
         "Trident/7.0" => "11.0",
         "Trident/6.0" => "10.0",
         "Trident/5.0" => "9.0",
-        "Trident/4.0" => "8.0"
+        "Trident/4.0" => "8.0",
       }.freeze
 
       def self.extend?(agent)

--- a/lib/user_agent/browsers/itunes.rb
+++ b/lib/user_agent/browsers/itunes.rb
@@ -1,26 +1,26 @@
 class UserAgent
   module Browsers
     # The user agent for iTunes
-    # 
+    #
     # Some user agents:
     # iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11
     # iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25
     # iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15
     # iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24
-    # iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25 
+    # iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25
     class ITunes < Webkit
       def self.extend?(agent)
-        agent.detect { |useragent| useragent.product == "iTunes" }
+        agent.detect { |useragent| useragent.product == 'iTunes' }
       end
 
       # @return ["iTunes"] Always return iTunes as the browser
       def browser
-        "iTunes"
+        'iTunes'
       end
 
       # @return [Version] The version of iTunes in use
       def version
-        self.iTunes.version
+        iTunes.version
       end
 
       # @return [nil] nil - not included in the user agent
@@ -34,24 +34,24 @@ class UserAgent
       end
 
       # Parses the operating system in use.
-      # 
+      #
       # @return [String] The operating system
       def os
         full_os = self.full_os
 
         if application && application.comment[0] =~ /Windows/
           if full_os =~ /Windows 8\.1/
-            "Windows 8.1"
+            'Windows 8.1'
           elsif full_os =~ /Windows 8/
-            "Windows 8"
+            'Windows 8'
           elsif full_os =~ /Windows 7/
-            "Windows 7"
+            'Windows 7'
           elsif full_os =~ /Windows Vista/
-            "Windows Vista"
+            'Windows Vista'
           elsif full_os =~ /Windows XP/
-            "Windows XP"
+            'Windows XP'
           else
-            "Windows"
+            'Windows'
           end
         else
           super
@@ -59,16 +59,14 @@ class UserAgent
       end
 
       # Parses the operating system in use.
-      # 
+      #
       # @return [String] The operating system
       def full_os
-        if application && application.comment && application.comment.length > 1
-          full_os = application.comment[1]
+        full_os = application.comment[1] if application && application.comment && application.comment.length > 1
 
-          full_os = "#{full_os})" if full_os =~ /\(Build [0-9][0-9][0-9][0-9]\z/ # The regex chops the ) off :(
+        full_os = "#{full_os})" if application && application.comment && application.comment.length > 1 && full_os =~ /\(Build [0-9][0-9][0-9][0-9]\z/ # The regex chops the ) off :(
 
-          full_os
-        end
+        full_os
       end
     end
   end

--- a/lib/user_agent/browsers/itunes.rb
+++ b/lib/user_agent/browsers/itunes.rb
@@ -10,12 +10,12 @@ class UserAgent
     # iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25
     class ITunes < Webkit
       def self.extend?(agent)
-        agent.detect { |useragent| useragent.product == 'iTunes' }
+        agent.detect { |useragent| useragent.product == "iTunes" }
       end
 
       # @return ["iTunes"] Always return iTunes as the browser
       def browser
-        'iTunes'
+        "iTunes"
       end
 
       # @return [Version] The version of iTunes in use
@@ -41,17 +41,17 @@ class UserAgent
 
         if application && application.comment[0] =~ /Windows/
           if full_os =~ /Windows 8\.1/
-            'Windows 8.1'
+            "Windows 8.1"
           elsif full_os =~ /Windows 8/
-            'Windows 8'
+            "Windows 8"
           elsif full_os =~ /Windows 7/
-            'Windows 7'
+            "Windows 7"
           elsif full_os =~ /Windows Vista/
-            'Windows Vista'
+            "Windows Vista"
           elsif full_os =~ /Windows XP/
-            'Windows XP'
+            "Windows XP"
           else
-            'Windows'
+            "Windows"
           end
         else
           super

--- a/lib/user_agent/browsers/libavformat.rb
+++ b/lib/user_agent/browsers/libavformat.rb
@@ -4,18 +4,18 @@ class UserAgent
     class Libavformat < Base
       def self.extend?(agent)
         agent.detect do |useragent|
-          useragent.product == "Lavf" || (useragent.product == "NSPlayer" && agent.version == "4.1.0.3856")
+          useragent.product == 'Lavf' || (useragent.product == 'NSPlayer' && agent.version == '4.1.0.3856')
         end
       end
 
       # @return ["libavformat"] To make it easy to pick it out, all of the UAs that Lavf uses have this browser.
       def browser
-        "libavformat"
+        'libavformat'
       end
 
       # @return [nil, Version] If the product is NSPlayer, we don't have a version
       def version
-        super unless detect_product("NSPlayer")
+        super unless detect_product('NSPlayer')
       end
 
       # @return [nil] Lavf doesn't return us anything here

--- a/lib/user_agent/browsers/libavformat.rb
+++ b/lib/user_agent/browsers/libavformat.rb
@@ -4,18 +4,18 @@ class UserAgent
     class Libavformat < Base
       def self.extend?(agent)
         agent.detect do |useragent|
-          useragent.product == 'Lavf' || (useragent.product == 'NSPlayer' && agent.version == '4.1.0.3856')
+          useragent.product == "Lavf" || (useragent.product == "NSPlayer" && agent.version == "4.1.0.3856")
         end
       end
 
       # @return ["libavformat"] To make it easy to pick it out, all of the UAs that Lavf uses have this browser.
       def browser
-        'libavformat'
+        "libavformat"
       end
 
       # @return [nil, Version] If the product is NSPlayer, we don't have a version
       def version
-        super unless detect_product('NSPlayer')
+        super unless detect_product("NSPlayer")
       end
 
       # @return [nil] Lavf doesn't return us anything here

--- a/lib/user_agent/browsers/opera.rb
+++ b/lib/user_agent/browsers/opera.rb
@@ -2,13 +2,13 @@ class UserAgent
   module Browsers
     class Opera < Base
       def self.extend?(agent)
-        (agent.first && agent.first.product == 'Opera') ||
-          (agent.application && agent.application.product == 'Opera') ||
-          (agent.last && agent.last.product == 'OPR')
+        (agent.first && agent.first.product == "Opera") ||
+          (agent.application && agent.application.product == "Opera") ||
+          (agent.last && agent.last.product == "OPR")
       end
 
       def browser
-        'Opera'
+        "Opera"
       end
 
       def version
@@ -18,9 +18,9 @@ class UserAgent
           rescue StandardError
             Version.new
           end
-        elsif (product = detect_product('Version'))
+        elsif (product = detect_product("Version"))
           Version.new(product.version)
-        elsif (product = detect_product('OPR'))
+        elsif (product = detect_product("OPR"))
           Version.new(product.version)
         else
           super
@@ -31,7 +31,7 @@ class UserAgent
         return unless application.comment
 
         if application.comment[0] =~ /Windows/
-          'Windows'
+          "Windows"
         else
           application.comment[0]
         end
@@ -80,7 +80,7 @@ class UserAgent
       end
 
       def macintosh?
-        platform == 'Macintosh'
+        platform == "Macintosh"
       end
     end
   end

--- a/lib/user_agent/browsers/opera.rb
+++ b/lib/user_agent/browsers/opera.rb
@@ -4,7 +4,7 @@ class UserAgent
       def self.extend?(agent)
         (agent.first && agent.first.product == 'Opera') ||
           (agent.application && agent.application.product == 'Opera') ||
-            (agent.last && agent.last.product == 'OPR')
+          (agent.last && agent.last.product == 'OPR')
       end
 
       def browser
@@ -13,10 +13,14 @@ class UserAgent
 
       def version
         if mini?
-          Version.new(application.comment.detect{|c| c =~ /Opera Mini/}[/Opera Mini\/([\d\.]+)/, 1]) rescue Version.new
-        elsif product = detect_product('Version')
+          begin
+            Version.new(application.comment.detect { |c| c =~ /Opera Mini/ }[%r{Opera Mini\/([\d\.]+)}, 1])
+          rescue StandardError
+            Version.new
+          end
+        elsif (product = detect_product('Version'))
           Version.new(product.version)
-        elsif product = detect_product('OPR')
+        elsif (product = detect_product('OPR'))
           Version.new(product.version)
         else
           super
@@ -27,7 +31,7 @@ class UserAgent
         return unless application.comment
 
         if application.comment[0] =~ /Windows/
-          "Windows"
+          'Windows'
         else
           application.comment[0]
         end
@@ -37,11 +41,11 @@ class UserAgent
         if application.comment.nil?
           :strong
         elsif macintosh?
-          Security[application.comment[2]]
+          SECURITY[application.comment[2]]
         elsif mini?
-          Security[application.comment[-2]]
+          SECURITY[application.comment[-2]]
         else
-          Security[application.comment[1]]
+          SECURITY[application.comment[1]]
         end
       end
 
@@ -70,13 +74,14 @@ class UserAgent
       end
 
       private
-        def mini?
-          /Opera Mini/ === application
-        end
 
-        def macintosh?
-          platform == 'Macintosh'
-        end
+      def mini?
+        /Opera Mini/ =~ application
+      end
+
+      def macintosh?
+        platform == 'Macintosh'
+      end
     end
   end
 end

--- a/lib/user_agent/browsers/playstation.rb
+++ b/lib/user_agent/browsers/playstation.rb
@@ -8,9 +8,9 @@ class UserAgent
     class PlayStation < Base
       def self.extend?(agent)
         !agent.application.nil? && !agent.application.comment.nil? && agent.application.comment.any? && (
-          agent.application.comment.first.include?('PLAYSTATION 3') ||
-          agent.application.comment.first.include?('PlayStation Vita') ||
-          agent.application.comment.first.include?('PlayStation 4')
+          agent.application.comment.first.include?("PLAYSTATION 3") ||
+          agent.application.comment.first.include?("PlayStation Vita") ||
+          agent.application.comment.first.include?("PlayStation 4")
         )
       end
 
@@ -18,12 +18,12 @@ class UserAgent
       #
       # @return [nil, String] the name of the browser
       def browser
-        if application.comment.first.include?('PLAYSTATION 3')
-          'PS3 Internet Browser'
-        elsif last.product == 'Silk'
-          'Silk'
-        elsif application.comment.first.include?('PlayStation 4')
-          'PS4 Internet Browser'
+        if application.comment.first.include?("PLAYSTATION 3")
+          "PS3 Internet Browser"
+        elsif last.product == "Silk"
+          "Silk"
+        elsif application.comment.first.include?("PlayStation 4")
+          "PS4 Internet Browser"
         end
       end
 
@@ -31,26 +31,26 @@ class UserAgent
       #
       # @return [true, false] is this a mobile browser?
       def mobile?
-        platform == 'PlayStation Vita'
+        platform == "PlayStation Vita"
       end
 
       # Returns the operating system in use.
       #
       # @return [String] the operating system in use
       def os
-        application.comment.join(' ')
+        application.comment.join(" ")
       end
 
       # Returns the platform in use.
       #
       # @return [nil, "PlayStation 3", "PlayStation 4", "PlayStation Vita"] the platform in use
       def platform
-        if os.include?('PLAYSTATION 3')
-          'PlayStation 3'
-        elsif os.include?('PlayStation 4')
-          'PlayStation 4'
-        elsif os.include?('PlayStation Vita')
-          'PlayStation Vita'
+        if os.include?("PLAYSTATION 3")
+          "PlayStation 3"
+        elsif os.include?("PlayStation 4")
+          "PlayStation 4"
+        elsif os.include?("PlayStation Vita")
+          "PlayStation Vita"
         end
       end
 
@@ -59,14 +59,14 @@ class UserAgent
       #
       # @return [nil, Version] the version
       def version
-        if browser == 'Silk'
+        if browser == "Silk"
           last.version
-        elsif platform == 'PlayStation 3'
-          Version.new(os.split('PLAYSTATION 3 ').last)
-        elsif platform == 'PlayStation 4'
-          Version.new(os.split('PlayStation 4 ').last)
-        elsif platform == 'PlayStation Vita'
-          Version.new(os.split('PlayStation Vita ').last)
+        elsif platform == "PlayStation 3"
+          Version.new(os.split("PLAYSTATION 3 ").last)
+        elsif platform == "PlayStation 4"
+          Version.new(os.split("PlayStation 4 ").last)
+        elsif platform == "PlayStation Vita"
+          Version.new(os.split("PlayStation Vita ").last)
         end
       end
     end

--- a/lib/user_agent/browsers/playstation.rb
+++ b/lib/user_agent/browsers/playstation.rb
@@ -15,7 +15,7 @@ class UserAgent
       end
 
       # Returns the name of the browser in use.
-      # 
+      #
       # @return [nil, String] the name of the browser
       def browser
         if application.comment.first.include?('PLAYSTATION 3')
@@ -24,27 +24,25 @@ class UserAgent
           'Silk'
         elsif application.comment.first.include?('PlayStation 4')
           'PS4 Internet Browser'
-        else
-          nil
         end
       end
 
       # PS Vita is mobile, others are not.
-      # 
+      #
       # @return [true, false] is this a mobile browser?
       def mobile?
         platform == 'PlayStation Vita'
       end
 
       # Returns the operating system in use.
-      # 
+      #
       # @return [String] the operating system in use
       def os
         application.comment.join(' ')
       end
 
       # Returns the platform in use.
-      # 
+      #
       # @return [nil, "PlayStation 3", "PlayStation 4", "PlayStation Vita"] the platform in use
       def platform
         if os.include?('PLAYSTATION 3')
@@ -53,14 +51,12 @@ class UserAgent
           'PlayStation 4'
         elsif os.include?('PlayStation Vita')
           'PlayStation Vita'
-        else
-          nil
         end
       end
 
       # Returns the browser version in use. If Silk, returns the version of Silk.
       # Otherwise, returns the PS3/PS4 firmware version.
-      # 
+      #
       # @return [nil, Version] the version
       def version
         if browser == 'Silk'
@@ -71,8 +67,6 @@ class UserAgent
           Version.new(os.split('PlayStation 4 ').last)
         elsif platform == 'PlayStation Vita'
           Version.new(os.split('PlayStation Vita ').last)
-        else
-          nil
         end
       end
     end

--- a/lib/user_agent/browsers/podcast_addict.rb
+++ b/lib/user_agent/browsers/podcast_addict.rb
@@ -15,7 +15,7 @@ class UserAgent
       end
 
       # If we can figure out the device, return it.
-      # 
+      #
       # @return [nil, String] the device model
       def device
         return nil unless length >= 4
@@ -25,7 +25,7 @@ class UserAgent
       end
 
       # If we can figure out the device build, return it.
-      # 
+      #
       # @return [nil, String] the device build
       def device_build
         return nil unless length >= 4
@@ -35,7 +35,7 @@ class UserAgent
       end
 
       # Returns the localization, if known. We currently only know this for certain devices.
-      # 
+      #
       # @return [nil, String] the localization
       def localization
         return nil unless length >= 4
@@ -46,14 +46,14 @@ class UserAgent
       end
 
       # This is a mobile app, always return true.
-      # 
+      #
       # @return [true]
       def mobile?
         true
       end
 
       # Gets the operating system (some variant of Android, if we're certain that is the case)
-      # 
+      #
       # @return [nil, String] the operating system
       def os
         return nil unless length >= 4
@@ -65,31 +65,24 @@ class UserAgent
           self[3].comment[2]
         elsif (self[3].product == 'Dalvik' || self[3].product == 'Mozilla') && self[3].comment.length == 3
           'Android'
-        else
-          nil
         end
       end
 
       # Gets the platform (Android, if we're certain)
-      # 
+      #
       # @return [nil, "Android"] the platform
       def platform
-        if os.include?('Android')
-          'Android'
-        else
-          nil
-        end
+        'Android' if os.include?('Android')
       end
 
-
       # Get the security level reported
-      # 
+      #
       # @return [:weak, :strong, :none] the security level
       def security
         return nil unless length >= 4
         return nil unless self[3].product == 'Dalvik' || self[3].product == 'Mozilla'
 
-        Security[self[3].comment[1]]
+        SECURITY[self[3].comment[1]]
       end
 
       # We aren't provided with the version :(

--- a/lib/user_agent/browsers/podcast_addict.rb
+++ b/lib/user_agent/browsers/podcast_addict.rb
@@ -7,11 +7,11 @@ class UserAgent
     # Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)
     class PodcastAddict < Base
       def self.extend?(agent)
-        agent.length >= 3 && agent[0].product == 'Podcast' && agent[1].product == 'Addict' && agent[2].product == '-'
+        agent.length >= 3 && agent[0].product == "Podcast" && agent[1].product == "Addict" && agent[2].product == "-"
       end
 
       def browser
-        'Podcast Addict'
+        "Podcast Addict"
       end
 
       # If we can figure out the device, return it.
@@ -19,9 +19,9 @@ class UserAgent
       # @return [nil, String] the device model
       def device
         return nil unless length >= 4
-        return nil unless self[3].comment.last.include?(' Build/')
+        return nil unless self[3].comment.last.include?(" Build/")
 
-        self[3].comment.last.split(' Build/').first
+        self[3].comment.last.split(" Build/").first
       end
 
       # If we can figure out the device build, return it.
@@ -29,9 +29,9 @@ class UserAgent
       # @return [nil, String] the device build
       def device_build
         return nil unless length >= 4
-        return nil unless self[3].comment.last.include?(' Build/')
+        return nil unless self[3].comment.last.include?(" Build/")
 
-        self[3].comment.last.split(' Build/').last
+        self[3].comment.last.split(" Build/").last
       end
 
       # Returns the localization, if known. We currently only know this for certain devices.
@@ -39,7 +39,7 @@ class UserAgent
       # @return [nil, String] the localization
       def localization
         return nil unless length >= 4
-        return nil unless self[3].comment.last.include?('ALCATEL ')
+        return nil unless self[3].comment.last.include?("ALCATEL ")
         return nil unless self[3].comment.length >= 5
 
         self[3].comment[3]
@@ -61,10 +61,10 @@ class UserAgent
         # comment[0] = 'Linux'
         # comment[1] = 'U'
         # comment[2] = 'Android x.y.z' except when there are only 3 tokens, then we don't know the version
-        if (self[3].product == 'Dalvik' || self[3].product == 'Mozilla') && self[3].comment.length > 3
+        if (self[3].product == "Dalvik" || self[3].product == "Mozilla") && self[3].comment.length > 3
           self[3].comment[2]
-        elsif (self[3].product == 'Dalvik' || self[3].product == 'Mozilla') && self[3].comment.length == 3
-          'Android'
+        elsif (self[3].product == "Dalvik" || self[3].product == "Mozilla") && self[3].comment.length == 3
+          "Android"
         end
       end
 
@@ -72,7 +72,7 @@ class UserAgent
       #
       # @return [nil, "Android"] the platform
       def platform
-        'Android' if os.include?('Android')
+        "Android" if os.include?("Android")
       end
 
       # Get the security level reported
@@ -80,7 +80,7 @@ class UserAgent
       # @return [:weak, :strong, :none] the security level
       def security
         return nil unless length >= 4
-        return nil unless self[3].product == 'Dalvik' || self[3].product == 'Mozilla'
+        return nil unless self[3].product == "Dalvik" || self[3].product == "Mozilla"
 
         SECURITY[self[3].comment[1]]
       end

--- a/lib/user_agent/browsers/vivaldi.rb
+++ b/lib/user_agent/browsers/vivaldi.rb
@@ -2,11 +2,11 @@ class UserAgent
   module Browsers
     class Vivaldi < Base
       def self.extend?(agent)
-        agent.detect { |useragent| useragent.product == 'Vivaldi' }
+        agent.detect { |useragent| useragent.product == "Vivaldi" }
       end
 
       def browser
-        'Vivaldi'
+        "Vivaldi"
       end
 
       def build
@@ -25,18 +25,18 @@ class UserAgent
         return unless application
 
         if application.comment[0] =~ /Windows/
-          'Windows'
+          "Windows"
         elsif application.comment.any? { |c| c =~ /CrOS/ }
-          'ChromeOS'
+          "ChromeOS"
         elsif application.comment.any? { |c| c =~ /Android/ }
-          'Android'
+          "Android"
         else
           application.comment[0]
         end
       end
 
       def webkit
-        detect_product('AppleWebKit')
+        detect_product("AppleWebKit")
       end
 
       def os

--- a/lib/user_agent/browsers/vivaldi.rb
+++ b/lib/user_agent/browsers/vivaldi.rb
@@ -18,7 +18,7 @@ class UserAgent
       end
 
       def application
-        self.reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
+        reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
       end
 
       def platform
@@ -36,7 +36,7 @@ class UserAgent
       end
 
       def webkit
-        detect_product("AppleWebKit")
+        detect_product('AppleWebKit')
       end
 
       def os

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -51,17 +51,16 @@ class UserAgent
         "534.52.7" => "5.1.2"
       }.freeze
 
+      def BuildVersions # rubocop:disable Naming/MethodName
+        warn("#{__method__} is deprecated. Please use BUILD_VERSIONS instead")
+        BUILD_VERSIONS
+      end
+
       # Prior to Safari 3, the user agent did not include a version number
       def version
-        str = if (product = detect_product("Version"))
-                product.version
-              elsif os =~ /iOS ([\d\.]+)/ && browser == "Safari"
-                Regexp.last_match(1).tr("_", ".")
-              else
-                BUILD_VERSIONS[build.to_s]
-              end
-
-        Version.new(str)
+        return Version.new(detect_product("Version").version) if detect_product("Version")
+        return Version.new(Regexp.last_match(1).tr("_", ".")) if os =~ /iOS ([\d\.]+)/ && browser == "Safari"
+        Version.new(BUILD_VERSIONS[build.to_s])
       end
 
       def application

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -9,9 +9,9 @@ class UserAgent
       end
 
       def browser
-        return 'Android' if os =~ /Android/
-        return platform if platform == 'BlackBerry'
-        'Safari'
+        return "Android" if os =~ /Android/
+        return platform if platform == "BlackBerry"
+        "Safari"
       end
 
       def build
@@ -19,44 +19,44 @@ class UserAgent
       end
 
       BUILD_VERSIONS = {
-        '85.7'     => '1.0',
-        '85.8.5'   => '1.0.3',
-        '85.8.2'   => '1.0.3',
-        '124'      => '1.2',
-        '125.2'    => '1.2.2',
-        '125.4'    => '1.2.3',
-        '125.5.5'  => '1.2.4',
-        '125.5.6'  => '1.2.4',
-        '125.5.7'  => '1.2.4',
-        '312.1.1'  => '1.3',
-        '312.1'    => '1.3',
-        '312.5'    => '1.3.1',
-        '312.5.1'  => '1.3.1',
-        '312.5.2'  => '1.3.1',
-        '312.8'    => '1.3.2',
-        '312.8.1'  => '1.3.2',
-        '412'      => '2.0',
-        '412.6'    => '2.0',
-        '412.6.2'  => '2.0',
-        '412.7'    => '2.0.1',
-        '416.11'   => '2.0.2',
-        '416.12'   => '2.0.2',
-        '417.9'    => '2.0.3',
-        '418'      => '2.0.3',
-        '418.8'    => '2.0.4',
-        '418.9'    => '2.0.4',
-        '418.9.1'  => '2.0.4',
-        '419'      => '2.0.4',
-        '425.13'   => '2.2',
-        '534.52.7' => '5.1.2'
+        "85.7"     => "1.0",
+        "85.8.5"   => "1.0.3",
+        "85.8.2"   => "1.0.3",
+        "124"      => "1.2",
+        "125.2"    => "1.2.2",
+        "125.4"    => "1.2.3",
+        "125.5.5"  => "1.2.4",
+        "125.5.6"  => "1.2.4",
+        "125.5.7"  => "1.2.4",
+        "312.1.1"  => "1.3",
+        "312.1"    => "1.3",
+        "312.5"    => "1.3.1",
+        "312.5.1"  => "1.3.1",
+        "312.5.2"  => "1.3.1",
+        "312.8"    => "1.3.2",
+        "312.8.1"  => "1.3.2",
+        "412"      => "2.0",
+        "412.6"    => "2.0",
+        "412.6.2"  => "2.0",
+        "412.7"    => "2.0.1",
+        "416.11"   => "2.0.2",
+        "416.12"   => "2.0.2",
+        "417.9"    => "2.0.3",
+        "418"      => "2.0.3",
+        "418.8"    => "2.0.4",
+        "418.9"    => "2.0.4",
+        "418.9.1"  => "2.0.4",
+        "419"      => "2.0.4",
+        "425.13"   => "2.2",
+        "534.52.7" => "5.1.2"
       }.freeze
 
       # Prior to Safari 3, the user agent did not include a version number
       def version
-        str = if (product = detect_product('Version'))
+        str = if (product = detect_product("Version"))
                 product.version
-              elsif os =~ /iOS ([\d\.]+)/ && browser == 'Safari'
-                Regexp.last_match(1).tr('_', '.')
+              elsif os =~ /iOS ([\d\.]+)/ && browser == "Safari"
+                Regexp.last_match(1).tr("_", ".")
               else
                 BUILD_VERSIONS[build.to_s]
               end
@@ -72,11 +72,11 @@ class UserAgent
         return unless application
 
         if application.comment[0] =~ /Windows/
-          'Windows'
-        elsif application.comment[0] == 'BB10'
-          'BlackBerry'
+          "Windows"
+        elsif application.comment[0] == "BB10"
+          "BlackBerry"
         elsif application.comment.any? { |c| c =~ /Android/ }
-          'Android'
+          "Android"
         else
           application.comment[0]
         end

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -48,7 +48,7 @@ class UserAgent
         "418.9.1"  => "2.0.4",
         "419"      => "2.0.4",
         "425.13"   => "2.2",
-        "534.52.7" => "5.1.2"
+        "534.52.7" => "5.1.2",
       }.freeze
 
       def BuildVersions # rubocop:disable Naming/MethodName

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -51,8 +51,15 @@ class UserAgent
         "534.52.7" => "5.1.2",
       }.freeze
 
+      def build_versions_warned
+        @build_versions_warned ||= false
+      end
+
       def BuildVersions # rubocop:disable Naming/MethodName
-        warn("#{__method__} is deprecated. Please use BUILD_VERSIONS instead")
+        unless build_versions_warned
+          warn("#{__method__} is deprecated. Please use BUILD_VERSIONS instead")
+          @build_versions_warned = true
+        end
         BUILD_VERSIONS
       end
 
@@ -70,15 +77,10 @@ class UserAgent
       def platform
         return unless application
 
-        if application.comment[0] =~ /Windows/
-          "Windows"
-        elsif application.comment[0] == "BB10"
-          "BlackBerry"
-        elsif application.comment.any? { |c| c =~ /Android/ }
-          "Android"
-        else
-          application.comment[0]
-        end
+        return "Windows" if application.comment[0] =~ /Windows/
+        return "BlackBerry" if application.comment[0] == "BB10"
+        return "Android" if application.comment.any? { |c| c =~ /Android/ }
+        application.comment[0]
       end
 
       def webkit

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -2,74 +2,70 @@ class UserAgent
   module Browsers
     class Webkit < Base
       WEBKIT_PRODUCT_REGEXP = /\AAppleWebKit\z/i
-      WEBKIT_VERSION_REGEXP = /\A(?<webkit>AppleWebKit)\/(?<version>[\d\.]+)/i
+      WEBKIT_VERSION_REGEXP = %r{\A(?<webkit>AppleWebKit)\/(?<version>[\d\.]+)}i
 
       def self.extend?(agent)
         agent.detect { |useragent| useragent.product =~ WEBKIT_PRODUCT_REGEXP || useragent.detect_comment { |c| c =~ WEBKIT_VERSION_REGEXP } }
       end
 
       def browser
-        if os =~ /Android/
-          'Android'
-        elsif platform == 'BlackBerry'
-          platform
-        else
-          'Safari'
-        end
+        return 'Android' if os =~ /Android/
+        return platform if platform == 'BlackBerry'
+        'Safari'
       end
 
       def build
         webkit.version
       end
 
-      BuildVersions = {
-        "85.7"     => "1.0",
-        "85.8.5"   => "1.0.3",
-        "85.8.2"   => "1.0.3",
-        "124"      => "1.2",
-        "125.2"    => "1.2.2",
-        "125.4"    => "1.2.3",
-        "125.5.5"  => "1.2.4",
-        "125.5.6"  => "1.2.4",
-        "125.5.7"  => "1.2.4",
-        "312.1.1"  => "1.3",
-        "312.1"    => "1.3",
-        "312.5"    => "1.3.1",
-        "312.5.1"  => "1.3.1",
-        "312.5.2"  => "1.3.1",
-        "312.8"    => "1.3.2",
-        "312.8.1"  => "1.3.2",
-        "412"      => "2.0",
-        "412.6"    => "2.0",
-        "412.6.2"  => "2.0",
-        "412.7"    => "2.0.1",
-        "416.11"   => "2.0.2",
-        "416.12"   => "2.0.2",
-        "417.9"    => "2.0.3",
-        "418"      => "2.0.3",
-        "418.8"    => "2.0.4",
-        "418.9"    => "2.0.4",
-        "418.9.1"  => "2.0.4",
-        "419"      => "2.0.4",
-        "425.13"   => "2.2",
-        "534.52.7" => "5.1.2"
+      BUILD_VERSIONS = {
+        '85.7'     => '1.0',
+        '85.8.5'   => '1.0.3',
+        '85.8.2'   => '1.0.3',
+        '124'      => '1.2',
+        '125.2'    => '1.2.2',
+        '125.4'    => '1.2.3',
+        '125.5.5'  => '1.2.4',
+        '125.5.6'  => '1.2.4',
+        '125.5.7'  => '1.2.4',
+        '312.1.1'  => '1.3',
+        '312.1'    => '1.3',
+        '312.5'    => '1.3.1',
+        '312.5.1'  => '1.3.1',
+        '312.5.2'  => '1.3.1',
+        '312.8'    => '1.3.2',
+        '312.8.1'  => '1.3.2',
+        '412'      => '2.0',
+        '412.6'    => '2.0',
+        '412.6.2'  => '2.0',
+        '412.7'    => '2.0.1',
+        '416.11'   => '2.0.2',
+        '416.12'   => '2.0.2',
+        '417.9'    => '2.0.3',
+        '418'      => '2.0.3',
+        '418.8'    => '2.0.4',
+        '418.9'    => '2.0.4',
+        '418.9.1'  => '2.0.4',
+        '419'      => '2.0.4',
+        '425.13'   => '2.2',
+        '534.52.7' => '5.1.2'
       }.freeze
 
       # Prior to Safari 3, the user agent did not include a version number
       def version
-        str = if product = detect_product('Version')
-          product.version
-        elsif os =~ /iOS ([\d\.]+)/ && browser == "Safari"
-          $1.tr('_', '.')
-        else
-          BuildVersions[build.to_s]
-        end
+        str = if (product = detect_product('Version'))
+                product.version
+              elsif os =~ /iOS ([\d\.]+)/ && browser == 'Safari'
+                Regexp.last_match(1).tr('_', '.')
+              else
+                BUILD_VERSIONS[build.to_s]
+              end
 
         Version.new(str)
       end
 
       def application
-        self.reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
+        reject { |agent| agent.comment.nil? || agent.comment.empty? }.first
       end
 
       def platform
@@ -87,15 +83,15 @@ class UserAgent
       end
 
       def webkit
-        if product_match = detect { |useragent| useragent.product =~ WEBKIT_PRODUCT_REGEXP }
+        if (product_match = detect { |useragent| useragent.product =~ WEBKIT_PRODUCT_REGEXP })
           product_match
-        elsif comment_match = detect_comment_match(WEBKIT_VERSION_REGEXP)
+        elsif (comment_match = detect_comment_match(WEBKIT_VERSION_REGEXP))
           UserAgent.new(comment_match[:webkit], comment_match[:version])
         end
       end
 
       def security
-        Security[application.comment[1]]
+        SECURITY[application.comment[1]]
       end
 
       def os

--- a/lib/user_agent/browsers/wechat_browser.rb
+++ b/lib/user_agent/browsers/wechat_browser.rb
@@ -10,7 +10,7 @@ class UserAgent
       end
 
       def version
-        micro_messenger = detect_product("MicroMessenger")
+        micro_messenger = detect_product('MicroMessenger')
         Version.new(micro_messenger.version)
       end
 

--- a/lib/user_agent/browsers/wechat_browser.rb
+++ b/lib/user_agent/browsers/wechat_browser.rb
@@ -6,11 +6,11 @@ class UserAgent
       end
 
       def browser
-        'Wechat Browser'
+        "Wechat Browser"
       end
 
       def version
-        micro_messenger = detect_product('MicroMessenger')
+        micro_messenger = detect_product("MicroMessenger")
         Version.new(micro_messenger.version)
       end
 
@@ -18,9 +18,9 @@ class UserAgent
         return unless application && application.comment
 
         if application.comment[0] =~ /iPhone/
-          'iPhone'
+          "iPhone"
         elsif application.comment.any? { |c| c =~ /Android/ }
-          'Android'
+          "Android"
         else
           application.comment[0]
         end

--- a/lib/user_agent/browsers/windows_media_player.rb
+++ b/lib/user_agent/browsers/windows_media_player.rb
@@ -35,6 +35,11 @@ class UserAgent
         end
       end
 
+      def has_wmfsdk?(version) # rubocop:disable Naming/PredicateName
+        warn("#{__method__} is deprecated. Please use wmfsdk? instead")
+        wmfsdk?(version)
+      end
+
       # @return ["Windows Media Player"] All of the user agents we parse are Windows Media Player
       def browser
         "Windows Media Player"

--- a/lib/user_agent/browsers/windows_media_player.rb
+++ b/lib/user_agent/browsers/windows_media_player.rb
@@ -9,9 +9,9 @@ class UserAgent
       def self.extend?(agent)
         agent.detect do |useragent|
           %w[NSPlayer Windows-Media-Player WMFSDK].include?(useragent.product) &&
-            agent.version != '4.1.0.3856' && # 4.1.0.3856 is libavformat
-            agent.version != '7.10.0.3059' && # used by VLC for mmsh support
-            agent.version != '7.0.0.1956' # used by VLC for mmstu support
+            agent.version != "4.1.0.3856" && # 4.1.0.3856 is libavformat
+            agent.version != "7.10.0.3059" && # used by VLC for mmsh support
+            agent.version != "7.0.0.1956" # used by VLC for mmstu support
         end
       end
 
@@ -19,7 +19,7 @@ class UserAgent
       #
       # @return [Version, nil] The WMFSDK version
       def wmfsdk_version
-        (respond_to?('WMFSDK') && send('WMFSDK').version) || nil
+        (respond_to?("WMFSDK") && send("WMFSDK").version) || nil
       end
 
       # Check if the client supports the WMFSDK version passed in.
@@ -37,12 +37,12 @@ class UserAgent
 
       # @return ["Windows Media Player"] All of the user agents we parse are Windows Media Player
       def browser
-        'Windows Media Player'
+        "Windows Media Player"
       end
 
       # @return ["Windows"] All of the user agents we parse are on Windows
       def platform
-        'Windows'
+        "Windows"
       end
 
       # @return [true, false] Is this Windows Media Player 6.4 (NSPlayer 4.1) or Media Player 6.0 (NSPlayer 3.2)?
@@ -54,7 +54,7 @@ class UserAgent
       #
       # @return [true, false] Is this a mobile Windows Media Player?
       def mobile?
-        ['Windows Phone 8', 'Windows Phone 8.1'].include?(os)
+        ["Windows Phone 8", "Windows Phone 8.1"].include?(os)
       end
 
       # Parses the Windows Media Player version to figure out the host OS version
@@ -128,48 +128,48 @@ class UserAgent
         # WMP 6.4
         if classic?
           case version.to_a[3]
-          when 3564, 3925 then  'Windows 98'
-          when 3857 then        'Windows 9x'
-          when 3936 then        'Windows XP'
-          when 3938 then        'Windows 2000'
-          else 'Windows'
+          when 3564, 3925 then  "Windows 98"
+          when 3857 then        "Windows 9x"
+          when 3936 then        "Windows XP"
+          when 3938 then        "Windows 2000"
+          else "Windows"
           end
 
         # WMP 7/7.1
         elsif version.to_a[0] == 7
           case version.to_a[3]
-          when 3055 then 'Windows 98'
-          else 'Windows'
+          when 3055 then "Windows 98"
+          else "Windows"
           end
 
         # WMP 8 was also known as "Windows Media Player for Windows XP"
         elsif version.to_a[0] == 8
-          'Windows XP'
+          "Windows XP"
 
         # WMP 9/10
         elsif version.to_a[0] == 9 || version.to_a[0] == 10
           case version.to_a[3]
-          when 2980 then              'Windows 98/2000'
-          when 3268, 3367, 3270 then  'Windows 2000'
-          when 3802, 4503 then        'Windows XP'
-          else 'Windows'
+          when 2980 then              "Windows 98/2000"
+          when 3268, 3367, 3270 then  "Windows 2000"
+          when 3802, 4503 then        "Windows XP"
+          else "Windows"
           end
 
         # WMP 11/12
         elsif version.to_a[0] == 11 || version.to_a[0] == 12
           case version.to_a[2]
           when 9841, 9858, 9860,
-               9879 then              'Windows 10'
-          when 9651 then              'Windows Phone 8.1'
-          when 9600 then              'Windows 8.1'
-          when 9200 then              'Windows 8'
-          when 7600, 7601 then        'Windows 7'
-          when 6000, 6001, 6002 then  'Windows Vista'
-          when 5721 then              'Windows XP'
-          else                        'Windows'
+               9879 then              "Windows 10"
+          when 9651 then              "Windows Phone 8.1"
+          when 9600 then              "Windows 8.1"
+          when 9200 then              "Windows 8"
+          when 7600, 7601 then        "Windows 7"
+          when 6000, 6001, 6002 then  "Windows Vista"
+          when 5721 then              "Windows XP"
+          else                        "Windows"
           end
         else
-          'Windows'
+          "Windows"
         end
       end
     end

--- a/lib/user_agent/browsers/windows_media_player.rb
+++ b/lib/user_agent/browsers/windows_media_player.rb
@@ -35,8 +35,15 @@ class UserAgent
         end
       end
 
+      def wmfsdk_warned
+        @wmfsdk_warned ||= false
+      end
+
       def has_wmfsdk?(version) # rubocop:disable Naming/PredicateName
-        warn("#{__method__} is deprecated. Please use wmfsdk? instead")
+        unless wmfsdk_warned
+          warn("#{__method__} is deprecated. Please use wmfsdk? instead")
+          @wmfsdk_warned = true
+        end
         wmfsdk?(version)
       end
 

--- a/lib/user_agent/browsers/windows_media_player.rb
+++ b/lib/user_agent/browsers/windows_media_player.rb
@@ -2,47 +2,47 @@ class UserAgent
   module Browsers
     # The user agent used by Windows Media Player or applications which utilize the
     # Windows Media SDK.
-    # 
+    #
     # @note Both VLC and libavformat impersonate Windows Media Player when they think they
     #       are using MMS (Microsoft Media Services/Windows Media Server).
     class WindowsMediaPlayer < Base
       def self.extend?(agent)
         agent.detect do |useragent|
-          %w(NSPlayer Windows-Media-Player WMFSDK).include?(useragent.product) &&
-            agent.version != "4.1.0.3856" && # 4.1.0.3856 is libavformat
-            agent.version != "7.10.0.3059" && # used by VLC for mmsh support
-            agent.version != "7.0.0.1956" # used by VLC for mmstu support
+          %w[NSPlayer Windows-Media-Player WMFSDK].include?(useragent.product) &&
+            agent.version != '4.1.0.3856' && # 4.1.0.3856 is libavformat
+            agent.version != '7.10.0.3059' && # used by VLC for mmsh support
+            agent.version != '7.0.0.1956' # used by VLC for mmstu support
         end
       end
 
       # The Windows Media Format SDK version
-      # 
+      #
       # @return [Version, nil] The WMFSDK version
       def wmfsdk_version
-        (respond_to?("WMFSDK") && self.send("WMFSDK").version) || nil
+        (respond_to?('WMFSDK') && send('WMFSDK').version) || nil
       end
 
       # Check if the client supports the WMFSDK version passed in.
-      # 
+      #
       # @param [String] version
       #   The WMFSDK version to check for. For example, "9.0", "11.0", "12.0"
       # @return [true, false] Is this media player compatible with the passed WMFSDK version?
-      def has_wmfsdk?(version)
+      def wmfsdk?(version)
         if wmfsdk_version && wmfsdk_version.to_s =~ /\A#{version}/
-          return true
+          true
         else
-          return false
+          false
         end
       end
 
       # @return ["Windows Media Player"] All of the user agents we parse are Windows Media Player
       def browser
-        "Windows Media Player"
+        'Windows Media Player'
       end
 
       # @return ["Windows"] All of the user agents we parse are on Windows
       def platform
-        "Windows"
+        'Windows'
       end
 
       # @return [true, false] Is this Windows Media Player 6.4 (NSPlayer 4.1) or Media Player 6.0 (NSPlayer 3.2)?
@@ -51,125 +51,125 @@ class UserAgent
       end
 
       # Check if our parsed OS is a mobile OS
-      # 
+      #
       # @return [true, false] Is this a mobile Windows Media Player?
       def mobile?
-        ["Windows Phone 8", "Windows Phone 8.1"].include?(os)
+        ['Windows Phone 8', 'Windows Phone 8.1'].include?(os)
       end
 
       # Parses the Windows Media Player version to figure out the host OS version
-      # 
+      #
       # User agents I have personally found:
-      # 
+      #
       # Windows 95 with Windows Media Player 6.4::
       #   NSPlayer/4.1.0.3857
-      # 
+      #
       # Windows 98 SE with Windows Media Player 6.01::
       #   NSPlayer/3.2.0.3564
-      # 
+      #
       # Womdpws 98 SE with Windows Media Player 6.4::
       #   NSPlayer/4.1.0.3857
       #   NSPlayer/4.1.0.3925
-      # 
+      #
       # Windows 98 SE with Windows Media Player 7.1::
       #   NSPlayer/7.1.0.3055
-      # 
+      #
       # Windows 98 SE with Windows Media Player 9.0::
       #   Windows-Media-Player/9.00.00.2980
       #   NSPlayer/9.0.0.2980 WMFSDK/9.0
-      # 
+      #
       # Windows 2000 with Windows Media Player 6.4::
       #   NSPlayer/4.1.0.3938
-      # 
+      #
       # Windows 2000 with Windows Media Player 7.1 (downgraded from WMP9)::
       #   NSPlayer/9.0.0.3268
       #   NSPlayer/9.0.0.3268 WMFSDK/9.0
       #   NSPlayer/9.0.0.3270 WMFSDK/9.0
       #   NSPlayer/9.0.0.2980
-      # 
+      #
       # Windows 2000 with Windows Media Player 9.0::
       #   NSPlayer/9.0.0.3270 WMFSDK/9.0
       #   Windows-Media-Player/9.00.00.3367
-      # 
-      # Windows XP with Windows Media Player 6.4:: 
+      #
+      # Windows XP with Windows Media Player 6.4::
       #   NSPlayer/4.1.0.3936
-      # 
+      #
       # Windows XP with Windows Media Player 9::
       #   NSPlayer/9.0.0.4503
       #   NSPlayer/9.0.0.4503 WMFSDK/9.0
       #   Windows-Media-Player/9.00.00.4503
-      # 
+      #
       # Windows XP with Windows Media Player 10::
       #   NSPlayer/10.0.0.3802
       #   NSPlayer/10.0.0.3802 WMFSDK/10.0
       #   Windows-Media-Player/10.00.00.3802
-      # 
+      #
       # Windows XP with Windows Media Player 11::
       #   NSPlayer/11.0.5721.5262
       #   NSPlayer/11.0.5721.5262 WMFSDK/11.0
       #   Windows-Media-Player/11.0.5721.5262
-      # 
+      #
       # Windows Vista with Windows Media Player 11::
       #   NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392
       #   NSPlayer/11.0.6002.18005
       #   NSPlayer/11.0.6002.18049 WMFSDK/11.0
       #   Windows-Media-Player/11.0.6002.18311
-      # 
+      #
       # Windows 8.1 with Windows Media Player 12::
       #   NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031
-      # 
+      #
       # Windows 10 with Windows Media Player 12::
       #   Windows-Media-Player/12.0.9841.0
       #   NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000
-      # 
+      #
       # Windows Phone 8.1 (Podcasts app)::
       #   NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000
       def os
         # WMP 6.4
         if classic?
           case version.to_a[3]
-          when 3564, 3925 then  "Windows 98"
-          when 3857 then        "Windows 9x"
-          when 3936 then        "Windows XP"
-          when 3938 then        "Windows 2000"
-          else "Windows"
+          when 3564, 3925 then  'Windows 98'
+          when 3857 then        'Windows 9x'
+          when 3936 then        'Windows XP'
+          when 3938 then        'Windows 2000'
+          else 'Windows'
           end
 
         # WMP 7/7.1
         elsif version.to_a[0] == 7
           case version.to_a[3]
-          when 3055 then "Windows 98"
-          else "Windows"
+          when 3055 then 'Windows 98'
+          else 'Windows'
           end
 
         # WMP 8 was also known as "Windows Media Player for Windows XP"
         elsif version.to_a[0] == 8
-          "Windows XP"
+          'Windows XP'
 
         # WMP 9/10
         elsif version.to_a[0] == 9 || version.to_a[0] == 10
           case version.to_a[3]
-          when 2980 then              "Windows 98/2000"
-          when 3268, 3367, 3270 then  "Windows 2000"
-          when 3802, 4503 then        "Windows XP"
-          else "Windows"
+          when 2980 then              'Windows 98/2000'
+          when 3268, 3367, 3270 then  'Windows 2000'
+          when 3802, 4503 then        'Windows XP'
+          else 'Windows'
           end
 
         # WMP 11/12
         elsif version.to_a[0] == 11 || version.to_a[0] == 12
           case version.to_a[2]
           when 9841, 9858, 9860,
-               9879 then              "Windows 10"
-          when 9651 then              "Windows Phone 8.1"
-          when 9600 then              "Windows 8.1"
-          when 9200 then              "Windows 8"
-          when 7600, 7601 then        "Windows 7"
-          when 6000, 6001, 6002 then  "Windows Vista"
-          when 5721 then              "Windows XP"
-          else                        "Windows"
+               9879 then              'Windows 10'
+          when 9651 then              'Windows Phone 8.1'
+          when 9600 then              'Windows 8.1'
+          when 9200 then              'Windows 8'
+          when 7600, 7601 then        'Windows 7'
+          when 6000, 6001, 6002 then  'Windows Vista'
+          when 5721 then              'Windows XP'
+          else                        'Windows'
           end
         else
-          "Windows"
+          'Windows'
         end
       end
     end

--- a/lib/user_agent/comparable.rb
+++ b/lib/user_agent/comparable.rb
@@ -7,11 +7,11 @@ class UserAgent
     end
 
     def <=(other)
-      (c = self <=> other) ? c == -1 || c == 0 : false
+      (c = self <=> other) ? c == -1 || c.zero? : false
     end
 
     def ==(other)
-      (c = self <=> other) ? c == 0 : false
+      (c = self <=> other) ? c.zero? : false
     end
 
     def >(other)
@@ -19,7 +19,7 @@ class UserAgent
     end
 
     def >=(other)
-      (c = self <=> other) ? c == 1 || c == 0 : false
+      (c = self <=> other) ? c == 1 || c.zero? : false
     end
   end
 end

--- a/lib/user_agent/operating_systems.rb
+++ b/lib/user_agent/operating_systems.rb
@@ -6,19 +6,19 @@ class UserAgent
 
     class << self
       WINDOWS = {
-        'Windows NT 10.0' => 'Windows 10',
-        'Windows NT 6.3'  => 'Windows 8.1',
-        'Windows NT 6.2'  => 'Windows 8',
-        'Windows NT 6.1'  => 'Windows 7',
-        'Windows NT 6.0'  => 'Windows Vista',
-        'Windows NT 5.2'  => 'Windows XP x64 Edition',
-        'Windows NT 5.1'  => 'Windows XP',
-        'Windows NT 5.01' => 'Windows 2000, Service Pack 1 (SP1)',
-        'Windows NT 5.0'  => 'Windows 2000',
-        'Windows NT 4.0'  => 'Windows NT 4.0',
-        'Windows 98'      => 'Windows 98',
-        'Windows 95'      => 'Windows 95',
-        'Windows CE'      => 'Windows CE'
+        "Windows NT 10.0" => "Windows 10",
+        "Windows NT 6.3"  => "Windows 8.1",
+        "Windows NT 6.2"  => "Windows 8",
+        "Windows NT 6.1"  => "Windows 7",
+        "Windows NT 6.0"  => "Windows Vista",
+        "Windows NT 5.2"  => "Windows XP x64 Edition",
+        "Windows NT 5.1"  => "Windows XP",
+        "Windows NT 5.01" => "Windows 2000, Service Pack 1 (SP1)",
+        "Windows NT 5.0"  => "Windows 2000",
+        "Windows NT 4.0"  => "Windows NT 4.0",
+        "Windows 98"      => "Windows 98",
+        "Windows 95"      => "Windows 95",
+        "Windows CE"      => "Windows CE"
       }.freeze
 
       def normalize_os(os)
@@ -29,7 +29,7 @@ class UserAgent
 
       def normalize_chrome_os(os)
         if os =~ CHROMEOS_REGEX && Regexp.last_match(2).nil?
-          'ChromeOS'
+          "ChromeOS"
         elsif os =~ CHROMEOS_REGEX
           version = Regexp.last_match(2)
           "ChromeOS #{version}"
@@ -38,18 +38,18 @@ class UserAgent
 
       def normalize_ios(os)
         if os =~ IOS_VERSION_REGEX && Regexp.last_match(1).nil?
-          'iOS'
+          "iOS"
         elsif os =~ IOS_VERSION_REGEX
-          version = Regexp.last_match(1).tr('_', '.')
+          version = Regexp.last_match(1).tr("_", ".")
           "iOS #{version}"
         end
       end
 
       def normalize_mac_os_x(os)
         if os =~ MACOS_REGEX && Regexp.last_match(1).nil?
-          'OS X'
+          "OS X"
         elsif os =~ MACOS_REGEX
-          version = Regexp.last_match(1).tr('_', '.')
+          version = Regexp.last_match(1).tr("_", ".")
           "OS X #{version}"
         end
       end

--- a/lib/user_agent/operating_systems.rb
+++ b/lib/user_agent/operating_systems.rb
@@ -17,7 +17,7 @@ class UserAgent
       "Windows NT 4.0"  => "Windows NT 4.0",
       "Windows 98"      => "Windows 98",
       "Windows 95"      => "Windows 95",
-      "Windows CE"      => "Windows CE"
+      "Windows CE"      => "Windows CE",
     }.freeze
 
     class << self

--- a/lib/user_agent/operating_systems.rb
+++ b/lib/user_agent/operating_systems.rb
@@ -20,9 +20,13 @@ class UserAgent
       "Windows CE"      => "Windows CE",
     }.freeze
 
+    @windows_warned = false
     class << self
     def Windows # rubocop:disable Naming/MethodName
-      warn("#{__method__} is deprecated. Please use WINDOWS instead")
+      unless @windows_warned
+        warn("#{__method__} is deprecated. Please use WINDOWS instead")
+        @windows_warned = true
+      end
       WINDOWS
     end
 

--- a/lib/user_agent/operating_systems.rb
+++ b/lib/user_agent/operating_systems.rb
@@ -1,59 +1,58 @@
 class UserAgent
   module OperatingSystems
     IOS_VERSION_REGEX = /CPU (?:iPhone |iPod )?OS ([\d_]+) like Mac OS X/
+    CHROMEOS_REGEX = /CrOS\s([^\s]+)\s(\d+(\.\d+)*)/
+    MACOS_REGEX = /(?:Intel|PPC) Mac OS X\s*([0-9_\.]+)?/
 
-    Windows = {
-      "Windows NT 10.0" => "Windows 10",
-      "Windows NT 6.3"  => "Windows 8.1",
-      "Windows NT 6.2"  => "Windows 8",
-      "Windows NT 6.1"  => "Windows 7",
-      "Windows NT 6.0"  => "Windows Vista",
-      "Windows NT 5.2"  => "Windows XP x64 Edition",
-      "Windows NT 5.1"  => "Windows XP",
-      "Windows NT 5.01" => "Windows 2000, Service Pack 1 (SP1)",
-      "Windows NT 5.0"  => "Windows 2000",
-      "Windows NT 4.0"  => "Windows NT 4.0",
-      "Windows 98"      => "Windows 98",
-      "Windows 95"      => "Windows 95",
-      "Windows CE"      => "Windows CE"
-    }.freeze
+    class << self
+      WINDOWS = {
+        'Windows NT 10.0' => 'Windows 10',
+        'Windows NT 6.3'  => 'Windows 8.1',
+        'Windows NT 6.2'  => 'Windows 8',
+        'Windows NT 6.1'  => 'Windows 7',
+        'Windows NT 6.0'  => 'Windows Vista',
+        'Windows NT 5.2'  => 'Windows XP x64 Edition',
+        'Windows NT 5.1'  => 'Windows XP',
+        'Windows NT 5.01' => 'Windows 2000, Service Pack 1 (SP1)',
+        'Windows NT 5.0'  => 'Windows 2000',
+        'Windows NT 4.0'  => 'Windows NT 4.0',
+        'Windows 98'      => 'Windows 98',
+        'Windows 95'      => 'Windows 95',
+        'Windows CE'      => 'Windows CE'
+      }.freeze
 
-    def self.normalize_os(os)
-      Windows[os] || normalize_mac_os_x(os) || normalize_ios(os) || normalize_chrome_os(os) || os
+      def normalize_os(os)
+        WINDOWS[os] || normalize_mac_os_x(os) || normalize_ios(os) || normalize_chrome_os(os) || os
+      end
+
+      private
+
+      def normalize_chrome_os(os)
+        if os =~ CHROMEOS_REGEX && Regexp.last_match(2).nil?
+          'ChromeOS'
+        elsif os =~ CHROMEOS_REGEX
+          version = Regexp.last_match(2)
+          "ChromeOS #{version}"
+        end
+      end
+
+      def normalize_ios(os)
+        if os =~ IOS_VERSION_REGEX && Regexp.last_match(1).nil?
+          'iOS'
+        elsif os =~ IOS_VERSION_REGEX
+          version = Regexp.last_match(1).tr('_', '.')
+          "iOS #{version}"
+        end
+      end
+
+      def normalize_mac_os_x(os)
+        if os =~ MACOS_REGEX && Regexp.last_match(1).nil?
+          'OS X'
+        elsif os =~ MACOS_REGEX
+          version = Regexp.last_match(1).tr('_', '.')
+          "OS X #{version}"
+        end
+      end
     end
-
-    private
-      def self.normalize_chrome_os(os)
-        if os =~ /CrOS\s([^\s]+)\s(\d+(\.\d+)*)/
-          if $2.nil?
-            "ChromeOS"
-          else
-            version = $2
-            "ChromeOS #{version}"
-          end
-        end
-      end
-
-      def self.normalize_ios(os)
-        if os =~ IOS_VERSION_REGEX
-          if $1.nil?
-            "iOS"
-          else
-            version = $1.tr('_', '.')
-            "iOS #{version}"
-          end
-        end
-      end
-
-      def self.normalize_mac_os_x(os)
-        if os =~ /(?:Intel|PPC) Mac OS X\s*([0-9_\.]+)?/
-          if $1.nil?
-            "OS X"
-          else
-            version = $1.tr('_', '.')
-            "OS X #{version}"
-          end
-        end
-      end
   end
 end

--- a/lib/user_agent/operating_systems.rb
+++ b/lib/user_agent/operating_systems.rb
@@ -4,60 +4,60 @@ class UserAgent
     CHROMEOS_REGEX = /CrOS\s([^\s]+)\s(\d+(\.\d+)*)/
     MACOS_REGEX = /(?:Intel|PPC) Mac OS X\s*([0-9_\.]+)?/
 
+    WINDOWS = {
+      "Windows NT 10.0" => "Windows 10",
+      "Windows NT 6.3"  => "Windows 8.1",
+      "Windows NT 6.2"  => "Windows 8",
+      "Windows NT 6.1"  => "Windows 7",
+      "Windows NT 6.0"  => "Windows Vista",
+      "Windows NT 5.2"  => "Windows XP x64 Edition",
+      "Windows NT 5.1"  => "Windows XP",
+      "Windows NT 5.01" => "Windows 2000, Service Pack 1 (SP1)",
+      "Windows NT 5.0"  => "Windows 2000",
+      "Windows NT 4.0"  => "Windows NT 4.0",
+      "Windows 98"      => "Windows 98",
+      "Windows 95"      => "Windows 95",
+      "Windows CE"      => "Windows CE"
+    }.freeze
+
     class << self
-      WINDOWS = {
-        "Windows NT 10.0" => "Windows 10",
-        "Windows NT 6.3"  => "Windows 8.1",
-        "Windows NT 6.2"  => "Windows 8",
-        "Windows NT 6.1"  => "Windows 7",
-        "Windows NT 6.0"  => "Windows Vista",
-        "Windows NT 5.2"  => "Windows XP x64 Edition",
-        "Windows NT 5.1"  => "Windows XP",
-        "Windows NT 5.01" => "Windows 2000, Service Pack 1 (SP1)",
-        "Windows NT 5.0"  => "Windows 2000",
-        "Windows NT 4.0"  => "Windows NT 4.0",
-        "Windows 98"      => "Windows 98",
-        "Windows 95"      => "Windows 95",
-        "Windows CE"      => "Windows CE"
-      }.freeze
+    def Windows # rubocop:disable Naming/MethodName
+      warn("#{__method__} is deprecated. Please use WINDOWS instead")
+      WINDOWS
+    end
 
-      def Windows # rubocop:disable Naming/MethodName
-        warn("#{__method__} is deprecated. Please use WINDOWS instead")
-        WINDOWS
-      end
-
-      def normalize_os(os)
-        WINDOWS[os] || normalize_mac_os_x(os) || normalize_ios(os) || normalize_chrome_os(os) || os
-      end
+    def normalize_os(os)
+      WINDOWS[os] || normalize_mac_os_x(os) || normalize_ios(os) || normalize_chrome_os(os) || os
+    end
 
       private
 
-      def normalize_chrome_os(os)
-        if os =~ CHROMEOS_REGEX && Regexp.last_match(2).nil?
-          "ChromeOS"
-        elsif os =~ CHROMEOS_REGEX
-          version = Regexp.last_match(2)
-          "ChromeOS #{version}"
-        end
+    def normalize_chrome_os(os)
+      if os =~ CHROMEOS_REGEX && Regexp.last_match(2).nil?
+        "ChromeOS"
+      elsif os =~ CHROMEOS_REGEX
+        version = Regexp.last_match(2)
+        "ChromeOS #{version}"
       end
+    end
 
-      def normalize_ios(os)
-        if os =~ IOS_VERSION_REGEX && Regexp.last_match(1).nil?
-          "iOS"
-        elsif os =~ IOS_VERSION_REGEX
-          version = Regexp.last_match(1).tr("_", ".")
-          "iOS #{version}"
-        end
+    def normalize_ios(os)
+      if os =~ IOS_VERSION_REGEX && Regexp.last_match(1).nil?
+        "iOS"
+      elsif os =~ IOS_VERSION_REGEX
+        version = Regexp.last_match(1).tr("_", ".")
+        "iOS #{version}"
       end
+    end
 
-      def normalize_mac_os_x(os)
-        if os =~ MACOS_REGEX && Regexp.last_match(1).nil?
-          "OS X"
-        elsif os =~ MACOS_REGEX
-          version = Regexp.last_match(1).tr("_", ".")
-          "OS X #{version}"
-        end
+    def normalize_mac_os_x(os)
+      if os =~ MACOS_REGEX && Regexp.last_match(1).nil?
+        "OS X"
+      elsif os =~ MACOS_REGEX
+        version = Regexp.last_match(1).tr("_", ".")
+        "OS X #{version}"
       end
+    end
     end
   end
 end

--- a/lib/user_agent/operating_systems.rb
+++ b/lib/user_agent/operating_systems.rb
@@ -21,6 +21,11 @@ class UserAgent
         "Windows CE"      => "Windows CE"
       }.freeze
 
+      def Windows # rubocop:disable Naming/MethodName
+        warn("#{__method__} is deprecated. Please use WINDOWS instead")
+        WINDOWS
+      end
+
       def normalize_os(os)
         WINDOWS[os] || normalize_mac_os_x(os) || normalize_ios(os) || normalize_chrome_os(os) || os
       end

--- a/lib/user_agent/version.rb
+++ b/lib/user_agent/version.rb
@@ -9,7 +9,7 @@ class UserAgent
       when String
         super
       when NilClass
-        super('')
+        super("")
       else
         raise ArgumentError, "invalid value for Version: #{obj.inspect}"
       end

--- a/lib/user_agent/version.rb
+++ b/lib/user_agent/version.rb
@@ -9,7 +9,7 @@ class UserAgent
       when String
         super
       when NilClass
-        super("")
+        super('')
       else
         raise ArgumentError, "invalid value for Version: #{obj.inspect}"
       end
@@ -66,30 +66,23 @@ class UserAgent
       case other
       when Version
         if @comparable
-          ([0]*6).zip(to_a, other.to_a).each do |dump, a, b|
+          ([0] * 6).zip(to_a, other.to_a).each do |_dump, a, b|
             a ||= 0
             b ||= 0
 
-            if a.is_a?(String) && b.is_a?(Integer)
-              return -1
-            elsif a.is_a?(Integer) && b.is_a?(String)
-              return 1
-            elsif a == b
-              next
-            else
-              return a <=> b
-            end
+            return -1 if a.is_a?(String) && b.is_a?(Integer)
+            return 1 if a.is_a?(Integer) && b.is_a?(String)
+            next if a == b
+            return a <=> b
           end
           0
         elsif to_s == other.to_s
-          return 0
+          0
         else
-          return -1
+          -1
         end
       when String, NilClass
         self <=> self.class.new(other)
-      else
-        nil
       end
     end
 
@@ -98,7 +91,7 @@ class UserAgent
     end
 
     def inspect
-      "#<#{self.class} #{to_s}>"
+      "#<#{self.class} #{self}>"
     end
   end
 end

--- a/lib/useragent.rb
+++ b/lib/useragent.rb
@@ -1,1 +1,1 @@
-require 'user_agent'
+require "user_agent"

--- a/spec/browsers/apple_core_media_user_agent_spec.rb
+++ b/spec/browsers/apple_core_media_user_agent_spec.rb
@@ -1,13 +1,13 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples 'AppleCoreMedia' do
+shared_examples "AppleCoreMedia" do
   it "should return 'AppleCoreMedia' as its browser" do
-    expect(@useragent.browser).to eq('AppleCoreMedia')
+    expect(@useragent.browser).to eq("AppleCoreMedia")
   end
 end
 
-shared_examples 'AppleCoreMedia runs on' do |platform, os|
+shared_examples "AppleCoreMedia runs on" do |platform, os|
   it "should return '#{platform}' as its platform" do
     expect(@useragent.platform).to eq(platform)
   end
@@ -17,68 +17,68 @@ shared_examples 'AppleCoreMedia runs on' do |platform, os|
   end
 end
 
-shared_examples 'AppleCoreMedia has version number' do |version|
+shared_examples "AppleCoreMedia has version number" do |version|
   it "should return '#{version}' as its version" do
     expect(@useragent.version).to eq(version)
   end
 end
 
-shared_examples 'AppleCoreMedia has localization' do |locale|
+shared_examples "AppleCoreMedia has localization" do |locale|
   it "should return '#{locale}' as its localization" do
     expect(@useragent.localization).to eq(locale)
   end
 end
 
-shared_examples 'AppleCoreMedia has strong encryption' do
+shared_examples "AppleCoreMedia has strong encryption" do
   it "should return ':strong' as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 end
 
-describe 'UserAgent: AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)' do
+describe "UserAgent: AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)" do
   before do
-    @useragent = UserAgent.parse('AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)')
+    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)")
   end
 
-  it_behaves_like 'AppleCoreMedia'
-  it_behaves_like 'AppleCoreMedia runs on', 'iPhone', 'iOS 8.1.1'
-  it_behaves_like 'AppleCoreMedia has version number', '1.0.0.12B435'
-  it_behaves_like 'AppleCoreMedia has localization', 'en_us'
-  it_behaves_like 'AppleCoreMedia has strong encryption'
+  it_behaves_like "AppleCoreMedia"
+  it_behaves_like "AppleCoreMedia runs on", "iPhone", "iOS 8.1.1"
+  it_behaves_like "AppleCoreMedia has version number", "1.0.0.12B435"
+  it_behaves_like "AppleCoreMedia has localization", "en_us"
+  it_behaves_like "AppleCoreMedia has strong encryption"
 end
 
-describe 'UserAgent: AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)' do
+describe "UserAgent: AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)" do
   before do
-    @useragent = UserAgent.parse('AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)')
+    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)")
   end
 
-  it_behaves_like 'AppleCoreMedia'
-  it_behaves_like 'AppleCoreMedia runs on', 'iPod', 'iOS 6.1.5'
-  it_behaves_like 'AppleCoreMedia has version number', '1.0.0.10B400'
-  it_behaves_like 'AppleCoreMedia has localization', 'en_us'
-  it_behaves_like 'AppleCoreMedia has strong encryption'
+  it_behaves_like "AppleCoreMedia"
+  it_behaves_like "AppleCoreMedia runs on", "iPod", "iOS 6.1.5"
+  it_behaves_like "AppleCoreMedia has version number", "1.0.0.10B400"
+  it_behaves_like "AppleCoreMedia has localization", "en_us"
+  it_behaves_like "AppleCoreMedia has strong encryption"
 end
 
-describe 'UserAgent: AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)' do
+describe "UserAgent: AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)" do
   before do
-    @useragent = UserAgent.parse('AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)')
+    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)")
   end
 
-  it_behaves_like 'AppleCoreMedia'
-  it_behaves_like 'AppleCoreMedia runs on', 'iPad', 'iOS 7.1.2'
-  it_behaves_like 'AppleCoreMedia has version number', '1.0.0.11D257'
-  it_behaves_like 'AppleCoreMedia has localization', 'en_gb'
-  it_behaves_like 'AppleCoreMedia has strong encryption'
+  it_behaves_like "AppleCoreMedia"
+  it_behaves_like "AppleCoreMedia runs on", "iPad", "iOS 7.1.2"
+  it_behaves_like "AppleCoreMedia has version number", "1.0.0.11D257"
+  it_behaves_like "AppleCoreMedia has localization", "en_gb"
+  it_behaves_like "AppleCoreMedia has strong encryption"
 end
 
-describe 'UserAgent: AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)' do
+describe "UserAgent: AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)" do
   before do
-    @useragent = UserAgent.parse('AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)')
+    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)")
   end
 
-  it_behaves_like 'AppleCoreMedia'
-  it_behaves_like 'AppleCoreMedia runs on', 'iPhone', 'iOS 7.1.2'
-  it_behaves_like 'AppleCoreMedia has version number', '1.0.0.11D257'
-  it_behaves_like 'AppleCoreMedia has localization', 'en_us'
-  it_behaves_like 'AppleCoreMedia has strong encryption'
+  it_behaves_like "AppleCoreMedia"
+  it_behaves_like "AppleCoreMedia runs on", "iPhone", "iOS 7.1.2"
+  it_behaves_like "AppleCoreMedia has version number", "1.0.0.11D257"
+  it_behaves_like "AppleCoreMedia has localization", "en_us"
+  it_behaves_like "AppleCoreMedia has strong encryption"
 end

--- a/spec/browsers/apple_core_media_user_agent_spec.rb
+++ b/spec/browsers/apple_core_media_user_agent_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples "AppleCoreMedia" do
-  it "should return 'AppleCoreMedia' as its browser" do
+  it "returns 'AppleCoreMedia' as its browser" do
     expect(@useragent.browser).to eq("AppleCoreMedia")
   end
 end
@@ -30,7 +30,7 @@ shared_examples "AppleCoreMedia has localization" do |locale|
 end
 
 shared_examples "AppleCoreMedia has strong encryption" do
-  it "should return ':strong' as its security" do
+  it "returns ':strong' as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 end

--- a/spec/browsers/apple_core_media_user_agent_spec.rb
+++ b/spec/browsers/apple_core_media_user_agent_spec.rb
@@ -3,82 +3,76 @@ require "user_agent"
 
 shared_examples "AppleCoreMedia" do
   it "returns 'AppleCoreMedia' as its browser" do
-    expect(@useragent.browser).to eq("AppleCoreMedia")
+    expect(useragent.browser).to eq("AppleCoreMedia")
   end
 end
 
 shared_examples "AppleCoreMedia runs on" do |platform, os|
   it "should return '#{platform}' as its platform" do
-    expect(@useragent.platform).to eq(platform)
+    expect(useragent.platform).to eq(platform)
   end
 
   it "should return '#{os}' as its OS" do
-    expect(@useragent.os).to eq(os)
+    expect(useragent.os).to eq(os)
   end
 end
 
 shared_examples "AppleCoreMedia has version number" do |version|
   it "should return '#{version}' as its version" do
-    expect(@useragent.version).to eq(version)
+    expect(useragent.version).to eq(version)
   end
 end
 
 shared_examples "AppleCoreMedia has localization" do |locale|
   it "should return '#{locale}' as its localization" do
-    expect(@useragent.localization).to eq(locale)
+    expect(useragent.localization).to eq(locale)
   end
 end
 
 shared_examples "AppleCoreMedia has strong encryption" do
   it "returns ':strong' as its security" do
-    expect(@useragent.security).to eq(:strong)
+    expect(useragent.security).to eq(:strong)
   end
 end
 
-describe "UserAgent: AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)" do
-  before do
-    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)")
+describe UserAgent do
+  context "when iPhone iOS 8.1.1" do
+    let(:useragent) { described_class.parse("AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)") }
+
+    it_behaves_like "AppleCoreMedia"
+    it_behaves_like "AppleCoreMedia runs on", "iPhone", "iOS 8.1.1"
+    it_behaves_like "AppleCoreMedia has version number", "1.0.0.12B435"
+    it_behaves_like "AppleCoreMedia has localization", "en_us"
+    it_behaves_like "AppleCoreMedia has strong encryption"
   end
 
-  it_behaves_like "AppleCoreMedia"
-  it_behaves_like "AppleCoreMedia runs on", "iPhone", "iOS 8.1.1"
-  it_behaves_like "AppleCoreMedia has version number", "1.0.0.12B435"
-  it_behaves_like "AppleCoreMedia has localization", "en_us"
-  it_behaves_like "AppleCoreMedia has strong encryption"
-end
+  context "when iPod iOS 6.1.5" do
+    let(:useragent) { described_class.parse("AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)") }
 
-describe "UserAgent: AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)" do
-  before do
-    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)")
+    it_behaves_like "AppleCoreMedia"
+    it_behaves_like "AppleCoreMedia runs on", "iPod", "iOS 6.1.5"
+    it_behaves_like "AppleCoreMedia has version number", "1.0.0.10B400"
+    it_behaves_like "AppleCoreMedia has localization", "en_us"
+    it_behaves_like "AppleCoreMedia has strong encryption"
   end
 
-  it_behaves_like "AppleCoreMedia"
-  it_behaves_like "AppleCoreMedia runs on", "iPod", "iOS 6.1.5"
-  it_behaves_like "AppleCoreMedia has version number", "1.0.0.10B400"
-  it_behaves_like "AppleCoreMedia has localization", "en_us"
-  it_behaves_like "AppleCoreMedia has strong encryption"
-end
+  context "when iPad iOS 7.1.2" do
+    let(:useragent) { described_class.parse("AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)") }
 
-describe "UserAgent: AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)" do
-  before do
-    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)")
+    it_behaves_like "AppleCoreMedia"
+    it_behaves_like "AppleCoreMedia runs on", "iPad", "iOS 7.1.2"
+    it_behaves_like "AppleCoreMedia has version number", "1.0.0.11D257"
+    it_behaves_like "AppleCoreMedia has localization", "en_gb"
+    it_behaves_like "AppleCoreMedia has strong encryption"
   end
 
-  it_behaves_like "AppleCoreMedia"
-  it_behaves_like "AppleCoreMedia runs on", "iPad", "iOS 7.1.2"
-  it_behaves_like "AppleCoreMedia has version number", "1.0.0.11D257"
-  it_behaves_like "AppleCoreMedia has localization", "en_gb"
-  it_behaves_like "AppleCoreMedia has strong encryption"
-end
+  context "when iPhone iOS 7.1.2" do
+    let(:useragent) { described_class.parse("AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)") }
 
-describe "UserAgent: AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)" do
-  before do
-    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)")
+    it_behaves_like "AppleCoreMedia"
+    it_behaves_like "AppleCoreMedia runs on", "iPhone", "iOS 7.1.2"
+    it_behaves_like "AppleCoreMedia has version number", "1.0.0.11D257"
+    it_behaves_like "AppleCoreMedia has localization", "en_us"
+    it_behaves_like "AppleCoreMedia has strong encryption"
   end
-
-  it_behaves_like "AppleCoreMedia"
-  it_behaves_like "AppleCoreMedia runs on", "iPhone", "iOS 7.1.2"
-  it_behaves_like "AppleCoreMedia has version number", "1.0.0.11D257"
-  it_behaves_like "AppleCoreMedia has localization", "en_us"
-  it_behaves_like "AppleCoreMedia has strong encryption"
 end

--- a/spec/browsers/apple_core_media_user_agent_spec.rb
+++ b/spec/browsers/apple_core_media_user_agent_spec.rb
@@ -1,12 +1,13 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples "AppleCoreMedia" do
+shared_examples 'AppleCoreMedia' do
   it "should return 'AppleCoreMedia' as its browser" do
-    expect(@useragent.browser).to eq("AppleCoreMedia")
+    expect(@useragent.browser).to eq('AppleCoreMedia')
   end
 end
 
-shared_examples "AppleCoreMedia runs on" do |platform, os|
+shared_examples 'AppleCoreMedia runs on' do |platform, os|
   it "should return '#{platform}' as its platform" do
     expect(@useragent.platform).to eq(platform)
   end
@@ -16,68 +17,68 @@ shared_examples "AppleCoreMedia runs on" do |platform, os|
   end
 end
 
-shared_examples "AppleCoreMedia has version number" do |version|
+shared_examples 'AppleCoreMedia has version number' do |version|
   it "should return '#{version}' as its version" do
     expect(@useragent.version).to eq(version)
   end
 end
 
-shared_examples "AppleCoreMedia has localization" do |locale|
+shared_examples 'AppleCoreMedia has localization' do |locale|
   it "should return '#{locale}' as its localization" do
     expect(@useragent.localization).to eq(locale)
   end
 end
 
-shared_examples "AppleCoreMedia has strong encryption" do
+shared_examples 'AppleCoreMedia has strong encryption' do
   it "should return ':strong' as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 end
 
-describe "UserAgent: AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)" do
+describe 'UserAgent: AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)' do
   before do
-    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)")
+    @useragent = UserAgent.parse('AppleCoreMedia/1.0.0.12B435 (iPhone; U; CPU OS 8_1_1 like Mac OS X; en_us)')
   end
 
-  it_behaves_like "AppleCoreMedia"
-  it_behaves_like "AppleCoreMedia runs on", "iPhone", "iOS 8.1.1"
-  it_behaves_like "AppleCoreMedia has version number", "1.0.0.12B435"
-  it_behaves_like "AppleCoreMedia has localization", "en_us"
-  it_behaves_like "AppleCoreMedia has strong encryption"
+  it_behaves_like 'AppleCoreMedia'
+  it_behaves_like 'AppleCoreMedia runs on', 'iPhone', 'iOS 8.1.1'
+  it_behaves_like 'AppleCoreMedia has version number', '1.0.0.12B435'
+  it_behaves_like 'AppleCoreMedia has localization', 'en_us'
+  it_behaves_like 'AppleCoreMedia has strong encryption'
 end
 
-describe "UserAgent: AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)" do
+describe 'UserAgent: AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)' do
   before do
-    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)")
+    @useragent = UserAgent.parse('AppleCoreMedia/1.0.0.10B400 (iPod; U; CPU OS 6_1_5 like Mac OS X; en_us)')
   end
 
-  it_behaves_like "AppleCoreMedia"
-  it_behaves_like "AppleCoreMedia runs on", "iPod", "iOS 6.1.5"
-  it_behaves_like "AppleCoreMedia has version number", "1.0.0.10B400"
-  it_behaves_like "AppleCoreMedia has localization", "en_us"
-  it_behaves_like "AppleCoreMedia has strong encryption"
+  it_behaves_like 'AppleCoreMedia'
+  it_behaves_like 'AppleCoreMedia runs on', 'iPod', 'iOS 6.1.5'
+  it_behaves_like 'AppleCoreMedia has version number', '1.0.0.10B400'
+  it_behaves_like 'AppleCoreMedia has localization', 'en_us'
+  it_behaves_like 'AppleCoreMedia has strong encryption'
 end
 
-describe "UserAgent: AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)" do
+describe 'UserAgent: AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)' do
   before do
-    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)")
+    @useragent = UserAgent.parse('AppleCoreMedia/1.0.0.11D257 (iPad; U; CPU OS 7_1_2 like Mac OS X; en_gb)')
   end
 
-  it_behaves_like "AppleCoreMedia"
-  it_behaves_like "AppleCoreMedia runs on", "iPad", "iOS 7.1.2"
-  it_behaves_like "AppleCoreMedia has version number", "1.0.0.11D257"
-  it_behaves_like "AppleCoreMedia has localization", "en_gb"
-  it_behaves_like "AppleCoreMedia has strong encryption"
+  it_behaves_like 'AppleCoreMedia'
+  it_behaves_like 'AppleCoreMedia runs on', 'iPad', 'iOS 7.1.2'
+  it_behaves_like 'AppleCoreMedia has version number', '1.0.0.11D257'
+  it_behaves_like 'AppleCoreMedia has localization', 'en_gb'
+  it_behaves_like 'AppleCoreMedia has strong encryption'
 end
 
-describe "UserAgent: AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)" do
+describe 'UserAgent: AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)' do
   before do
-    @useragent = UserAgent.parse("AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)")
+    @useragent = UserAgent.parse('AppleCoreMedia/1.0.0.11D257 (iPhone; U; CPU OS 7_1_2 like Mac OS X; en_us)')
   end
 
-  it_behaves_like "AppleCoreMedia"
-  it_behaves_like "AppleCoreMedia runs on", "iPhone", "iOS 7.1.2"
-  it_behaves_like "AppleCoreMedia has version number", "1.0.0.11D257"
-  it_behaves_like "AppleCoreMedia has localization", "en_us"
-  it_behaves_like "AppleCoreMedia has strong encryption"
+  it_behaves_like 'AppleCoreMedia'
+  it_behaves_like 'AppleCoreMedia runs on', 'iPhone', 'iOS 7.1.2'
+  it_behaves_like 'AppleCoreMedia has version number', '1.0.0.11D257'
+  it_behaves_like 'AppleCoreMedia has localization', 'en_us'
+  it_behaves_like 'AppleCoreMedia has strong encryption'
 end

--- a/spec/browsers/bot_user_agent_spec.rb
+++ b/spec/browsers/bot_user_agent_spec.rb
@@ -1,9 +1,9 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
   end
 
   it { expect(@useragent).to be_bot }
@@ -11,7 +11,7 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)")
   end
 
   it { expect(@useragent).to be_bot }
@@ -19,23 +19,23 @@ end
 
 describe "UserAgent: 'Twitterbot/1.0'" do
   before do
-    @useragent = UserAgent.parse('Twitterbot/1.0')
+    @useragent = UserAgent.parse("Twitterbot/1.0")
   end
 
   it { expect(@useragent).to be_bot }
 end
 
-describe 'UserAgent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)' do
+describe "UserAgent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)")
   end
 
   it { expect(@useragent).to be_bot }
 end
 
-describe 'UserAgent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' do
+describe "UserAgent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
   end
 
   it { expect(@useragent).to be_bot }

--- a/spec/browsers/bot_user_agent_spec.rb
+++ b/spec/browsers/bot_user_agent_spec.rb
@@ -1,8 +1,9 @@
+require 'spec_helper'
 require 'user_agent'
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
   end
 
   it { expect(@useragent).to be_bot }
@@ -10,7 +11,7 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)')
   end
 
   it { expect(@useragent).to be_bot }
@@ -18,24 +19,24 @@ end
 
 describe "UserAgent: 'Twitterbot/1.0'" do
   before do
-    @useragent = UserAgent.parse("Twitterbot/1.0")
+    @useragent = UserAgent.parse('Twitterbot/1.0')
   end
 
-  it { expect(@useragent).to be_bot}
+  it { expect(@useragent).to be_bot }
 end
 
-describe "UserAgent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)" do
+describe 'UserAgent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)')
   end
 
-  it { expect(@useragent).to be_bot}
+  it { expect(@useragent).to be_bot }
 end
 
-describe "UserAgent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" do
+describe 'UserAgent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
   end
 
-  it { expect(@useragent).to be_bot}
+  it { expect(@useragent).to be_bot }
 end

--- a/spec/browsers/bot_user_agent_spec.rb
+++ b/spec/browsers/bot_user_agent_spec.rb
@@ -1,42 +1,34 @@
 require "spec_helper"
 require "user_agent"
 
-describe "UserAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)") }
+
+    it { expect(useragent).to be_bot }
   end
 
-  it { expect(@useragent).to be_bot }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)") }
 
-describe "UserAgent: 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)")
+    it { expect(useragent).to be_bot }
   end
 
-  it { expect(@useragent).to be_bot }
-end
+  context do
+    let(:useragent) { described_class.parse("Twitterbot/1.0") }
 
-describe "UserAgent: 'Twitterbot/1.0'" do
-  before do
-    @useragent = UserAgent.parse("Twitterbot/1.0")
+    it { expect(useragent).to be_bot }
   end
 
-  it { expect(@useragent).to be_bot }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)") }
 
-describe "UserAgent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)")
+    it { expect(useragent).to be_bot }
   end
 
-  it { expect(@useragent).to be_bot }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)") }
 
-describe "UserAgent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+    it { expect(useragent).to be_bot }
   end
-
-  it { expect(@useragent).to be_bot }
 end

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -1,161 +1,161 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples_for 'Chrome browser' do
+shared_examples_for "Chrome browser" do
   it "should return 'Chrome' as its browser" do
-    expect(@useragent.browser).to eq('Chrome')
+    expect(@useragent.browser).to eq("Chrome")
   end
 end
 
 # http://www.useragentstring.com/Chrome30.0.1599.17_id_19721.php
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '30.0.1599.17' as its version" do
-    expect(@useragent.version).to eq('30.0.1599.17')
+    expect(@useragent.version).to eq("30.0.1599.17")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 8' as its os" do
-    expect(@useragent.os).to eq('Windows 8')
+    expect(@useragent.os).to eq("Windows 8")
   end
 end
 
 # http://www.useragentstring.com/Chrome29.0.1547.62_id_19709.php
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '29.0.1547.62' as its version" do
-    expect(@useragent.version).to eq('29.0.1547.62')
+    expect(@useragent.version).to eq("29.0.1547.62")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '29.0.1547.57' as its version" do
-    expect(@useragent.version).to eq('29.0.1547.57')
+    expect(@useragent.version).to eq("29.0.1547.57")
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq('X11')
+    expect(@useragent.platform).to eq("X11")
   end
 
   it "should return 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq('Linux x86_64')
+    expect(@useragent.os).to eq("Linux x86_64")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '536.26' as its build" do
-    expect(@useragent.build).to eq('536.26')
+    expect(@useragent.build).to eq("536.26")
   end
 
   it "should return '28.0.1500.16' as its version" do
-    expect(@useragent.version).to eq('28.0.1500.16')
+    expect(@useragent.version).to eq("28.0.1500.16")
   end
 
   it "should return '536.26' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('536.26')
+    expect(@useragent.webkit.version).to eq("536.26")
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq('iPhone')
+    expect(@useragent.platform).to eq("iPhone")
   end
 
   it "should return 'iOS 6.1.3' as its os" do
-    expect(@useragent.os).to eq('iOS 6.1.3')
+    expect(@useragent.os).to eq("iOS 6.1.3")
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17' do
+describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.8.2' as its os" do
-    expect(@useragent.os).to eq('OS X 10.8.2')
+    expect(@useragent.os).to eq("OS X 10.8.2")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '535.19' as its build" do
-    expect(@useragent.build).to eq('535.19')
+    expect(@useragent.build).to eq("535.19")
   end
 
   it "should return '18.0.1025.168' as its version" do
-    expect(@useragent.version).to eq('18.0.1025.168')
+    expect(@useragent.version).to eq("18.0.1025.168")
   end
 
   it "should return '535.19' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('535.19')
+    expect(@useragent.webkit.version).to eq("535.19")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 end
 
-describe 'Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19' do
+describe "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19")
   end
 
   it "should return 'Chrome' as its browser" do
-    expect(@useragent.browser).to eq('Chrome')
+    expect(@useragent.browser).to eq("Chrome")
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq('Android')
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "should return 'Android 4.2' as its os" do
-    expect(@useragent.os).to eq('Android 4.2')
+    expect(@useragent.os).to eq("Android 4.2")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -163,194 +163,194 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '534.16' as its build" do
-    expect(@useragent.build).to eq('534.16')
+    expect(@useragent.build).to eq("534.16")
   end
 
   it "should return '10.0.639.0' as its version" do
-    expect(@useragent.version).to eq('10.0.639.0')
+    expect(@useragent.version).to eq("10.0.639.0")
   end
 
   it "should return '534.16' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('534.16')
+    expect(@useragent.webkit.version).to eq("534.16")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq('OS X 10.6.5')
+    expect(@useragent.os).to eq("OS X 10.6.5")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 
-  it 'should be greater than Chrome 8.0' do
-    other = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10')
+  it "should be greater than Chrome 8.0" do
+    other = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
     expect(@useragent).to be > other
   end
 
-  it 'should not be less than Chrome 8.0' do
-    other = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10')
+  it "should not be less than Chrome 8.0" do
+    other = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
     expect(@useragent).not_to be < other
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '534.10' as its build" do
-    expect(@useragent.build).to eq('534.10')
+    expect(@useragent.build).to eq("534.10")
   end
 
   it "should return '8.0.552.231' as its version" do
-    expect(@useragent.version).to eq('8.0.552.231')
+    expect(@useragent.version).to eq("8.0.552.231")
   end
 
   it "should return '534.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('534.10')
+    expect(@useragent.webkit.version).to eq("534.10")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq('OS X 10.6.5')
+    expect(@useragent.os).to eq("OS X 10.6.5")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10')
+    @useragent = UserAgent.parse("Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '534.10' as its build" do
-    expect(@useragent.build).to eq('534.10')
+    expect(@useragent.build).to eq("534.10")
   end
 
   it "should return '8.0.552.215' as its version" do
-    expect(@useragent.version).to eq('8.0.552.215')
+    expect(@useragent.version).to eq("8.0.552.215")
   end
 
   it "should return '534.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('534.10')
+    expect(@useragent.webkit.version).to eq("534.10")
   end
 
-  it 'should return nil as its platform' do
+  it "should return nil as its platform" do
     expect(@useragent.platform).to be_nil
   end
 
-  it 'should return nil as its os' do
+  it "should return nil as its os" do
     expect(@useragent.os).to be_nil
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '533.2' as its build" do
-    expect(@useragent.build).to eq('533.2')
+    expect(@useragent.build).to eq("533.2")
   end
 
   it "should return '6.0' as its version" do
-    expect(@useragent.version).to eq('6.0')
+    expect(@useragent.version).to eq("6.0")
   end
 
   it "should return '533.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('533.2')
+    expect(@useragent.webkit.version).to eq("533.2")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '525.13' as its build" do
-    expect(@useragent.build).to eq('525.13')
+    expect(@useragent.build).to eq("525.13")
   end
 
   it "should return '0.0.2' as its version" do
-    expect(@useragent.version).to eq('0.0.2')
+    expect(@useragent.version).to eq("0.0.2")
   end
 
   it "should return '525.13' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('525.13')
+    expect(@useragent.webkit.version).to eq("525.13")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36' do
+describe "UserAgent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36")
   end
 
-  it_should_behave_like 'Chrome browser'
+  it_should_behave_like "Chrome browser"
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq('537.36')
+    expect(@useragent.build).to eq("537.36")
   end
 
   it "should return '29.0.1547.62' as its version" do
-    expect(@useragent.version).to eq('29.0.1547.62')
+    expect(@useragent.version).to eq("29.0.1547.62")
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('537.36')
+    expect(@useragent.webkit.version).to eq("537.36")
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq('X11')
+    expect(@useragent.platform).to eq("X11")
   end
 
   it "should return 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq('Linux x86_64')
+    expect(@useragent.os).to eq("Linux x86_64")
   end
 end

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -1,356 +1,356 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples_for "Chrome browser" do
+shared_examples_for 'Chrome browser' do
   it "should return 'Chrome' as its browser" do
-    expect(@useragent.browser).to eq("Chrome")
+    expect(@useragent.browser).to eq('Chrome')
   end
 end
 
 # http://www.useragentstring.com/Chrome30.0.1599.17_id_19721.php
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '30.0.1599.17' as its version" do
-    expect(@useragent.version).to eq("30.0.1599.17")
+    expect(@useragent.version).to eq('30.0.1599.17')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 8' as its os" do
-    expect(@useragent.os).to eq("Windows 8")
+    expect(@useragent.os).to eq('Windows 8')
   end
 end
 
 # http://www.useragentstring.com/Chrome29.0.1547.62_id_19709.php
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '29.0.1547.62' as its version" do
-    expect(@useragent.version).to eq("29.0.1547.62")
+    expect(@useragent.version).to eq('29.0.1547.62')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '29.0.1547.57' as its version" do
-    expect(@useragent.version).to eq("29.0.1547.57")
+    expect(@useragent.version).to eq('29.0.1547.57')
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
+    expect(@useragent.platform).to eq('X11')
   end
 
   it "should return 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq("Linux x86_64")
+    expect(@useragent.os).to eq('Linux x86_64')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '536.26' as its build" do
-    expect(@useragent.build).to eq("536.26")
+    expect(@useragent.build).to eq('536.26')
   end
 
   it "should return '28.0.1500.16' as its version" do
-    expect(@useragent.version).to eq("28.0.1500.16")
+    expect(@useragent.version).to eq('28.0.1500.16')
   end
 
   it "should return '536.26' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("536.26")
+    expect(@useragent.webkit.version).to eq('536.26')
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
+    expect(@useragent.platform).to eq('iPhone')
   end
 
   it "should return 'iOS 6.1.3' as its os" do
-    expect(@useragent.os).to eq("iOS 6.1.3")
+    expect(@useragent.os).to eq('iOS 6.1.3')
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17" do
+describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.8.2' as its os" do
-    expect(@useragent.os).to eq("OS X 10.8.2")
+    expect(@useragent.os).to eq('OS X 10.8.2')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '535.19' as its build" do
-    expect(@useragent.build).to eq("535.19")
+    expect(@useragent.build).to eq('535.19')
   end
 
   it "should return '18.0.1025.168' as its version" do
-    expect(@useragent.version).to eq("18.0.1025.168")
+    expect(@useragent.version).to eq('18.0.1025.168')
   end
 
   it "should return '535.19' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("535.19")
+    expect(@useragent.webkit.version).to eq('535.19')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 end
 
-describe "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19" do
+describe 'Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19')
   end
 
   it "should return 'Chrome' as its browser" do
-    expect(@useragent.browser).to eq("Chrome")
+    expect(@useragent.browser).to eq('Chrome')
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
+    expect(@useragent.platform).to eq('Android')
   end
 
   it "should return 'Android 4.2' as its os" do
-    expect(@useragent.os).to eq("Android 4.2")
+    expect(@useragent.os).to eq('Android 4.2')
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '534.16' as its build" do
-    expect(@useragent.build).to eq("534.16")
+    expect(@useragent.build).to eq('534.16')
   end
 
   it "should return '10.0.639.0' as its version" do
-    expect(@useragent.version).to eq("10.0.639.0")
+    expect(@useragent.version).to eq('10.0.639.0')
   end
 
   it "should return '534.16' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.16")
+    expect(@useragent.webkit.version).to eq('534.16')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6.5")
+    expect(@useragent.os).to eq('OS X 10.6.5')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 
-  it "should be greater than Chrome 8.0" do
-    other = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
+  it 'should be greater than Chrome 8.0' do
+    other = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10')
     expect(@useragent).to be > other
   end
 
-  it "should not be less than Chrome 8.0" do
-    other = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
+  it 'should not be less than Chrome 8.0' do
+    other = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10')
     expect(@useragent).not_to be < other
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '534.10' as its build" do
-    expect(@useragent.build).to eq("534.10")
+    expect(@useragent.build).to eq('534.10')
   end
 
   it "should return '8.0.552.231' as its version" do
-    expect(@useragent.version).to eq("8.0.552.231")
+    expect(@useragent.version).to eq('8.0.552.231')
   end
 
   it "should return '534.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.10")
+    expect(@useragent.webkit.version).to eq('534.10')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6.5")
+    expect(@useragent.os).to eq('OS X 10.6.5')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10")
+    @useragent = UserAgent.parse('Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '534.10' as its build" do
-    expect(@useragent.build).to eq("534.10")
+    expect(@useragent.build).to eq('534.10')
   end
 
   it "should return '8.0.552.215' as its version" do
-    expect(@useragent.version).to eq("8.0.552.215")
+    expect(@useragent.version).to eq('8.0.552.215')
   end
 
   it "should return '534.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.10")
+    expect(@useragent.webkit.version).to eq('534.10')
   end
 
-  it "should return nil as its platform" do
+  it 'should return nil as its platform' do
     expect(@useragent.platform).to be_nil
   end
 
-  it "should return nil as its os" do
+  it 'should return nil as its os' do
     expect(@useragent.os).to be_nil
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '533.2' as its build" do
-    expect(@useragent.build).to eq("533.2")
+    expect(@useragent.build).to eq('533.2')
   end
 
   it "should return '6.0' as its version" do
-    expect(@useragent.version).to eq("6.0")
+    expect(@useragent.version).to eq('6.0')
   end
 
   it "should return '533.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("533.2")
+    expect(@useragent.webkit.version).to eq('533.2')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '525.13' as its build" do
-    expect(@useragent.build).to eq("525.13")
+    expect(@useragent.build).to eq('525.13')
   end
 
   it "should return '0.0.2' as its version" do
-    expect(@useragent.version).to eq("0.0.2")
+    expect(@useragent.version).to eq('0.0.2')
   end
 
   it "should return '525.13' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("525.13")
+    expect(@useragent.webkit.version).to eq('525.13')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36" do
+describe 'UserAgent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36')
   end
 
-  it_should_behave_like "Chrome browser"
+  it_should_behave_like 'Chrome browser'
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
+    expect(@useragent.build).to eq('537.36')
   end
 
   it "should return '29.0.1547.62' as its version" do
-    expect(@useragent.version).to eq("29.0.1547.62")
+    expect(@useragent.version).to eq('29.0.1547.62')
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
+    expect(@useragent.webkit.version).to eq('537.36')
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
+    expect(@useragent.platform).to eq('X11')
   end
 
   it "should return 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq("Linux x86_64")
+    expect(@useragent.os).to eq('Linux x86_64')
   end
 end

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -3,354 +3,330 @@ require "user_agent"
 
 shared_examples_for "Chrome browser" do
   it "returns 'Chrome' as its browser" do
-    expect(@useragent.browser).to eq("Chrome")
+    expect(useragent.browser).to eq("Chrome")
   end
 end
 
 # http://www.useragentstring.com/Chrome30.0.1599.17_id_19721.php
-describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36")
-  end
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36") }
 
-  it_behaves_like "Chrome browser"
+    it_behaves_like "Chrome browser"
 
-  it "returns '30.0.1599.17' as its version" do
-    expect(@useragent.version).to eq("30.0.1599.17")
-  end
+    it "returns '30.0.1599.17' as its version" do
+      expect(useragent.version).to eq("30.0.1599.17")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'Windows 8' as its os" do
-    expect(@useragent.os).to eq("Windows 8")
-  end
-end
-
-# http://www.useragentstring.com/Chrome29.0.1547.62_id_19709.php
-describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36")
+    it "returns 'Windows 8' as its os" do
+      expect(useragent.os).to eq("Windows 8")
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  # http://www.useragentstring.com/Chrome29.0.1547.62_id_19709.php
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36") }
 
-  it "returns '29.0.1547.62' as its version" do
-    expect(@useragent.version).to eq("29.0.1547.62")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '29.0.1547.62' as its version" do
+      expect(useragent.version).to eq("29.0.1547.62")
+    end
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36")
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36") }
 
-  it "returns '29.0.1547.57' as its version" do
-    expect(@useragent.version).to eq("29.0.1547.57")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
-  end
+    it "returns '29.0.1547.57' as its version" do
+      expect(useragent.version).to eq("29.0.1547.57")
+    end
 
-  it "returns 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq("Linux x86_64")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25")
+    it "returns 'X11' as its platform" do
+      expect(useragent.platform).to eq("X11")
+    end
+
+    it "returns 'Linux x86_64' as its os" do
+      expect(useragent.os).to eq("Linux x86_64")
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25") }
 
-  it "returns '536.26' as its build" do
-    expect(@useragent.build).to eq("536.26")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns '28.0.1500.16' as its version" do
-    expect(@useragent.version).to eq("28.0.1500.16")
-  end
+    it "returns '536.26' as its build" do
+      expect(useragent.build).to eq("536.26")
+    end
 
-  it "returns '536.26' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("536.26")
-  end
+    it "returns '28.0.1500.16' as its version" do
+      expect(useragent.version).to eq("28.0.1500.16")
+    end
 
-  it "returns 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
-  end
+    it "returns '536.26' as its webkit version" do
+      expect(useragent.webkit.version).to eq("536.26")
+    end
 
-  it "returns 'iOS 6.1.3' as its os" do
-    expect(@useragent.os).to eq("iOS 6.1.3")
-  end
+    it "returns 'iPhone' as its platform" do
+      expect(useragent.platform).to eq("iPhone")
+    end
 
-  it { expect(@useragent).to be_mobile }
-end
+    it "returns 'iOS 6.1.3' as its os" do
+      expect(useragent.os).to eq("iOS 6.1.3")
+    end
 
-describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17")
+    it { expect(useragent).to be_mobile }
   end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17") }
 
-  it "returns 'OS X 10.8.2' as its os" do
-    expect(@useragent.os).to eq("OS X 10.8.2")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19")
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
+
+    it "returns 'OS X 10.8.2' as its os" do
+      expect(useragent.os).to eq("OS X 10.8.2")
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19") }
 
-  it "returns '535.19' as its build" do
-    expect(@useragent.build).to eq("535.19")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns '18.0.1025.168' as its version" do
-    expect(@useragent.version).to eq("18.0.1025.168")
-  end
+    it "returns '535.19' as its build" do
+      expect(useragent.build).to eq("535.19")
+    end
 
-  it "returns '535.19' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("535.19")
-  end
+    it "returns '18.0.1025.168' as its version" do
+      expect(useragent.version).to eq("18.0.1025.168")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '535.19' as its webkit version" do
+      expect(useragent.webkit.version).to eq("535.19")
+    end
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
-end
-
-describe "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'Chrome' as its browser" do
-    expect(@useragent.browser).to eq("Chrome")
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
   end
 
-  it "returns 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19") }
 
-  it "returns 'Android 4.2' as its os" do
-    expect(@useragent.os).to eq("Android 4.2")
-  end
+    it "returns 'Chrome' as its browser" do
+      expect(useragent.browser).to eq("Chrome")
+    end
 
-  it { expect(@useragent).to be_mobile }
-end
+    it "returns 'Android' as its platform" do
+      expect(useragent.platform).to eq("Android")
+    end
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16")
+    it "returns 'Android 4.2' as its os" do
+      expect(useragent.os).to eq("Android 4.2")
+    end
+
+    it { expect(useragent).to be_mobile }
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16") }
 
-  it "returns '534.16' as its build" do
-    expect(@useragent.build).to eq("534.16")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns '10.0.639.0' as its version" do
-    expect(@useragent.version).to eq("10.0.639.0")
-  end
+    it "returns '534.16' as its build" do
+      expect(useragent.build).to eq("534.16")
+    end
 
-  it "returns '534.16' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.16")
-  end
+    it "returns '10.0.639.0' as its version" do
+      expect(useragent.version).to eq("10.0.639.0")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns '534.16' as its webkit version" do
+      expect(useragent.webkit.version).to eq("534.16")
+    end
 
-  it "returns 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6.5")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
+    it "returns 'OS X 10.6.5' as its os" do
+      expect(useragent.os).to eq("OS X 10.6.5")
+    end
 
-  it "is greater than Chrome 8.0" do
-    other = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
-    expect(@useragent).to be > other
-  end
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
 
-  it "is not less than Chrome 8.0" do
-    other = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
-    expect(@useragent).not_to be < other
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
+    it "is greater than Chrome 8.0" do
+      other = described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
+      expect(useragent).to be > other
+    end
+
+    it "is not less than Chrome 8.0" do
+      other = described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
+      expect(useragent).not_to be < other
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10") }
 
-  it "returns '534.10' as its build" do
-    expect(@useragent.build).to eq("534.10")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns '8.0.552.231' as its version" do
-    expect(@useragent.version).to eq("8.0.552.231")
-  end
+    it "returns '534.10' as its build" do
+      expect(useragent.build).to eq("534.10")
+    end
 
-  it "returns '534.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.10")
-  end
+    it "returns '8.0.552.231' as its version" do
+      expect(useragent.version).to eq("8.0.552.231")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns '534.10' as its webkit version" do
+      expect(useragent.webkit.version).to eq("534.10")
+    end
 
-  it "returns 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6.5")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10")
+    it "returns 'OS X 10.6.5' as its os" do
+      expect(useragent.os).to eq("OS X 10.6.5")
+    end
+
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10") }
 
-  it "returns '534.10' as its build" do
-    expect(@useragent.build).to eq("534.10")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns '8.0.552.215' as its version" do
-    expect(@useragent.version).to eq("8.0.552.215")
-  end
+    it "returns '534.10' as its build" do
+      expect(useragent.build).to eq("534.10")
+    end
 
-  it "returns '534.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.10")
-  end
+    it "returns '8.0.552.215' as its version" do
+      expect(useragent.version).to eq("8.0.552.215")
+    end
 
-  it "returns nil as its platform" do
-    expect(@useragent.platform).to be_nil
-  end
+    it "returns '534.10' as its webkit version" do
+      expect(useragent.webkit.version).to eq("534.10")
+    end
 
-  it "returns nil as its os" do
-    expect(@useragent.os).to be_nil
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0")
+    it "returns nil as its platform" do
+      expect(useragent.platform).to be_nil
+    end
+
+    it "returns nil as its os" do
+      expect(useragent.os).to be_nil
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0") }
 
-  it "returns '533.2' as its build" do
-    expect(@useragent.build).to eq("533.2")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns '6.0' as its version" do
-    expect(@useragent.version).to eq("6.0")
-  end
+    it "returns '533.2' as its build" do
+      expect(useragent.build).to eq("533.2")
+    end
 
-  it "returns '533.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("533.2")
-  end
+    it "returns '6.0' as its version" do
+      expect(useragent.version).to eq("6.0")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '533.2' as its webkit version" do
+      expect(useragent.webkit.version).to eq("533.2")
+    end
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13")
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13") }
 
-  it "returns '525.13' as its build" do
-    expect(@useragent.build).to eq("525.13")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns '0.0.2' as its version" do
-    expect(@useragent.version).to eq("0.0.2")
-  end
+    it "returns '525.13' as its build" do
+      expect(useragent.build).to eq("525.13")
+    end
 
-  it "returns '525.13' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("525.13")
-  end
+    it "returns '0.0.2' as its version" do
+      expect(useragent.version).to eq("0.0.2")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '525.13' as its webkit version" do
+      expect(useragent.webkit.version).to eq("525.13")
+    end
 
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36")
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
+
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it_behaves_like "Chrome browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36") }
 
-  it "returns '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
-  end
+    it_behaves_like "Chrome browser"
 
-  it "returns '29.0.1547.62' as its version" do
-    expect(@useragent.version).to eq("29.0.1547.62")
-  end
+    it "returns '537.36' as its build" do
+      expect(useragent.build).to eq("537.36")
+    end
 
-  it "returns '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
-  end
+    it "returns '29.0.1547.62' as its version" do
+      expect(useragent.version).to eq("29.0.1547.62")
+    end
 
-  it "returns 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
-  end
+    it "returns '537.36' as its webkit version" do
+      expect(useragent.webkit.version).to eq("537.36")
+    end
+
+    it "returns 'X11' as its platform" do
+      expect(useragent.platform).to eq("X11")
+    end
 
-  it "returns 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq("Linux x86_64")
+    it "returns 'Linux x86_64' as its os" do
+      expect(useragent.os).to eq("Linux x86_64")
+    end
   end
 end

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples_for "Chrome browser" do
-  it "should return 'Chrome' as its browser" do
+  it "returns 'Chrome' as its browser" do
     expect(@useragent.browser).to eq("Chrome")
   end
 end
@@ -13,17 +13,17 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KH
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.17 Safari/537.36")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '30.0.1599.17' as its version" do
+  it "returns '30.0.1599.17' as its version" do
     expect(@useragent.version).to eq("30.0.1599.17")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 8' as its os" do
+  it "returns 'Windows 8' as its os" do
     expect(@useragent.os).to eq("Windows 8")
   end
 end
@@ -34,17 +34,17 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KH
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '29.0.1547.62' as its version" do
+  it "returns '29.0.1547.62' as its version" do
     expect(@useragent.version).to eq("29.0.1547.62")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 end
@@ -54,17 +54,17 @@ describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML,
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '29.0.1547.57' as its version" do
+  it "returns '29.0.1547.57' as its version" do
     expect(@useragent.version).to eq("29.0.1547.57")
   end
 
-  it "should return 'X11' as its platform" do
+  it "returns 'X11' as its platform" do
     expect(@useragent.platform).to eq("X11")
   end
 
-  it "should return 'Linux x86_64' as its os" do
+  it "returns 'Linux x86_64' as its os" do
     expect(@useragent.os).to eq("Linux x86_64")
   end
 end
@@ -74,25 +74,25 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) Ap
     @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '536.26' as its build" do
+  it "returns '536.26' as its build" do
     expect(@useragent.build).to eq("536.26")
   end
 
-  it "should return '28.0.1500.16' as its version" do
+  it "returns '28.0.1500.16' as its version" do
     expect(@useragent.version).to eq("28.0.1500.16")
   end
 
-  it "should return '536.26' as its webkit version" do
+  it "returns '536.26' as its webkit version" do
     expect(@useragent.webkit.version).to eq("536.26")
   end
 
-  it "should return 'iPhone' as its platform" do
+  it "returns 'iPhone' as its platform" do
     expect(@useragent.platform).to eq("iPhone")
   end
 
-  it "should return 'iOS 6.1.3' as its os" do
+  it "returns 'iOS 6.1.3' as its os" do
     expect(@useragent.os).to eq("iOS 6.1.3")
   end
 
@@ -104,11 +104,11 @@ describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHT
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.40 Safari/537.17")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.8.2' as its os" do
+  it "returns 'OS X 10.8.2' as its os" do
     expect(@useragent.os).to eq("OS X 10.8.2")
   end
 end
@@ -118,25 +118,25 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KH
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '535.19' as its build" do
+  it "returns '535.19' as its build" do
     expect(@useragent.build).to eq("535.19")
   end
 
-  it "should return '18.0.1025.168' as its version" do
+  it "returns '18.0.1025.168' as its version" do
     expect(@useragent.version).to eq("18.0.1025.168")
   end
 
-  it "should return '535.19' as its webkit version" do
+  it "returns '535.19' as its webkit version" do
     expect(@useragent.webkit.version).to eq("535.19")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 end
@@ -146,15 +146,15 @@ describe "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535
     @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19")
   end
 
-  it "should return 'Chrome' as its browser" do
+  it "returns 'Chrome' as its browser" do
     expect(@useragent.browser).to eq("Chrome")
   end
 
-  it "should return 'Android' as its platform" do
+  it "returns 'Android' as its platform" do
     expect(@useragent.platform).to eq("Android")
   end
 
-  it "should return 'Android 4.2' as its os" do
+  it "returns 'Android 4.2' as its os" do
     expect(@useragent.os).to eq("Android 4.2")
   end
 
@@ -166,38 +166,38 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) A
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.639.0 Safari/534.16")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '534.16' as its build" do
+  it "returns '534.16' as its build" do
     expect(@useragent.build).to eq("534.16")
   end
 
-  it "should return '10.0.639.0' as its version" do
+  it "returns '10.0.639.0' as its version" do
     expect(@useragent.version).to eq("10.0.639.0")
   end
 
-  it "should return '534.16' as its webkit version" do
+  it "returns '534.16' as its webkit version" do
     expect(@useragent.webkit.version).to eq("534.16")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.6.5' as its os" do
+  it "returns 'OS X 10.6.5' as its os" do
     expect(@useragent.os).to eq("OS X 10.6.5")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 
-  it "should be greater than Chrome 8.0" do
+  it "is greater than Chrome 8.0" do
     other = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
     expect(@useragent).to be > other
   end
 
-  it "should not be less than Chrome 8.0" do
+  it "is not less than Chrome 8.0" do
     other = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
     expect(@useragent).not_to be < other
   end
@@ -208,29 +208,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) A
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-US) AppleWebKit/534.10 (KHTML, like Gecko) Chrome/8.0.552.231 Safari/534.10")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '534.10' as its build" do
+  it "returns '534.10' as its build" do
     expect(@useragent.build).to eq("534.10")
   end
 
-  it "should return '8.0.552.231' as its version" do
+  it "returns '8.0.552.231' as its version" do
     expect(@useragent.version).to eq("8.0.552.231")
   end
 
-  it "should return '534.10' as its webkit version" do
+  it "returns '534.10' as its webkit version" do
     expect(@useragent.webkit.version).to eq("534.10")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.6.5' as its os" do
+  it "returns 'OS X 10.6.5' as its os" do
     expect(@useragent.os).to eq("OS X 10.6.5")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -240,25 +240,25 @@ describe "UserAgent: 'Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/5
     @useragent = UserAgent.parse("Mozilla/5.0 AppleWebKit/534.10 Chrome/8.0.552.215 Safari/534.10")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '534.10' as its build" do
+  it "returns '534.10' as its build" do
     expect(@useragent.build).to eq("534.10")
   end
 
-  it "should return '8.0.552.215' as its version" do
+  it "returns '8.0.552.215' as its version" do
     expect(@useragent.version).to eq("8.0.552.215")
   end
 
-  it "should return '534.10' as its webkit version" do
+  it "returns '534.10' as its webkit version" do
     expect(@useragent.webkit.version).to eq("534.10")
   end
 
-  it "should return nil as its platform" do
+  it "returns nil as its platform" do
     expect(@useragent.platform).to be_nil
   end
 
-  it "should return nil as its os" do
+  it "returns nil as its os" do
     expect(@useragent.os).to be_nil
   end
 end
@@ -268,29 +268,29 @@ describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKi
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/6.0")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '533.2' as its build" do
+  it "returns '533.2' as its build" do
     expect(@useragent.build).to eq("533.2")
   end
 
-  it "should return '6.0' as its version" do
+  it "returns '6.0' as its version" do
     expect(@useragent.version).to eq("6.0")
   end
 
-  it "should return '533.2' as its webkit version" do
+  it "returns '533.2' as its webkit version" do
     expect(@useragent.webkit.version).to eq("533.2")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -300,29 +300,29 @@ describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKi
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.0.2 Safari/525.13")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '525.13' as its build" do
+  it "returns '525.13' as its build" do
     expect(@useragent.build).to eq("525.13")
   end
 
-  it "should return '0.0.2' as its version" do
+  it "returns '0.0.2' as its version" do
     expect(@useragent.version).to eq("0.0.2")
   end
 
-  it "should return '525.13' as its webkit version" do
+  it "returns '525.13' as its webkit version" do
     expect(@useragent.webkit.version).to eq("525.13")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -332,25 +332,25 @@ describe "UserAgent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, 
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.62 Safari/537.36")
   end
 
-  it_should_behave_like "Chrome browser"
+  it_behaves_like "Chrome browser"
 
-  it "should return '537.36' as its build" do
+  it "returns '537.36' as its build" do
     expect(@useragent.build).to eq("537.36")
   end
 
-  it "should return '29.0.1547.62' as its version" do
+  it "returns '29.0.1547.62' as its version" do
     expect(@useragent.version).to eq("29.0.1547.62")
   end
 
-  it "should return '537.36' as its webkit version" do
+  it "returns '537.36' as its webkit version" do
     expect(@useragent.webkit.version).to eq("537.36")
   end
 
-  it "should return 'X11' as its platform" do
+  it "returns 'X11' as its platform" do
     expect(@useragent.platform).to eq("X11")
   end
 
-  it "should return 'Linux x86_64' as its os" do
+  it "returns 'Linux x86_64' as its os" do
     expect(@useragent.os).to eq("Linux x86_64")
   end
 end

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -1,44 +1,44 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples_for 'Edge browser' do
+shared_examples_for "Edge browser" do
   it "should return 'Edge' as its browser" do
-    expect(@useragent.browser).to eq('Edge')
+    expect(@useragent.browser).to eq("Edge")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 end
 
-describe 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240' do
+describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240")
   end
 
-  it_should_behave_like 'Edge browser'
+  it_should_behave_like "Edge browser"
 
   it "should return '12.10240' as its version" do
-    expect(@useragent.version).to eq('12.10240')
+    expect(@useragent.version).to eq("12.10240")
   end
 
   it "should return 'Windows 10' as its os" do
-    expect(@useragent.os).to eq('Windows 10')
+    expect(@useragent.os).to eq("Windows 10")
   end
 end
 
-describe 'Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586' do
+describe "Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586')
+    @useragent = UserAgent.parse("Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586")
   end
 
-  it_should_behave_like 'Edge browser'
+  it_should_behave_like "Edge browser"
 
   it "should return '13.10586' as its version" do
-    expect(@useragent.version).to eq('13.10586')
+    expect(@useragent.version).to eq("13.10586")
   end
 
   it "should return 'Windows 10' as its os" do
-    expect(@useragent.os).to eq('Windows 10')
+    expect(@useragent.os).to eq("Windows 10")
   end
 end

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples_for "Edge browser" do
-  it "should return 'Edge' as its browser" do
+  it "returns 'Edge' as its browser" do
     expect(@useragent.browser).to eq("Edge")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 end
@@ -16,13 +16,13 @@ describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, l
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240")
   end
 
-  it_should_behave_like "Edge browser"
+  it_behaves_like "Edge browser"
 
-  it "should return '12.10240' as its version" do
+  it "returns '12.10240' as its version" do
     expect(@useragent.version).to eq("12.10240")
   end
 
-  it "should return 'Windows 10' as its os" do
+  it "returns 'Windows 10' as its os" do
     expect(@useragent.os).to eq("Windows 10")
   end
 end
@@ -32,13 +32,13 @@ describe "Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Win
     @useragent = UserAgent.parse("Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586")
   end
 
-  it_should_behave_like "Edge browser"
+  it_behaves_like "Edge browser"
 
-  it "should return '13.10586' as its version" do
+  it "returns '13.10586' as its version" do
     expect(@useragent.version).to eq("13.10586")
   end
 
-  it "should return 'Windows 10' as its os" do
+  it "returns 'Windows 10' as its os" do
     expect(@useragent.os).to eq("Windows 10")
   end
 end

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -1,43 +1,44 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples_for "Edge browser" do
+shared_examples_for 'Edge browser' do
   it "should return 'Edge' as its browser" do
-    expect(@useragent.browser).to eq("Edge")
+    expect(@useragent.browser).to eq('Edge')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 end
 
-describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240" do
+describe 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240')
   end
 
-  it_should_behave_like "Edge browser"
+  it_should_behave_like 'Edge browser'
 
   it "should return '12.10240' as its version" do
-    expect(@useragent.version).to eq("12.10240")
+    expect(@useragent.version).to eq('12.10240')
   end
 
   it "should return 'Windows 10' as its os" do
-    expect(@useragent.os).to eq("Windows 10")
+    expect(@useragent.os).to eq('Windows 10')
   end
 end
 
-describe "Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586" do
+describe 'Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586")
+    @useragent = UserAgent.parse('Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586')
   end
 
-  it_should_behave_like "Edge browser"
+  it_should_behave_like 'Edge browser'
 
   it "should return '13.10586' as its version" do
-    expect(@useragent.version).to eq("13.10586")
+    expect(@useragent.version).to eq('13.10586')
   end
 
   it "should return 'Windows 10' as its os" do
-    expect(@useragent.os).to eq("Windows 10")
+    expect(@useragent.os).to eq('Windows 10')
   end
 end

--- a/spec/browsers/edge_user_agent_spec.rb
+++ b/spec/browsers/edge_user_agent_spec.rb
@@ -3,42 +3,40 @@ require "user_agent"
 
 shared_examples_for "Edge browser" do
   it "returns 'Edge' as its browser" do
-    expect(@useragent.browser).to eq("Edge")
+    expect(useragent.browser).to eq("Edge")
   end
 
   it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(useragent.platform).to eq("Windows")
   end
 end
 
-describe "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240")
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240") }
+
+    it_behaves_like "Edge browser"
+
+    it "returns '12.10240' as its version" do
+      expect(useragent.version).to eq("12.10240")
+    end
+
+    it "returns 'Windows 10' as its os" do
+      expect(useragent.os).to eq("Windows 10")
+    end
   end
 
-  it_behaves_like "Edge browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586") }
 
-  it "returns '12.10240' as its version" do
-    expect(@useragent.version).to eq("12.10240")
-  end
+    it_behaves_like "Edge browser"
 
-  it "returns 'Windows 10' as its os" do
-    expect(@useragent.os).to eq("Windows 10")
-  end
-end
+    it "returns '13.10586' as its version" do
+      expect(useragent.version).to eq("13.10586")
+    end
 
-describe "Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 SHC; SHC-Unit-04973; SHC-HTS; SHC-KIOSK; SHC-MAC-0000 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586")
-  end
-
-  it_behaves_like "Edge browser"
-
-  it "returns '13.10586' as its version" do
-    expect(@useragent.version).to eq("13.10586")
-  end
-
-  it "returns 'Windows 10' as its os" do
-    expect(@useragent.os).to eq("Windows 10")
+    it "returns 'Windows 10' as its os" do
+      expect(useragent.os).to eq("Windows 10")
+    end
   end
 end

--- a/spec/browsers/gecko_user_agent_spec.rb
+++ b/spec/browsers/gecko_user_agent_spec.rb
@@ -3,586 +3,546 @@ require "user_agent"
 
 shared_examples_for "Firefox browser" do
   it "returns 'Firefox' as its browser" do
-    expect(@useragent.browser).to eq("Firefox")
+    expect(useragent.browser).to eq("Firefox")
   end
 
   it "returns :strong as its security" do
-    expect(@useragent.security).to eq(:strong)
+    expect(useragent.security).to eq(:strong)
   end
 end
 
-describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8")
-  end
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8") }
 
-  it_behaves_like "Firefox browser"
+    it_behaves_like "Firefox browser"
 
-  it "returns '4.0b8' as its version" do
-    expect(@useragent.version).to eq("4.0b8")
-  end
+    it "returns '4.0b8' as its version" do
+      expect(useragent.version).to eq("4.0b8")
+    end
 
-  it "returns '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20100101")
-  end
+    it "returns '20100101' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20100101")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6")
-  end
+    it "returns 'OS X 10.6' as its os" do
+      expect(useragent.os).to eq("OS X 10.6")
+    end
 
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
+
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13") }
 
-describe "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13")
-  end
+    it_behaves_like "Firefox browser"
 
-  it_behaves_like "Firefox browser"
+    it "returns '3.6.13' as its version" do
+      expect(useragent.version).to eq("3.6.13")
+    end
 
-  it "returns '3.6.13' as its version" do
-    expect(@useragent.version).to eq("3.6.13")
-  end
+    it "returns '20101203' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20101203")
+    end
 
-  it "returns '20101203' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20101203")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X 10.6' as its os" do
+      expect(useragent.os).to eq("OS X 10.6")
+    end
 
-  it "returns 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6")
-  end
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1") }
 
-describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1")
-  end
+    it_behaves_like "Firefox browser"
 
-  it_behaves_like "Firefox browser"
+    it "returns '3.0.1' as its version" do
+      expect(useragent.version).to eq("3.0.1")
+    end
 
-  it "returns '3.0.1' as its version" do
-    expect(@useragent.version).to eq("3.0.1")
-  end
+    it "returns '2008070206' as its gecko version" do
+      expect(useragent.gecko.version).to eq("2008070206")
+    end
 
-  it "returns '2008070206' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("2008070206")
-  end
+    it "returns 'X11' as its platform" do
+      expect(useragent.platform).to eq("X11")
+    end
 
-  it "returns 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
-  end
+    it "returns 'Linux i686' as its os" do
+      expect(useragent.os).to eq("Linux i686")
+    end
 
-  it "returns 'Linux i686' as its os" do
-    expect(@useragent.os).to eq("Linux i686")
-  end
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0") }
 
-describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0")
-  end
+    it_behaves_like "Firefox browser"
 
-  it_behaves_like "Firefox browser"
+    it "returns '27.0' as its version" do
+      expect(useragent.version).to eq("27.0")
+    end
 
-  it "returns '27.0' as its version" do
-    expect(@useragent.version).to eq("27.0")
-  end
+    it "returns '20100101' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20100101")
+    end
 
-  it "returns '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20100101")
-  end
+    it "returns 'X11' as its platform" do
+      expect(useragent.platform).to eq("X11")
+    end
 
-  it "returns 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
-  end
+    it "returns 'Linux x86_64' as its os" do
+      expect(useragent.os).to eq("Linux x86_64")
+    end
 
-  it "returns 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq("Linux x86_64")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
-  end
+    it_behaves_like "Firefox browser"
 
-  it_behaves_like "Firefox browser"
+    it "returns '2.0.0.14' as its version" do
+      expect(useragent.version).to eq("2.0.0.14")
+    end
 
-  it "returns '2.0.0.14' as its version" do
-    expect(@useragent.version).to eq("2.0.0.14")
-  end
+    it "returns '20080404' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20080404")
+    end
 
-  it "returns '20080404' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20080404")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14") }
 
-  it_behaves_like "Firefox browser"
+    it_behaves_like "Firefox browser"
 
-  it "returns '2.0.0.14' as its version" do
-    expect(@useragent.version).to eq("2.0.0.14")
-  end
+    it "returns '2.0.0.14' as its version" do
+      expect(useragent.version).to eq("2.0.0.14")
+    end
 
-  it "returns '20080404' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20080404")
-  end
+    it "returns '20080404' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20080404")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
-  end
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1")
-  end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1") }
 
-  it "returns '16.0.1' as its version" do
-    expect(@useragent.version).to eq("16.0.1")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20121011' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20121011")
-  end
+    it "returns '16.0.1' as its version" do
+      expect(useragent.version).to eq("16.0.1")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '20121011' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20121011")
+    end
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1")
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
   end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1") }
 
-  it "returns '16.0.1' as its version" do
-    expect(@useragent.version).to eq("16.0.1")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20121011' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20121011")
-  end
+    it "returns '16.0.1' as its version" do
+      expect(useragent.version).to eq("16.0.1")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '20121011' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20121011")
+    end
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
-  end
-end
-
-describe "Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0")
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
   end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0") }
 
-  it "returns '17.0' as its version" do
-    expect(@useragent.version).to eq("17.0")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20100101")
-  end
+    it "returns '17.0' as its version" do
+      expect(useragent.version).to eq("17.0")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '20100101' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20100101")
+    end
 
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0")
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
+
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
   end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0") }
 
-  it "returns '17.0' as its version" do
-    expect(@useragent.version).to eq("17.0")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20100101")
-  end
+    it "returns '17.0' as its version" do
+      expect(useragent.version).to eq("17.0")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '20100101' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20100101")
+    end
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12")
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
   end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12") }
 
-  it "returns '1.5.0.12' as its version" do
-    expect(@useragent.version).to eq("1.5.0.12")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20070508' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20070508")
-  end
+    it "returns '1.5.0.12' as its version" do
+      expect(useragent.version).to eq("1.5.0.12")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns '20070508' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20070508")
+    end
 
-  it "returns 'PPC Mac OS X Mach-O' as its os" do
-    expect(@useragent.os).to eq("OS X")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12")
+    it "returns 'PPC Mac OS X Mach-O' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
+
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12") }
 
-  it "returns '1.5.0.12' as its version" do
-    expect(@useragent.version).to eq("1.5.0.12")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20070508' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20070508")
-  end
+    it "returns '1.5.0.12' as its version" do
+      expect(useragent.version).to eq("1.5.0.12")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '20070508' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20070508")
+    end
 
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1")
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
+
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1") }
 
-  it "returns '1.5.0.4' as its version" do
-    expect(@useragent.version).to eq("1.5.0.4")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20060612' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20060612")
-  end
+    it "returns '1.5.0.4' as its version" do
+      expect(useragent.version).to eq("1.5.0.4")
+    end
 
-  it "returns 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
-  end
+    it "returns '20060612' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20060612")
+    end
 
-  it "returns 'Linux i686' as its os" do
-    expect(@useragent.os).to eq("Linux i686")
-  end
+    it "returns 'X11' as its platform" do
+      expect(useragent.platform).to eq("X11")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)")
-  end
+    it "returns 'Linux i686' as its os" do
+      expect(useragent.os).to eq("Linux i686")
+    end
 
-  it "returns 'Camino' as its browser" do
-    expect(@useragent.browser).to eq("Camino")
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it "returns '1.6' as its version" do
-    expect(@useragent.version).to eq("1.6")
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)") }
 
-  it "returns '20080409' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20080409")
-  end
+    it "returns 'Camino' as its browser" do
+      expect(useragent.browser).to eq("Camino")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns '1.6' as its version" do
+      expect(useragent.version).to eq("1.6")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
-  end
+    it "returns '20080409' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20080409")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Iceweasel' as its browser" do
-    expect(@useragent.browser).to eq("Iceweasel")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns '2.0' as its version" do
-    expect(@useragent.version).to eq("2.0")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns '20061024' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20061024")
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)") }
 
-  it "returns 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
-  end
+    it "returns 'Iceweasel' as its browser" do
+      expect(useragent.browser).to eq("Iceweasel")
+    end
 
-  it "returns 'Linux i686' as its os" do
-    expect(@useragent.os).to eq("Linux i686")
-  end
+    it "returns '2.0' as its version" do
+      expect(useragent.version).to eq("2.0")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.4) Gecko/20091017 SeaMonkey/2.0" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.4) Gecko/20091017 SeaMonkey/2.0")
-  end
+    it "returns '20061024' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20061024")
+    end
 
-  it "returns 'Seamonkey' as its browser" do
-    expect(@useragent.browser).to eq("Seamonkey")
-  end
+    it "returns 'X11' as its platform" do
+      expect(useragent.platform).to eq("X11")
+    end
 
-  it "returns '2.0' as its version" do
-    expect(@useragent.version).to eq("2.0")
-  end
+    it "returns 'Linux i686' as its os" do
+      expect(useragent.os).to eq("Linux i686")
+    end
 
-  it "returns '20091017' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20091017")
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.4) Gecko/20091017 SeaMonkey/2.0") }
 
-  it "returns 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6")
-  end
+    it "returns 'Seamonkey' as its browser" do
+      expect(useragent.browser).to eq("Seamonkey")
+    end
 
-  it "returns 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
-  end
-end
-
-describe "Mozilla/5.0 (Android; Mobile; rv:19.0) Gecko/19.0 Firefox/19.0" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Android; Mobile; rv:19.0) Gecko/19.0 Firefox/19.0")
-  end
+    it "returns '2.0' as its version" do
+      expect(useragent.version).to eq("2.0")
+    end
 
-  it_behaves_like "Firefox browser"
+    it "returns '20091017' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20091017")
+    end
 
-  it "returns true for mobile?" do
-    expect(@useragent.mobile?).to be true
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Android' as the platform" do
-    expect(@useragent.platform).to eq("Android")
-  end
+    it "returns 'OS X 10.6' as its os" do
+      expect(useragent.os).to eq("OS X 10.6")
+    end
 
-  it "returns 'Android' as the operating system" do
-    expect(@useragent.os).to eq("Android")
-  end
-end
-
-describe "Mozilla/5.0 (Mobile; rv:41.0) Gecko/41.0 Firefox/41.0" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Mobile; rv:41.0) Gecko/41.0 Firefox/41.0")
+    it "returns 'en-US' as its localization" do
+      expect(useragent.localization).to eq("en-US")
+    end
   end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Android; Mobile; rv:19.0) Gecko/19.0 Firefox/19.0") }
 
-  it "returns true for mobile?" do
-    expect(@useragent.mobile?).to be true
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns nil as the platform" do
-    expect(@useragent.platform).to be_nil
-  end
+    it "returns true for mobile?" do
+      expect(useragent.mobile?).to be true
+    end
 
-  it "returns nil as the operating system" do
-    expect(@useragent.os).to be_nil
-  end
-end
-
-describe "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x")
+    it "returns 'Android' as the platform" do
+      expect(useragent.platform).to eq("Android")
+    end
+
+    it "returns 'Android' as the operating system" do
+      expect(useragent.os).to eq("Android")
+    end
   end
 
-  it_behaves_like "Firefox browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Mobile; rv:41.0) Gecko/41.0 Firefox/41.0") }
 
-  it "returns 'x.x' as its version" do
-    expect(@useragent.version).to eq("x.x")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20041107' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20041107")
-  end
+    it "returns true for mobile?" do
+      expect(useragent.mobile?).to be true
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns nil as the platform" do
+      expect(useragent.platform).to be_nil
+    end
 
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
-  end
-end
-
-shared_examples_for "PaleMoon browser" do
-  it "returns 'PaleMoon' as its browser" do
-    expect(@useragent.browser).to eq("PaleMoon")
+    it "returns nil as the operating system" do
+      expect(useragent.os).to be_nil
+    end
   end
-end
-
-describe "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1")
-  end
 
-  it_behaves_like "PaleMoon browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x") }
 
-  it "returns '24.7.1' as its version" do
-    expect(@useragent.version).to eq("24.7.1")
-  end
+    it_behaves_like "Firefox browser"
 
-  it "returns '20140802' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20140802")
-  end
+    it "returns 'x.x' as its version" do
+      expect(useragent.version).to eq("x.x")
+    end
 
-  it "returns '24.7' as its firefox version" do
-    expect(@useragent.firefox.version).to eq("24.7")
-  end
+    it "returns '20041107' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20041107")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
   end
-end
-
-describe "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0")
+
+  shared_examples_for "PaleMoon browser" do
+    it "returns 'PaleMoon' as its browser" do
+      expect(useragent.browser).to eq("PaleMoon")
+    end
   end
 
-  it_behaves_like "PaleMoon browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1") }
 
-  it "returns '25.0.0' as its version" do
-    expect(@useragent.version).to eq("25.0.0")
-  end
+    it_behaves_like "PaleMoon browser"
 
-  it "returns '20141001' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20141001")
+    it "returns '24.7.1' as its version" do
+      expect(useragent.version).to eq("24.7.1")
+    end
+
+    it "returns '20140802' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20140802")
+    end
+
+    it "returns '24.7' as its firefox version" do
+      expect(useragent.firefox.version).to eq("24.7")
+    end
+
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
   end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0") }
+
+    it_behaves_like "PaleMoon browser"
+
+    it "returns '25.0.0' as its version" do
+      expect(useragent.version).to eq("25.0.0")
+    end
+
+    it "returns '20141001' as its gecko version" do
+      expect(useragent.gecko.version).to eq("20141001")
+    end
 
-  it "returns '24.7' as its firefox version" do
-    expect { @useragent.firefox }.to raise_error(NoMethodError)
+    it "returns '24.7' as its firefox version" do
+      expect { useragent.firefox }.to raise_error(NoMethodError)
+    end
   end
 end

--- a/spec/browsers/gecko_user_agent_spec.rb
+++ b/spec/browsers/gecko_user_agent_spec.rb
@@ -1,71 +1,71 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples_for 'Firefox browser' do
+shared_examples_for "Firefox browser" do
   it "should return 'Firefox' as its browser" do
-    expect(@useragent.browser).to eq('Firefox')
+    expect(@useragent.browser).to eq("Firefox")
   end
 
-  it 'should return :strong as its security' do
+  it "should return :strong as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 end
 
-describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8' do
+describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '4.0b8' as its version" do
-    expect(@useragent.version).to eq('4.0b8')
+    expect(@useragent.version).to eq("4.0b8")
   end
 
   it "should return '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20100101')
+    expect(@useragent.gecko.version).to eq("20100101")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq('OS X 10.6')
+    expect(@useragent.os).to eq("OS X 10.6")
   end
 
-  it 'should return nil as its localization' do
+  it "should return nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13' do
+describe "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '3.6.13' as its version" do
-    expect(@useragent.version).to eq('3.6.13')
+    expect(@useragent.version).to eq("3.6.13")
   end
 
   it "should return '20101203' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20101203')
+    expect(@useragent.gecko.version).to eq("20101203")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq('OS X 10.6')
+    expect(@useragent.os).to eq("OS X 10.6")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -73,29 +73,29 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '3.0.1' as its version" do
-    expect(@useragent.version).to eq('3.0.1')
+    expect(@useragent.version).to eq("3.0.1")
   end
 
   it "should return '2008070206' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('2008070206')
+    expect(@useragent.gecko.version).to eq("2008070206")
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq('X11')
+    expect(@useragent.platform).to eq("X11")
   end
 
   it "should return 'Linux i686' as its os" do
-    expect(@useragent.os).to eq('Linux i686')
+    expect(@useragent.os).to eq("Linux i686")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -103,25 +103,25 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '27.0' as its version" do
-    expect(@useragent.version).to eq('27.0')
+    expect(@useragent.version).to eq("27.0")
   end
 
   it "should return '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20100101')
+    expect(@useragent.gecko.version).to eq("20100101")
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq('X11')
+    expect(@useragent.platform).to eq("X11")
   end
 
   it "should return 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq('Linux x86_64')
+    expect(@useragent.os).to eq("Linux x86_64")
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -129,457 +129,457 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '2.0.0.14' as its version" do
-    expect(@useragent.version).to eq('2.0.0.14')
+    expect(@useragent.version).to eq("2.0.0.14")
   end
 
   it "should return '20080404' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20080404')
+    expect(@useragent.gecko.version).to eq("20080404")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '2.0.0.14' as its version" do
-    expect(@useragent.version).to eq('2.0.0.14')
+    expect(@useragent.version).to eq("2.0.0.14")
   end
 
   it "should return '20080404' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20080404')
+    expect(@useragent.gecko.version).to eq("20080404")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '16.0.1' as its version" do
-    expect(@useragent.version).to eq('16.0.1')
+    expect(@useragent.version).to eq("16.0.1")
   end
 
   it "should return '20121011' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20121011')
+    expect(@useragent.gecko.version).to eq("20121011")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 
-  it 'should return nil as its localization' do
+  it "should return nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '16.0.1' as its version" do
-    expect(@useragent.version).to eq('16.0.1')
+    expect(@useragent.version).to eq("16.0.1")
   end
 
   it "should return '20121011' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20121011')
+    expect(@useragent.gecko.version).to eq("20121011")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 
-  it 'should return nil as its localization' do
+  it "should return nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
 
-describe 'Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0' do
+describe "Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '17.0' as its version" do
-    expect(@useragent.version).to eq('17.0')
+    expect(@useragent.version).to eq("17.0")
   end
 
   it "should return '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20100101')
+    expect(@useragent.gecko.version).to eq("20100101")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 
-  it 'should return nil as its localization' do
+  it "should return nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0' do
+describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '17.0' as its version" do
-    expect(@useragent.version).to eq('17.0')
+    expect(@useragent.version).to eq("17.0")
   end
 
   it "should return '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20100101')
+    expect(@useragent.gecko.version).to eq("20100101")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 
-  it 'should return nil as its localization' do
+  it "should return nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '1.5.0.12' as its version" do
-    expect(@useragent.version).to eq('1.5.0.12')
+    expect(@useragent.version).to eq("1.5.0.12")
   end
 
   it "should return '20070508' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20070508')
+    expect(@useragent.gecko.version).to eq("20070508")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'PPC Mac OS X Mach-O' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '1.5.0.12' as its version" do
-    expect(@useragent.version).to eq('1.5.0.12')
+    expect(@useragent.version).to eq("1.5.0.12")
   end
 
   it "should return '20070508' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20070508')
+    expect(@useragent.gecko.version).to eq("20070508")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return '1.5.0.4' as its version" do
-    expect(@useragent.version).to eq('1.5.0.4')
+    expect(@useragent.version).to eq("1.5.0.4")
   end
 
   it "should return '20060612' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20060612')
+    expect(@useragent.gecko.version).to eq("20060612")
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq('X11')
+    expect(@useragent.platform).to eq("X11")
   end
 
   it "should return 'Linux i686' as its os" do
-    expect(@useragent.os).to eq('Linux i686')
+    expect(@useragent.os).to eq("Linux i686")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)")
   end
 
   it "should return 'Camino' as its browser" do
-    expect(@useragent.browser).to eq('Camino')
+    expect(@useragent.browser).to eq("Camino")
   end
 
   it "should return '1.6' as its version" do
-    expect(@useragent.version).to eq('1.6')
+    expect(@useragent.version).to eq("1.6")
   end
 
   it "should return '20080409' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20080409')
+    expect(@useragent.gecko.version).to eq("20080409")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)' do
+describe "UserAgent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)")
   end
 
   it "should return 'Iceweasel' as its browser" do
-    expect(@useragent.browser).to eq('Iceweasel')
+    expect(@useragent.browser).to eq("Iceweasel")
   end
 
   it "should return '2.0' as its version" do
-    expect(@useragent.version).to eq('2.0')
+    expect(@useragent.version).to eq("2.0")
   end
 
   it "should return '20061024' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20061024')
+    expect(@useragent.gecko.version).to eq("20061024")
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq('X11')
+    expect(@useragent.platform).to eq("X11")
   end
 
   it "should return 'Linux i686' as its os" do
-    expect(@useragent.os).to eq('Linux i686')
+    expect(@useragent.os).to eq("Linux i686")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.4) Gecko/20091017 SeaMonkey/2.0' do
+describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.4) Gecko/20091017 SeaMonkey/2.0" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.4) Gecko/20091017 SeaMonkey/2.0')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.4) Gecko/20091017 SeaMonkey/2.0")
   end
 
   it "should return 'Seamonkey' as its browser" do
-    expect(@useragent.browser).to eq('Seamonkey')
+    expect(@useragent.browser).to eq("Seamonkey")
   end
 
   it "should return '2.0' as its version" do
-    expect(@useragent.version).to eq('2.0')
+    expect(@useragent.version).to eq("2.0")
   end
 
   it "should return '20091017' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20091017')
+    expect(@useragent.gecko.version).to eq("20091017")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq('OS X 10.6')
+    expect(@useragent.os).to eq("OS X 10.6")
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq('en-US')
+    expect(@useragent.localization).to eq("en-US")
   end
 end
 
-describe 'Mozilla/5.0 (Android; Mobile; rv:19.0) Gecko/19.0 Firefox/19.0' do
+describe "Mozilla/5.0 (Android; Mobile; rv:19.0) Gecko/19.0 Firefox/19.0" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Android; Mobile; rv:19.0) Gecko/19.0 Firefox/19.0')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Android; Mobile; rv:19.0) Gecko/19.0 Firefox/19.0")
   end
 
-  it_behaves_like 'Firefox browser'
+  it_behaves_like "Firefox browser"
 
-  it 'returns true for mobile?' do
+  it "returns true for mobile?" do
     expect(@useragent.mobile?).to be true
   end
 
   it "returns 'Android' as the platform" do
-    expect(@useragent.platform).to eq('Android')
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "returns 'Android' as the operating system" do
-    expect(@useragent.os).to eq('Android')
+    expect(@useragent.os).to eq("Android")
   end
 end
 
-describe 'Mozilla/5.0 (Mobile; rv:41.0) Gecko/41.0 Firefox/41.0' do
+describe "Mozilla/5.0 (Mobile; rv:41.0) Gecko/41.0 Firefox/41.0" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Mobile; rv:41.0) Gecko/41.0 Firefox/41.0')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Mobile; rv:41.0) Gecko/41.0 Firefox/41.0")
   end
 
-  it_behaves_like 'Firefox browser'
+  it_behaves_like "Firefox browser"
 
-  it 'returns true for mobile?' do
+  it "returns true for mobile?" do
     expect(@useragent.mobile?).to be true
   end
 
-  it 'returns nil as the platform' do
+  it "returns nil as the platform" do
     expect(@useragent.platform).to be_nil
   end
 
-  it 'returns nil as the operating system' do
+  it "returns nil as the operating system" do
     expect(@useragent.os).to be_nil
   end
 end
 
-describe 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x' do
+describe "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x")
   end
 
-  it_should_behave_like 'Firefox browser'
+  it_should_behave_like "Firefox browser"
 
   it "should return 'x.x' as its version" do
-    expect(@useragent.version).to eq('x.x')
+    expect(@useragent.version).to eq("x.x")
   end
 
   it "should return '20041107' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20041107')
+    expect(@useragent.gecko.version).to eq("20041107")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 end
 
-shared_examples_for 'PaleMoon browser' do
+shared_examples_for "PaleMoon browser" do
   it "should return 'PaleMoon' as its browser" do
-    expect(@useragent.browser).to eq('PaleMoon')
+    expect(@useragent.browser).to eq("PaleMoon")
   end
 end
 
-describe 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1' do
+describe "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1")
   end
 
-  it_should_behave_like 'PaleMoon browser'
+  it_should_behave_like "PaleMoon browser"
 
   it "should return '24.7.1' as its version" do
-    expect(@useragent.version).to eq('24.7.1')
+    expect(@useragent.version).to eq("24.7.1")
   end
 
   it "should return '20140802' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20140802')
+    expect(@useragent.gecko.version).to eq("20140802")
   end
 
   it "should return '24.7' as its firefox version" do
-    expect(@useragent.firefox.version).to eq('24.7')
+    expect(@useragent.firefox.version).to eq("24.7")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 end
 
-describe 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0' do
+describe "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0")
   end
 
-  it_should_behave_like 'PaleMoon browser'
+  it_should_behave_like "PaleMoon browser"
 
   it "should return '25.0.0' as its version" do
-    expect(@useragent.version).to eq('25.0.0')
+    expect(@useragent.version).to eq("25.0.0")
   end
 
   it "should return '20141001' as its gecko version" do
-    expect(@useragent.gecko.version).to eq('20141001')
+    expect(@useragent.gecko.version).to eq("20141001")
   end
 
   it "should return '24.7' as its firefox version" do

--- a/spec/browsers/gecko_user_agent_spec.rb
+++ b/spec/browsers/gecko_user_agent_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples_for "Firefox browser" do
-  it "should return 'Firefox' as its browser" do
+  it "returns 'Firefox' as its browser" do
     expect(@useragent.browser).to eq("Firefox")
   end
 
-  it "should return :strong as its security" do
+  it "returns :strong as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 end
@@ -16,25 +16,25 @@ describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '4.0b8' as its version" do
+  it "returns '4.0b8' as its version" do
     expect(@useragent.version).to eq("4.0b8")
   end
 
-  it "should return '20100101' as its gecko version" do
+  it "returns '20100101' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20100101")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.6' as its os" do
+  it "returns 'OS X 10.6' as its os" do
     expect(@useragent.os).to eq("OS X 10.6")
   end
 
-  it "should return nil as its localization" do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 
@@ -46,25 +46,25 @@ describe "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Ge
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '3.6.13' as its version" do
+  it "returns '3.6.13' as its version" do
     expect(@useragent.version).to eq("3.6.13")
   end
 
-  it "should return '20101203' as its gecko version" do
+  it "returns '20101203' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20101203")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.6' as its os" do
+  it "returns 'OS X 10.6' as its os" do
     expect(@useragent.os).to eq("OS X 10.6")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 
@@ -76,25 +76,25 @@ describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '3.0.1' as its version" do
+  it "returns '3.0.1' as its version" do
     expect(@useragent.version).to eq("3.0.1")
   end
 
-  it "should return '2008070206' as its gecko version" do
+  it "returns '2008070206' as its gecko version" do
     expect(@useragent.gecko.version).to eq("2008070206")
   end
 
-  it "should return 'X11' as its platform" do
+  it "returns 'X11' as its platform" do
     expect(@useragent.platform).to eq("X11")
   end
 
-  it "should return 'Linux i686' as its os" do
+  it "returns 'Linux i686' as its os" do
     expect(@useragent.os).to eq("Linux i686")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 
@@ -106,21 +106,21 @@ describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Fi
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '27.0' as its version" do
+  it "returns '27.0' as its version" do
     expect(@useragent.version).to eq("27.0")
   end
 
-  it "should return '20100101' as its gecko version" do
+  it "returns '20100101' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20100101")
   end
 
-  it "should return 'X11' as its platform" do
+  it "returns 'X11' as its platform" do
     expect(@useragent.platform).to eq("X11")
   end
 
-  it "should return 'Linux x86_64' as its os" do
+  it "returns 'Linux x86_64' as its os" do
     expect(@useragent.os).to eq("Linux x86_64")
   end
 
@@ -132,25 +132,25 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '2.0.0.14' as its version" do
+  it "returns '2.0.0.14' as its version" do
     expect(@useragent.version).to eq("2.0.0.14")
   end
 
-  it "should return '20080404' as its gecko version" do
+  it "returns '20080404' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20080404")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -160,25 +160,25 @@ describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.1
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '2.0.0.14' as its version" do
+  it "returns '2.0.0.14' as its version" do
     expect(@useragent.version).to eq("2.0.0.14")
   end
 
-  it "should return '20080404' as its gecko version" do
+  it "returns '20080404' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20080404")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -188,25 +188,25 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '16.0.1' as its version" do
+  it "returns '16.0.1' as its version" do
     expect(@useragent.version).to eq("16.0.1")
   end
 
-  it "should return '20121011' as its gecko version" do
+  it "returns '20121011' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20121011")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
-  it "should return nil as its localization" do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
@@ -216,25 +216,25 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '16.0.1' as its version" do
+  it "returns '16.0.1' as its version" do
     expect(@useragent.version).to eq("16.0.1")
   end
 
-  it "should return '20121011' as its gecko version" do
+  it "returns '20121011' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20121011")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
-  it "should return nil as its localization" do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
@@ -244,25 +244,25 @@ describe "Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0" do
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '17.0' as its version" do
+  it "returns '17.0' as its version" do
     expect(@useragent.version).to eq("17.0")
   end
 
-  it "should return '20100101' as its gecko version" do
+  it "returns '20100101' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20100101")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 
-  it "should return nil as its localization" do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
@@ -272,25 +272,25 @@ describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefo
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '17.0' as its version" do
+  it "returns '17.0' as its version" do
     expect(@useragent.version).to eq("17.0")
   end
 
-  it "should return '20100101' as its gecko version" do
+  it "returns '20100101' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20100101")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
-  it "should return nil as its localization" do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
@@ -300,25 +300,25 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '1.5.0.12' as its version" do
+  it "returns '1.5.0.12' as its version" do
     expect(@useragent.version).to eq("1.5.0.12")
   end
 
-  it "should return '20070508' as its gecko version" do
+  it "returns '20070508' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20070508")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'PPC Mac OS X Mach-O' as its os" do
+  it "returns 'PPC Mac OS X Mach-O' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -328,25 +328,25 @@ describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.1
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '1.5.0.12' as its version" do
+  it "returns '1.5.0.12' as its version" do
     expect(@useragent.version).to eq("1.5.0.12")
   end
 
-  it "should return '20070508' as its gecko version" do
+  it "returns '20070508' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20070508")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -356,25 +356,25 @@ describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return '1.5.0.4' as its version" do
+  it "returns '1.5.0.4' as its version" do
     expect(@useragent.version).to eq("1.5.0.4")
   end
 
-  it "should return '20060612' as its gecko version" do
+  it "returns '20060612' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20060612")
   end
 
-  it "should return 'X11' as its platform" do
+  it "returns 'X11' as its platform" do
     expect(@useragent.platform).to eq("X11")
   end
 
-  it "should return 'Linux i686' as its os" do
+  it "returns 'Linux i686' as its os" do
     expect(@useragent.os).to eq("Linux i686")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -384,27 +384,27 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)")
   end
 
-  it "should return 'Camino' as its browser" do
+  it "returns 'Camino' as its browser" do
     expect(@useragent.browser).to eq("Camino")
   end
 
-  it "should return '1.6' as its version" do
+  it "returns '1.6' as its version" do
     expect(@useragent.version).to eq("1.6")
   end
 
-  it "should return '20080409' as its gecko version" do
+  it "returns '20080409' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20080409")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -414,27 +414,27 @@ describe "UserAgent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/200
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)")
   end
 
-  it "should return 'Iceweasel' as its browser" do
+  it "returns 'Iceweasel' as its browser" do
     expect(@useragent.browser).to eq("Iceweasel")
   end
 
-  it "should return '2.0' as its version" do
+  it "returns '2.0' as its version" do
     expect(@useragent.version).to eq("2.0")
   end
 
-  it "should return '20061024' as its gecko version" do
+  it "returns '20061024' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20061024")
   end
 
-  it "should return 'X11' as its platform" do
+  it "returns 'X11' as its platform" do
     expect(@useragent.platform).to eq("X11")
   end
 
-  it "should return 'Linux i686' as its os" do
+  it "returns 'Linux i686' as its os" do
     expect(@useragent.os).to eq("Linux i686")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -444,27 +444,27 @@ describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.4) Gecko/20091017 SeaMonkey/2.0")
   end
 
-  it "should return 'Seamonkey' as its browser" do
+  it "returns 'Seamonkey' as its browser" do
     expect(@useragent.browser).to eq("Seamonkey")
   end
 
-  it "should return '2.0' as its version" do
+  it "returns '2.0' as its version" do
     expect(@useragent.version).to eq("2.0")
   end
 
-  it "should return '20091017' as its gecko version" do
+  it "returns '20091017' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20091017")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.6' as its os" do
+  it "returns 'OS X 10.6' as its os" do
     expect(@useragent.os).to eq("OS X 10.6")
   end
 
-  it "should return 'en-US' as its localization" do
+  it "returns 'en-US' as its localization" do
     expect(@useragent.localization).to eq("en-US")
   end
 end
@@ -514,27 +514,27 @@ describe "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/200411
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x")
   end
 
-  it_should_behave_like "Firefox browser"
+  it_behaves_like "Firefox browser"
 
-  it "should return 'x.x' as its version" do
+  it "returns 'x.x' as its version" do
     expect(@useragent.version).to eq("x.x")
   end
 
-  it "should return '20041107' as its gecko version" do
+  it "returns '20041107' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20041107")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 end
 
 shared_examples_for "PaleMoon browser" do
-  it "should return 'PaleMoon' as its browser" do
+  it "returns 'PaleMoon' as its browser" do
     expect(@useragent.browser).to eq("PaleMoon")
   end
 end
@@ -544,25 +544,25 @@ describe "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1")
   end
 
-  it_should_behave_like "PaleMoon browser"
+  it_behaves_like "PaleMoon browser"
 
-  it "should return '24.7.1' as its version" do
+  it "returns '24.7.1' as its version" do
     expect(@useragent.version).to eq("24.7.1")
   end
 
-  it "should return '20140802' as its gecko version" do
+  it "returns '20140802' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20140802")
   end
 
-  it "should return '24.7' as its firefox version" do
+  it "returns '24.7' as its firefox version" do
     expect(@useragent.firefox.version).to eq("24.7")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 end
@@ -572,17 +572,17 @@ describe "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/2
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0")
   end
 
-  it_should_behave_like "PaleMoon browser"
+  it_behaves_like "PaleMoon browser"
 
-  it "should return '25.0.0' as its version" do
+  it "returns '25.0.0' as its version" do
     expect(@useragent.version).to eq("25.0.0")
   end
 
-  it "should return '20141001' as its gecko version" do
+  it "returns '20141001' as its gecko version" do
     expect(@useragent.gecko.version).to eq("20141001")
   end
 
-  it "should return '24.7' as its firefox version" do
+  it "returns '24.7' as its firefox version" do
     expect { @useragent.firefox }.to raise_error(NoMethodError)
   end
 end

--- a/spec/browsers/gecko_user_agent_spec.rb
+++ b/spec/browsers/gecko_user_agent_spec.rb
@@ -1,11 +1,12 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples_for "Firefox browser" do
+shared_examples_for 'Firefox browser' do
   it "should return 'Firefox' as its browser" do
-    expect(@useragent.browser).to eq("Firefox")
+    expect(@useragent.browser).to eq('Firefox')
   end
 
-  it "should return :strong as its security" do
+  it 'should return :strong as its security' do
     expect(@useragent.security).to eq(:strong)
   end
 end
@@ -15,25 +16,25 @@ describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 
     @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '4.0b8' as its version" do
-    expect(@useragent.version).to eq("4.0b8")
+    expect(@useragent.version).to eq('4.0b8')
   end
 
   it "should return '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20100101")
+    expect(@useragent.gecko.version).to eq('20100101')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6")
+    expect(@useragent.os).to eq('OS X 10.6')
   end
 
-  it "should return nil as its localization" do
+  it 'should return nil as its localization' do
     expect(@useragent.localization).to be_nil
   end
 
@@ -45,26 +46,26 @@ describe 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Ge
     @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '3.6.13' as its version" do
-    expect(@useragent.version).to eq("3.6.13")
+    expect(@useragent.version).to eq('3.6.13')
   end
 
   it "should return '20101203' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20101203")
+    expect(@useragent.gecko.version).to eq('20101203')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6")
+    expect(@useragent.os).to eq('OS X 10.6')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -72,29 +73,29 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.1) Gecko/2008070206 Firefox/3.0.1')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '3.0.1' as its version" do
-    expect(@useragent.version).to eq("3.0.1")
+    expect(@useragent.version).to eq('3.0.1')
   end
 
   it "should return '2008070206' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("2008070206")
+    expect(@useragent.gecko.version).to eq('2008070206')
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
+    expect(@useragent.platform).to eq('X11')
   end
 
   it "should return 'Linux i686' as its os" do
-    expect(@useragent.os).to eq("Linux i686")
+    expect(@useragent.os).to eq('Linux i686')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -102,25 +103,25 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '27.0' as its version" do
-    expect(@useragent.version).to eq("27.0")
+    expect(@useragent.version).to eq('27.0')
   end
 
   it "should return '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20100101")
+    expect(@useragent.gecko.version).to eq('20100101')
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
+    expect(@useragent.platform).to eq('X11')
   end
 
   it "should return 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq("Linux x86_64")
+    expect(@useragent.os).to eq('Linux x86_64')
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -128,112 +129,112 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '2.0.0.14' as its version" do
-    expect(@useragent.version).to eq("2.0.0.14")
+    expect(@useragent.version).to eq('2.0.0.14')
   end
 
   it "should return '20080404' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20080404")
+    expect(@useragent.gecko.version).to eq('20080404')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '2.0.0.14' as its version" do
-    expect(@useragent.version).to eq("2.0.0.14")
+    expect(@useragent.version).to eq('2.0.0.14')
   end
 
   it "should return '20080404' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20080404")
+    expect(@useragent.gecko.version).to eq('20080404')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '16.0.1' as its version" do
-    expect(@useragent.version).to eq("16.0.1")
+    expect(@useragent.version).to eq('16.0.1')
   end
 
   it "should return '20121011' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20121011")
+    expect(@useragent.gecko.version).to eq('20121011')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 
-  it "should return nil as its localization" do
+  it 'should return nil as its localization' do
     expect(@useragent.localization).to be_nil
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; Win64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '16.0.1' as its version" do
-    expect(@useragent.version).to eq("16.0.1")
+    expect(@useragent.version).to eq('16.0.1')
   end
 
   it "should return '20121011' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20121011")
+    expect(@useragent.gecko.version).to eq('20121011')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 
-  it "should return nil as its localization" do
+  it 'should return nil as its localization' do
     expect(@useragent.localization).to be_nil
   end
 end
@@ -243,25 +244,25 @@ describe 'Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0' do
     @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 5.1; rv:17.0) Gecko/20100101 Firefox/17.0')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '17.0' as its version" do
-    expect(@useragent.version).to eq("17.0")
+    expect(@useragent.version).to eq('17.0')
   end
 
   it "should return '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20100101")
+    expect(@useragent.gecko.version).to eq('20100101')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 
-  it "should return nil as its localization" do
+  it 'should return nil as its localization' do
     expect(@useragent.localization).to be_nil
   end
 end
@@ -271,140 +272,140 @@ describe 'UserAgent: Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefo
     @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; rv:17.0) Gecko/20100101 Firefox/17.0')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '17.0' as its version" do
-    expect(@useragent.version).to eq("17.0")
+    expect(@useragent.version).to eq('17.0')
   end
 
   it "should return '20100101' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20100101")
+    expect(@useragent.gecko.version).to eq('20100101')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 
-  it "should return nil as its localization" do
+  it 'should return nil as its localization' do
     expect(@useragent.localization).to be_nil
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X Mach-O; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '1.5.0.12' as its version" do
-    expect(@useragent.version).to eq("1.5.0.12")
+    expect(@useragent.version).to eq('1.5.0.12')
   end
 
   it "should return '20070508' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20070508")
+    expect(@useragent.gecko.version).to eq('20070508')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'PPC Mac OS X Mach-O' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.12) Gecko/20070508 Firefox/1.5.0.12')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '1.5.0.12' as its version" do
-    expect(@useragent.version).to eq("1.5.0.12")
+    expect(@useragent.version).to eq('1.5.0.12')
   end
 
   it "should return '20070508' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20070508")
+    expect(@useragent.gecko.version).to eq('20070508')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.0.4) Gecko/20060612 Firefox/1.5.0.4 Flock/0.7.0.17.1')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return '1.5.0.4' as its version" do
-    expect(@useragent.version).to eq("1.5.0.4")
+    expect(@useragent.version).to eq('1.5.0.4')
   end
 
   it "should return '20060612' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20060612")
+    expect(@useragent.gecko.version).to eq('20060612')
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
+    expect(@useragent.platform).to eq('X11')
   end
 
   it "should return 'Linux i686' as its os" do
-    expect(@useragent.os).to eq("Linux i686")
+    expect(@useragent.os).to eq('Linux i686')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en; rv:1.8.1.14) Gecko/20080409 Camino/1.6 (like Firefox/2.0.0.14)')
   end
 
   it "should return 'Camino' as its browser" do
-    expect(@useragent.browser).to eq("Camino")
+    expect(@useragent.browser).to eq('Camino')
   end
 
   it "should return '1.6' as its version" do
-    expect(@useragent.version).to eq("1.6")
+    expect(@useragent.version).to eq('1.6')
   end
 
   it "should return '20080409' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20080409")
+    expect(@useragent.gecko.version).to eq('20080409')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
@@ -414,27 +415,27 @@ describe 'UserAgent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/200
   end
 
   it "should return 'Iceweasel' as its browser" do
-    expect(@useragent.browser).to eq("Iceweasel")
+    expect(@useragent.browser).to eq('Iceweasel')
   end
 
   it "should return '2.0' as its version" do
-    expect(@useragent.version).to eq("2.0")
+    expect(@useragent.version).to eq('2.0')
   end
 
   it "should return '20061024' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20061024")
+    expect(@useragent.gecko.version).to eq('20061024')
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
+    expect(@useragent.platform).to eq('X11')
   end
 
   it "should return 'Linux i686' as its os" do
-    expect(@useragent.os).to eq("Linux i686")
+    expect(@useragent.os).to eq('Linux i686')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
@@ -444,27 +445,27 @@ describe 'UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1
   end
 
   it "should return 'Seamonkey' as its browser" do
-    expect(@useragent.browser).to eq("Seamonkey")
+    expect(@useragent.browser).to eq('Seamonkey')
   end
 
   it "should return '2.0' as its version" do
-    expect(@useragent.version).to eq("2.0")
+    expect(@useragent.version).to eq('2.0')
   end
 
   it "should return '20091017' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20091017")
+    expect(@useragent.gecko.version).to eq('20091017')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.6' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6")
+    expect(@useragent.os).to eq('OS X 10.6')
   end
 
   it "should return 'en-US' as its localization" do
-    expect(@useragent.localization).to eq("en-US")
+    expect(@useragent.localization).to eq('en-US')
   end
 end
 
@@ -499,11 +500,11 @@ describe 'Mozilla/5.0 (Mobile; rv:41.0) Gecko/41.0 Firefox/41.0' do
     expect(@useragent.mobile?).to be true
   end
 
-  it "returns nil as the platform" do
+  it 'returns nil as the platform' do
     expect(@useragent.platform).to be_nil
   end
 
-  it "returns nil as the operating system" do
+  it 'returns nil as the operating system' do
     expect(@useragent.os).to be_nil
   end
 end
@@ -513,28 +514,28 @@ describe 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/200411
     @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:x.x.x) Gecko/20041107 Firefox/x.x')
   end
 
-  it_should_behave_like "Firefox browser"
+  it_should_behave_like 'Firefox browser'
 
   it "should return 'x.x' as its version" do
-    expect(@useragent.version).to eq("x.x")
+    expect(@useragent.version).to eq('x.x')
   end
 
   it "should return '20041107' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20041107")
+    expect(@useragent.gecko.version).to eq('20041107')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 end
 
-shared_examples_for "PaleMoon browser" do
+shared_examples_for 'PaleMoon browser' do
   it "should return 'PaleMoon' as its browser" do
-    expect(@useragent.browser).to eq("PaleMoon")
+    expect(@useragent.browser).to eq('PaleMoon')
   end
 end
 
@@ -543,26 +544,26 @@ describe 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24
     @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.7) Gecko/20140802 Firefox/24.7 PaleMoon/24.7.1')
   end
 
-  it_should_behave_like "PaleMoon browser"
+  it_should_behave_like 'PaleMoon browser'
 
   it "should return '24.7.1' as its version" do
-    expect(@useragent.version).to eq("24.7.1")
+    expect(@useragent.version).to eq('24.7.1')
   end
 
   it "should return '20140802' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20140802")
+    expect(@useragent.gecko.version).to eq('20140802')
   end
 
   it "should return '24.7' as its firefox version" do
-    expect(@useragent.firefox.version).to eq("24.7")
+    expect(@useragent.firefox.version).to eq('24.7')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 end
 
@@ -571,14 +572,14 @@ describe 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/2
     @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:25.0) Gecko/20141001 PaleMoon/25.0.0')
   end
 
-  it_should_behave_like "PaleMoon browser"
+  it_should_behave_like 'PaleMoon browser'
 
   it "should return '25.0.0' as its version" do
-    expect(@useragent.version).to eq("25.0.0")
+    expect(@useragent.version).to eq('25.0.0')
   end
 
   it "should return '20141001' as its gecko version" do
-    expect(@useragent.gecko.version).to eq("20141001")
+    expect(@useragent.gecko.version).to eq('20141001')
   end
 
   it "should return '24.7' as its firefox version" do

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -1,144 +1,145 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples_for "Internet Explorer browser" do
+shared_examples_for 'Internet Explorer browser' do
   it "should return 'Internet Explorer' as its browser" do
-    expect(@useragent.browser).to eq("Internet Explorer")
+    expect(@useragent.browser).to eq('Internet Explorer')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko" do
+describe 'UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
+    expect(@useragent.version).to eq('11.0')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 
-  it "should have a higher version number than IE10" do
+  it 'should have a higher version number than IE10' do
     expect(@useragent.version).to be >
-      UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
+                                  UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko" do
+describe 'UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
+    expect(@useragent.version).to eq('11.0')
   end
 
   it "should return 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq("Windows 8.1")
+    expect(@useragent.os).to eq('Windows 8.1')
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko" do
+describe 'UserAgent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
+    expect(@useragent.version).to eq('11.0')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko" do
+describe 'UserAgent: Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko")
+    @useragent = UserAgent.parse('Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
+    expect(@useragent.version).to eq('11.0')
   end
 
   it "should return 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq("Windows 8.1")
+    expect(@useragent.os).to eq('Windows 8.1')
   end
 
-  it "should have a higher version number than IE10" do
+  it 'should have a higher version number than IE10' do
     expect(@useragent.version).to be >
-      UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
+                                  UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko" do
+describe 'UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
+    expect(@useragent.version).to eq('11.0')
   end
 
   it "should return 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq("Windows 8.1")
+    expect(@useragent.os).to eq('Windows 8.1')
   end
 
-  it "should have a higher version number than IE10" do
+  it 'should have a higher version number than IE10' do
     expect(@useragent.version).to be >
-      UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
+                                  UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
-  it "should return '11.0' as its version", :focus => true do
-    expect(@useragent.version).to eq("11.0")
+  it "should return '11.0' as its version", focus: true do
+    expect(@useragent.version).to eq('11.0')
   end
 
   it "should return 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq("Windows 8.1")
+    expect(@useragent.os).to eq('Windows 8.1')
   end
 
-  it "should have a higher version number than IE10" do
+  it 'should have a higher version number than IE10' do
     expect(@useragent.version).to be >
-      UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
+                                  UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko" do
+describe 'UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
+    expect(@useragent.version).to eq('11.0')
   end
 
   it "should return '11.0' as its real version" do
-    expect(@useragent.real_version).to eq("11.0")
+    expect(@useragent.real_version).to eq('11.0')
   end
 
   it { expect(@useragent).not_to be_compatibility_view }
@@ -146,22 +147,22 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '10.0' as its version" do
-    expect(@useragent.version).to eq("10.0")
+    expect(@useragent.version).to eq('10.0')
   end
 
   it "should return 'Windows 8' as its os" do
-    expect(@useragent.os).to eq("Windows 8")
+    expect(@useragent.os).to eq('Windows 8')
   end
 
-  it "should have a higher version number than IE9" do
+  it 'should have a higher version number than IE9' do
     expect(@useragent.version).to be >
-      UserAgent.parse('Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)').version
+                                  UserAgent.parse('Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)').version
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -169,17 +170,17 @@ end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '7.0' as its version" do
-    expect(@useragent.version).to eq("7.0")
+    expect(@useragent.version).to eq('7.0')
   end
 
   it "should return 'Windows 8' as its os" do
-    expect(@useragent.os).to eq("Windows 8")
+    expect(@useragent.os).to eq('Windows 8')
   end
 
   it { expect(@useragent).to be_compatibility_view }
@@ -188,17 +189,17 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '10.0' as its version" do
-    expect(@useragent.version).to eq("10.0")
+    expect(@useragent.version).to eq('10.0')
   end
 
   it "should return 'Windows 8' as its os" do
-    expect(@useragent.os).to eq("Windows 8")
+    expect(@useragent.os).to eq('Windows 8')
   end
 
   it { expect(@useragent).not_to be_compatibility_view }
@@ -207,17 +208,17 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '9.0' as its version" do
-    expect(@useragent.version).to eq("9.0")
+    expect(@useragent.version).to eq('9.0')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -225,17 +226,17 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '9.0' as its version" do
-    expect(@useragent.version).to eq("9.0")
+    expect(@useragent.version).to eq('9.0')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 
   it { expect(@useragent).not_to be_compatibility_view }
@@ -244,17 +245,17 @@ end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)' Compat View" do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '7.0' as its version" do
-    expect(@useragent.version).to eq("7.0")
+    expect(@useragent.version).to eq('7.0')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 
   it { expect(@useragent).to be_compatibility_view }
@@ -263,33 +264,33 @@ end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '7.0' as its version" do
-    expect(@useragent.version).to eq("7.0")
+    expect(@useragent.version).to eq('7.0')
   end
 
   it "should return 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq("Windows Vista")
+    expect(@useragent.os).to eq('Windows Vista')
   end
 end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '6.0' as its version" do
-    expect(@useragent.version).to eq("6.0")
+    expect(@useragent.version).to eq('6.0')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 
   it "should be == 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
@@ -297,63 +298,63 @@ describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" 
   end
 
   it "should not be == 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to eq(UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)"))
+    expect(@useragent).not_to eq(UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'))
   end
 
   it "should be > 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).to be > UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    expect(@useragent).to be > UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
   end
 
   it "should not be < 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to be < UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    expect(@useragent).not_to be < UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
   end
 
   it "should be >= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).to be >= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    expect(@useragent).to be >= UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
   end
 
   it "should not be >= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
-    expect(@useragent).not_to be >= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    expect(@useragent).not_to be >= UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
   end
 
   it "should be <= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
-    expect(@useragent).to be <= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    expect(@useragent).to be <= UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
   end
 
   it "should not be <= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to be <= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    expect(@useragent).not_to be <= UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
   end
 end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '5.5' as its version" do
-    expect(@useragent.version).to eq("5.5")
+    expect(@useragent.version).to eq('5.5')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '7.0' as its version" do
-    expect(@useragent.version).to eq("7.0")
+    expect(@useragent.version).to eq('7.0')
   end
 
   it "should return 'Windows Phone OS 7.0' as its os" do
-    expect(@useragent.os).to eq("Windows Phone OS 7.0")
+    expect(@useragent.os).to eq('Windows Phone OS 7.0')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -361,74 +362,74 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "should return '10.0' as its version" do
-    expect(@useragent.version).to eq("10.0")
+    expect(@useragent.version).to eq('10.0')
   end
 
   it "should return 'Windows Phone 8.0' as its os" do
-    expect(@useragent.os).to eq("Windows Phone 8.0")
+    expect(@useragent.os).to eq('Windows Phone 8.0')
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe "Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko" do
+describe 'Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko")
+    @useragent = UserAgent.parse('Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko')
   end
 
   it "should return '8.0' as its version" do
-    expect(@useragent.version).to eq("8.0")
+    expect(@useragent.version).to eq('8.0')
   end
 
   it "should return '11.0' as its real version" do
-    expect(@useragent.real_version).to eq("11.0")
+    expect(@useragent.real_version).to eq('11.0')
   end
 
   it { expect(@useragent).to be_compatibility_view }
 end
 
-describe "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))" do
+describe 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))")
+    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))')
   end
 
   it "should return '9.0' as its version" do
-    expect(@useragent.version).to eq("9.0")
+    expect(@useragent.version).to eq('9.0')
   end
 
   it "should return '11.0' as its real version" do
-    expect(@useragent.real_version).to eq("11.0")
+    expect(@useragent.real_version).to eq('11.0')
   end
 
   it { expect(@useragent).to be_compatibility_view }
 end
 
-describe "Non-Chrome Frame browsers" do
+describe 'Non-Chrome Frame browsers' do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
   it "shouldn't pose as chromeframe" do
     expect(@useragent.chromeframe).to be_nil
   end
 end
 
-describe "Chrome Frame installs before version 4.0" do
+describe 'Chrome Frame installs before version 4.0' do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
-  it "should return true as chromeframe" do
+  it 'should return true as chromeframe' do
     expect(@useragent.chromeframe).to be_truthy
   end
 
@@ -437,48 +438,48 @@ describe "Chrome Frame installs before version 4.0" do
   end
 end
 
-describe "Chrome Frame from version 4.0 on" do
-  context "as separate product" do
+describe 'Chrome Frame from version 4.0 on' do
+  context 'as separate product' do
     before do
-      @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/4.0")
+      @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/4.0')
     end
 
-    it_should_behave_like "Internet Explorer browser"
+    it_should_behave_like 'Internet Explorer browser'
 
-    it "should return true as chromeframe" do
+    it 'should return true as chromeframe' do
       expect(@useragent.chromeframe).to be_truthy
     end
 
-    it "should have a version" do
-      expect(@useragent.chromeframe.version).to eq("4.0")
+    it 'should have a version' do
+      expect(@useragent.chromeframe.version).to eq('4.0')
     end
   end
 
-  context "as versioned comment" do
+  context 'as versioned comment' do
     before do
-      @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe/4.0)")
+      @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe/4.0)')
     end
 
-    it_should_behave_like "Internet Explorer browser"
+    it_should_behave_like 'Internet Explorer browser'
 
-    it "should return true as chromeframe" do
+    it 'should return true as chromeframe' do
       expect(@useragent.chromeframe).to be_truthy
     end
 
-    it "should have a version" do
-      expect(@useragent.chromeframe.version).to eq("4.0")
+    it 'should have a version' do
+      expect(@useragent.chromeframe.version).to eq('4.0')
     end
   end
 end
 
-describe "UserAgent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)" do
+describe 'UserAgent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)' do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)')
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_should_behave_like 'Internet Explorer browser'
 
-  it "should not be considered to be in compatibility view" do
+  it 'should not be considered to be in compatibility view' do
     expect(@useragent).not_to be_compatibility_view
   end
 end

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -113,7 +113,7 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) 
 
   it_should_behave_like "Internet Explorer browser"
 
-  it "should return '11.0' as its version", focus: true do
+  it "should return '11.0' as its version", :focus => true do
     expect(@useragent.version).to eq("11.0")
   end
 

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples_for "Internet Explorer browser" do
-  it "should return 'Internet Explorer' as its browser" do
+  it "returns 'Internet Explorer' as its browser" do
     expect(@useragent.browser).to eq("Internet Explorer")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 end
@@ -16,17 +16,17 @@ describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gec
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '11.0' as its version" do
+  it "returns '11.0' as its version" do
     expect(@useragent.version).to eq("11.0")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
-  it "should have a higher version number than IE10" do
+  it "has a higher version number than IE10" do
     expect(@useragent.version).to be >
                                   UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
   end
@@ -37,13 +37,13 @@ describe "UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gec
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '11.0' as its version" do
+  it "returns '11.0' as its version" do
     expect(@useragent.version).to eq("11.0")
   end
 
-  it "should return 'Windows 8.1' as its os" do
+  it "returns 'Windows 8.1' as its os" do
     expect(@useragent.os).to eq("Windows 8.1")
   end
 end
@@ -53,13 +53,13 @@ describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) l
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '11.0' as its version" do
+  it "returns '11.0' as its version" do
     expect(@useragent.version).to eq("11.0")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 end
@@ -69,17 +69,17 @@ describe "UserAgent: Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E
     @useragent = UserAgent.parse("Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '11.0' as its version" do
+  it "returns '11.0' as its version" do
     expect(@useragent.version).to eq("11.0")
   end
 
-  it "should return 'Windows 8.1' as its os" do
+  it "returns 'Windows 8.1' as its os" do
     expect(@useragent.os).to eq("Windows 8.1")
   end
 
-  it "should have a higher version number than IE10" do
+  it "has a higher version number than IE10" do
     expect(@useragent.version).to be >
                                   UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
   end
@@ -90,17 +90,17 @@ describe "UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gec
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '11.0' as its version" do
+  it "returns '11.0' as its version" do
     expect(@useragent.version).to eq("11.0")
   end
 
-  it "should return 'Windows 8.1' as its os" do
+  it "returns 'Windows 8.1' as its os" do
     expect(@useragent.os).to eq("Windows 8.1")
   end
 
-  it "should have a higher version number than IE10" do
+  it "has a higher version number than IE10" do
     expect(@useragent.version).to be >
                                   UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
   end
@@ -111,17 +111,17 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) 
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '11.0' as its version", :focus => true do
+  it "returns '11.0' as its version", :focus => true do
     expect(@useragent.version).to eq("11.0")
   end
 
-  it "should return 'Windows 8.1' as its os" do
+  it "returns 'Windows 8.1' as its os" do
     expect(@useragent.os).to eq("Windows 8.1")
   end
 
-  it "should have a higher version number than IE10" do
+  it "has a higher version number than IE10" do
     expect(@useragent.version).to be >
                                   UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
   end
@@ -132,13 +132,13 @@ describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gec
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '11.0' as its version" do
+  it "returns '11.0' as its version" do
     expect(@useragent.version).to eq("11.0")
   end
 
-  it "should return '11.0' as its real version" do
+  it "returns '11.0' as its real version" do
     expect(@useragent.real_version).to eq("11.0")
   end
 
@@ -150,17 +150,17 @@ describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Triden
     @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '10.0' as its version" do
+  it "returns '10.0' as its version" do
     expect(@useragent.version).to eq("10.0")
   end
 
-  it "should return 'Windows 8' as its os" do
+  it "returns 'Windows 8' as its os" do
     expect(@useragent.os).to eq("Windows 8")
   end
 
-  it "should have a higher version number than IE9" do
+  it "has a higher version number than IE9" do
     expect(@useragent.version).to be >
                                   UserAgent.parse("Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)").version
   end
@@ -173,13 +173,13 @@ describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Tr
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '7.0' as its version" do
+  it "returns '7.0' as its version" do
     expect(@useragent.version).to eq("7.0")
   end
 
-  it "should return 'Windows 8' as its os" do
+  it "returns 'Windows 8' as its os" do
     expect(@useragent.os).to eq("Windows 8")
   end
 
@@ -192,13 +192,13 @@ describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; T
     @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '10.0' as its version" do
+  it "returns '10.0' as its version" do
     expect(@useragent.version).to eq("10.0")
   end
 
-  it "should return 'Windows 8' as its os" do
+  it "returns 'Windows 8' as its os" do
     expect(@useragent.os).to eq("Windows 8")
   end
 
@@ -211,13 +211,13 @@ describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident
     @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '9.0' as its version" do
+  it "returns '9.0' as its version" do
     expect(@useragent.version).to eq("9.0")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
@@ -229,13 +229,13 @@ describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident
     @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '9.0' as its version" do
+  it "returns '9.0' as its version" do
     expect(@useragent.version).to eq("9.0")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
@@ -248,13 +248,13 @@ describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; 
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '7.0' as its version" do
+  it "returns '7.0' as its version" do
     expect(@useragent.version).to eq("7.0")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
@@ -267,13 +267,13 @@ describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '7.0' as its version" do
+  it "returns '7.0' as its version" do
     expect(@useragent.version).to eq("7.0")
   end
 
-  it "should return 'Windows Vista' as its os" do
+  it "returns 'Windows Vista' as its os" do
     expect(@useragent.os).to eq("Windows Vista")
   end
 end
@@ -283,45 +283,45 @@ describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" 
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '6.0' as its version" do
+  it "returns '6.0' as its version" do
     expect(@useragent.version).to eq("6.0")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 
-  it "should be == 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
+  it "is == 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
     expect(@useragent).to eq(@useragent)
   end
 
-  it "should not be == 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+  it "is not == 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
     expect(@useragent).not_to eq(UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)"))
   end
 
-  it "should be > 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+  it "is > 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
     expect(@useragent).to be > UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
-  it "should not be < 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+  it "is not < 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
     expect(@useragent).not_to be < UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
-  it "should be >= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+  it "is >= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
     expect(@useragent).to be >= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
-  it "should not be >= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
+  it "is not >= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
     expect(@useragent).not_to be >= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
   end
 
-  it "should be <= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
+  it "is <= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
     expect(@useragent).to be <= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
   end
 
-  it "should not be <= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+  it "is not <= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
     expect(@useragent).not_to be <= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 end
@@ -331,13 +331,13 @@ describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '5.5' as its version" do
+  it "returns '5.5' as its version" do
     expect(@useragent.version).to eq("5.5")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 end
@@ -347,13 +347,13 @@ describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; T
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '7.0' as its version" do
+  it "returns '7.0' as its version" do
     expect(@useragent.version).to eq("7.0")
   end
 
-  it "should return 'Windows Phone OS 7.0' as its os" do
+  it "returns 'Windows Phone OS 7.0' as its os" do
     expect(@useragent.os).to eq("Windows Phone OS 7.0")
   end
 
@@ -365,13 +365,13 @@ describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Tri
     @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return '10.0' as its version" do
+  it "returns '10.0' as its version" do
     expect(@useragent.version).to eq("10.0")
   end
 
-  it "should return 'Windows Phone 8.0' as its os" do
+  it "returns 'Windows Phone 8.0' as its os" do
     expect(@useragent.os).to eq("Windows Phone 8.0")
   end
 
@@ -383,11 +383,11 @@ describe "Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Geck
     @useragent = UserAgent.parse("Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it "should return '8.0' as its version" do
+  it "returns '8.0' as its version" do
     expect(@useragent.version).to eq("8.0")
   end
 
-  it "should return '11.0' as its real version" do
+  it "returns '11.0' as its real version" do
     expect(@useragent.real_version).to eq("11.0")
   end
 
@@ -399,11 +399,11 @@ describe "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0;
     @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))")
   end
 
-  it "should return '9.0' as its version" do
+  it "returns '9.0' as its version" do
     expect(@useragent.version).to eq("9.0")
   end
 
-  it "should return '11.0' as its real version" do
+  it "returns '11.0' as its real version" do
     expect(@useragent.real_version).to eq("11.0")
   end
 
@@ -415,9 +415,9 @@ describe "Non-Chrome Frame browsers" do
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "shouldn't pose as chromeframe" do
+  it "does not pose as chromeframe" do
     expect(@useragent.chromeframe).to be_nil
   end
 end
@@ -427,13 +427,13 @@ describe "Chrome Frame installs before version 4.0" do
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should return true as chromeframe" do
+  it "returns true as chromeframe" do
     expect(@useragent.chromeframe).to be_truthy
   end
 
-  it "shouldn't have a version" do
+  it "does not have a version" do
     expect(@useragent.chromeframe).not_to respond_to(:version)
   end
 end
@@ -444,13 +444,13 @@ describe "Chrome Frame from version 4.0 on" do
       @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/4.0")
     end
 
-    it_should_behave_like "Internet Explorer browser"
+    it_behaves_like "Internet Explorer browser"
 
-    it "should return true as chromeframe" do
+    it "returns true as chromeframe" do
       expect(@useragent.chromeframe).to be_truthy
     end
 
-    it "should have a version" do
+    it "has a version" do
       expect(@useragent.chromeframe.version).to eq("4.0")
     end
   end
@@ -460,13 +460,13 @@ describe "Chrome Frame from version 4.0 on" do
       @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe/4.0)")
     end
 
-    it_should_behave_like "Internet Explorer browser"
+    it_behaves_like "Internet Explorer browser"
 
-    it "should return true as chromeframe" do
+    it "returns true as chromeframe" do
       expect(@useragent.chromeframe).to be_truthy
     end
 
-    it "should have a version" do
+    it "has a version" do
       expect(@useragent.chromeframe.version).to eq("4.0")
     end
   end
@@ -477,9 +477,9 @@ describe "UserAgent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)" do
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)")
   end
 
-  it_should_behave_like "Internet Explorer browser"
+  it_behaves_like "Internet Explorer browser"
 
-  it "should not be considered to be in compatibility view" do
+  it "is not considered to be in compatibility view" do
     expect(@useragent).not_to be_compatibility_view
   end
 end

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -1,145 +1,145 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples_for 'Internet Explorer browser' do
+shared_examples_for "Internet Explorer browser" do
   it "should return 'Internet Explorer' as its browser" do
-    expect(@useragent.browser).to eq('Internet Explorer')
+    expect(@useragent.browser).to eq("Internet Explorer")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko' do
+describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq('11.0')
+    expect(@useragent.version).to eq("11.0")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 
-  it 'should have a higher version number than IE10' do
+  it "should have a higher version number than IE10" do
     expect(@useragent.version).to be >
-                                  UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
+                                  UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' do
+describe "UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq('11.0')
+    expect(@useragent.version).to eq("11.0")
   end
 
   it "should return 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq('Windows 8.1')
+    expect(@useragent.os).to eq("Windows 8.1")
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko' do
+describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq('11.0')
+    expect(@useragent.version).to eq("11.0")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko' do
+describe "UserAgent: Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko')
+    @useragent = UserAgent.parse("Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq('11.0')
+    expect(@useragent.version).to eq("11.0")
   end
 
   it "should return 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq('Windows 8.1')
+    expect(@useragent.os).to eq("Windows 8.1")
   end
 
-  it 'should have a higher version number than IE10' do
+  it "should have a higher version number than IE10" do
     expect(@useragent.version).to be >
-                                  UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
+                                  UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko' do
+describe "UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq('11.0')
+    expect(@useragent.version).to eq("11.0")
   end
 
   it "should return 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq('Windows 8.1')
+    expect(@useragent.os).to eq("Windows 8.1")
   end
 
-  it 'should have a higher version number than IE10' do
+  it "should have a higher version number than IE10" do
     expect(@useragent.version).to be >
-                                  UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
+                                  UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '11.0' as its version", focus: true do
-    expect(@useragent.version).to eq('11.0')
+    expect(@useragent.version).to eq("11.0")
   end
 
   it "should return 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq('Windows 8.1')
+    expect(@useragent.os).to eq("Windows 8.1")
   end
 
-  it 'should have a higher version number than IE10' do
+  it "should have a higher version number than IE10" do
     expect(@useragent.version).to be >
-                                  UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)').version
+                                  UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko' do
+describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '11.0' as its version" do
-    expect(@useragent.version).to eq('11.0')
+    expect(@useragent.version).to eq("11.0")
   end
 
   it "should return '11.0' as its real version" do
-    expect(@useragent.real_version).to eq('11.0')
+    expect(@useragent.real_version).to eq("11.0")
   end
 
   it { expect(@useragent).not_to be_compatibility_view }
@@ -147,22 +147,22 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '10.0' as its version" do
-    expect(@useragent.version).to eq('10.0')
+    expect(@useragent.version).to eq("10.0")
   end
 
   it "should return 'Windows 8' as its os" do
-    expect(@useragent.os).to eq('Windows 8')
+    expect(@useragent.os).to eq("Windows 8")
   end
 
-  it 'should have a higher version number than IE9' do
+  it "should have a higher version number than IE9" do
     expect(@useragent.version).to be >
-                                  UserAgent.parse('Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)').version
+                                  UserAgent.parse("Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)").version
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -170,17 +170,17 @@ end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '7.0' as its version" do
-    expect(@useragent.version).to eq('7.0')
+    expect(@useragent.version).to eq("7.0")
   end
 
   it "should return 'Windows 8' as its os" do
-    expect(@useragent.os).to eq('Windows 8')
+    expect(@useragent.os).to eq("Windows 8")
   end
 
   it { expect(@useragent).to be_compatibility_view }
@@ -189,17 +189,17 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '10.0' as its version" do
-    expect(@useragent.version).to eq('10.0')
+    expect(@useragent.version).to eq("10.0")
   end
 
   it "should return 'Windows 8' as its os" do
-    expect(@useragent.os).to eq('Windows 8')
+    expect(@useragent.os).to eq("Windows 8")
   end
 
   it { expect(@useragent).not_to be_compatibility_view }
@@ -208,17 +208,17 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '9.0' as its version" do
-    expect(@useragent.version).to eq('9.0')
+    expect(@useragent.version).to eq("9.0")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -226,17 +226,17 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '9.0' as its version" do
-    expect(@useragent.version).to eq('9.0')
+    expect(@useragent.version).to eq("9.0")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 
   it { expect(@useragent).not_to be_compatibility_view }
@@ -245,17 +245,17 @@ end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)' Compat View" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '7.0' as its version" do
-    expect(@useragent.version).to eq('7.0')
+    expect(@useragent.version).to eq("7.0")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 
   it { expect(@useragent).to be_compatibility_view }
@@ -264,33 +264,33 @@ end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '7.0' as its version" do
-    expect(@useragent.version).to eq('7.0')
+    expect(@useragent.version).to eq("7.0")
   end
 
   it "should return 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq('Windows Vista')
+    expect(@useragent.os).to eq("Windows Vista")
   end
 end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '6.0' as its version" do
-    expect(@useragent.version).to eq('6.0')
+    expect(@useragent.version).to eq("6.0")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 
   it "should be == 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
@@ -298,63 +298,63 @@ describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" 
   end
 
   it "should not be == 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to eq(UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'))
+    expect(@useragent).not_to eq(UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)"))
   end
 
   it "should be > 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).to be > UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
+    expect(@useragent).to be > UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
   it "should not be < 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to be < UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
+    expect(@useragent).not_to be < UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
   it "should be >= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).to be >= UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
+    expect(@useragent).to be >= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
   it "should not be >= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
-    expect(@useragent).not_to be >= UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
+    expect(@useragent).not_to be >= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
   end
 
   it "should be <= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
-    expect(@useragent).to be <= UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
+    expect(@useragent).to be <= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
   end
 
   it "should not be <= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to be <= UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
+    expect(@useragent).not_to be <= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '5.5' as its version" do
-    expect(@useragent.version).to eq('5.5')
+    expect(@useragent.version).to eq("5.5")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '7.0' as its version" do
-    expect(@useragent.version).to eq('7.0')
+    expect(@useragent.version).to eq("7.0")
   end
 
   it "should return 'Windows Phone OS 7.0' as its os" do
-    expect(@useragent.os).to eq('Windows Phone OS 7.0')
+    expect(@useragent.os).to eq("Windows Phone OS 7.0")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -362,74 +362,74 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "should return '10.0' as its version" do
-    expect(@useragent.version).to eq('10.0')
+    expect(@useragent.version).to eq("10.0")
   end
 
   it "should return 'Windows Phone 8.0' as its os" do
-    expect(@useragent.os).to eq('Windows Phone 8.0')
+    expect(@useragent.os).to eq("Windows Phone 8.0")
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe 'Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko' do
+describe "Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko')
+    @useragent = UserAgent.parse("Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko")
   end
 
   it "should return '8.0' as its version" do
-    expect(@useragent.version).to eq('8.0')
+    expect(@useragent.version).to eq("8.0")
   end
 
   it "should return '11.0' as its real version" do
-    expect(@useragent.real_version).to eq('11.0')
+    expect(@useragent.real_version).to eq("11.0")
   end
 
   it { expect(@useragent).to be_compatibility_view }
 end
 
-describe 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))' do
+describe "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))')
+    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))")
   end
 
   it "should return '9.0' as its version" do
-    expect(@useragent.version).to eq('9.0')
+    expect(@useragent.version).to eq("9.0")
   end
 
   it "should return '11.0' as its real version" do
-    expect(@useragent.real_version).to eq('11.0')
+    expect(@useragent.real_version).to eq("11.0")
   end
 
   it { expect(@useragent).to be_compatibility_view }
 end
 
-describe 'Non-Chrome Frame browsers' do
+describe "Non-Chrome Frame browsers" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
   it "shouldn't pose as chromeframe" do
     expect(@useragent.chromeframe).to be_nil
   end
 end
 
-describe 'Chrome Frame installs before version 4.0' do
+describe "Chrome Frame installs before version 4.0" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
-  it 'should return true as chromeframe' do
+  it "should return true as chromeframe" do
     expect(@useragent.chromeframe).to be_truthy
   end
 
@@ -438,48 +438,48 @@ describe 'Chrome Frame installs before version 4.0' do
   end
 end
 
-describe 'Chrome Frame from version 4.0 on' do
-  context 'as separate product' do
+describe "Chrome Frame from version 4.0 on" do
+  context "as separate product" do
     before do
-      @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/4.0')
+      @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/4.0")
     end
 
-    it_should_behave_like 'Internet Explorer browser'
+    it_should_behave_like "Internet Explorer browser"
 
-    it 'should return true as chromeframe' do
+    it "should return true as chromeframe" do
       expect(@useragent.chromeframe).to be_truthy
     end
 
-    it 'should have a version' do
-      expect(@useragent.chromeframe.version).to eq('4.0')
+    it "should have a version" do
+      expect(@useragent.chromeframe.version).to eq("4.0")
     end
   end
 
-  context 'as versioned comment' do
+  context "as versioned comment" do
     before do
-      @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe/4.0)')
+      @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe/4.0)")
     end
 
-    it_should_behave_like 'Internet Explorer browser'
+    it_should_behave_like "Internet Explorer browser"
 
-    it 'should return true as chromeframe' do
+    it "should return true as chromeframe" do
       expect(@useragent.chromeframe).to be_truthy
     end
 
-    it 'should have a version' do
-      expect(@useragent.chromeframe.version).to eq('4.0')
+    it "should have a version" do
+      expect(@useragent.chromeframe.version).to eq("4.0")
     end
   end
 end
 
-describe 'UserAgent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)' do
+describe "UserAgent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)")
   end
 
-  it_should_behave_like 'Internet Explorer browser'
+  it_should_behave_like "Internet Explorer browser"
 
-  it 'should not be considered to be in compatibility view' do
+  it "should not be considered to be in compatibility view" do
     expect(@useragent).not_to be_compatibility_view
   end
 end

--- a/spec/browsers/internet_explorer_user_agent_spec.rb
+++ b/spec/browsers/internet_explorer_user_agent_spec.rb
@@ -3,483 +3,437 @@ require "user_agent"
 
 shared_examples_for "Internet Explorer browser" do
   it "returns 'Internet Explorer' as its browser" do
-    expect(@useragent.browser).to eq("Internet Explorer")
+    expect(useragent.browser).to eq("Internet Explorer")
   end
 
   it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(useragent.platform).to eq("Windows")
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko")
-  end
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko") }
 
-  it_behaves_like "Internet Explorer browser"
+    it_behaves_like "Internet Explorer browser"
 
-  it "returns '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
-  end
-
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
-
-  it "has a higher version number than IE10" do
-    expect(@useragent.version).to be >
-                                  UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
-  end
-
-  it "returns 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq("Windows 8.1")
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
-  end
-
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
-  end
-
-  it "returns 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq("Windows 8.1")
-  end
-
-  it "has a higher version number than IE10" do
-    expect(@useragent.version).to be >
-                                  UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
-  end
-
-  it "returns 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq("Windows 8.1")
-  end
-
-  it "has a higher version number than IE10" do
-    expect(@useragent.version).to be >
-                                  UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
-  end
-end
-
-describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '11.0' as its version", :focus => true do
-    expect(@useragent.version).to eq("11.0")
-  end
-
-  it "returns 'Windows 8.1' as its os" do
-    expect(@useragent.os).to eq("Windows 8.1")
-  end
-
-  it "has a higher version number than IE10" do
-    expect(@useragent.version).to be >
-                                  UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '11.0' as its version" do
-    expect(@useragent.version).to eq("11.0")
-  end
-
-  it "returns '11.0' as its real version" do
-    expect(@useragent.real_version).to eq("11.0")
-  end
-
-  it { expect(@useragent).not_to be_compatibility_view }
-end
-
-describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '10.0' as its version" do
-    expect(@useragent.version).to eq("10.0")
-  end
-
-  it "returns 'Windows 8' as its os" do
-    expect(@useragent.os).to eq("Windows 8")
-  end
-
-  it "has a higher version number than IE9" do
-    expect(@useragent.version).to be >
-                                  UserAgent.parse("Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)").version
-  end
-
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '7.0' as its version" do
-    expect(@useragent.version).to eq("7.0")
-  end
-
-  it "returns 'Windows 8' as its os" do
-    expect(@useragent.os).to eq("Windows 8")
-  end
-
-  it { expect(@useragent).to be_compatibility_view }
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '10.0' as its version" do
-    expect(@useragent.version).to eq("10.0")
-  end
-
-  it "returns 'Windows 8' as its os" do
-    expect(@useragent.os).to eq("Windows 8")
-  end
-
-  it { expect(@useragent).not_to be_compatibility_view }
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '9.0' as its version" do
-    expect(@useragent.version).to eq("9.0")
-  end
-
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
-
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '9.0' as its version" do
-    expect(@useragent.version).to eq("9.0")
-  end
-
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
-
-  it { expect(@useragent).not_to be_compatibility_view }
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)' Compat View" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '7.0' as its version" do
-    expect(@useragent.version).to eq("7.0")
-  end
-
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
-
-  it { expect(@useragent).to be_compatibility_view }
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '7.0' as its version" do
-    expect(@useragent.version).to eq("7.0")
-  end
-
-  it "returns 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq("Windows Vista")
-  end
-end
-
-describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '6.0' as its version" do
-    expect(@useragent.version).to eq("6.0")
-  end
-
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
-  end
-
-  it "is == 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
-    expect(@useragent).to eq(@useragent)
-  end
-
-  it "is not == 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to eq(UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)"))
-  end
-
-  it "is > 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).to be > UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
-  end
-
-  it "is not < 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to be < UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
-  end
-
-  it "is >= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).to be >= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
-  end
-
-  it "is not >= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
-    expect(@useragent).not_to be >= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-  end
-
-  it "is <= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
-    expect(@useragent).to be <= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-  end
-
-  it "is not <= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-    expect(@useragent).not_to be <= UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
-  end
-end
-
-describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '5.5' as its version" do
-    expect(@useragent.version).to eq("5.5")
-  end
-
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
-  end
-end
-
-describe "UserAgent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '7.0' as its version" do
-    expect(@useragent.version).to eq("7.0")
-  end
-
-  it "returns 'Windows Phone OS 7.0' as its os" do
-    expect(@useragent.os).to eq("Windows Phone OS 7.0")
-  end
-
-  it { expect(@useragent).to be_mobile }
-end
-
-describe "UserAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns '10.0' as its version" do
-    expect(@useragent.version).to eq("10.0")
-  end
-
-  it "returns 'Windows Phone 8.0' as its os" do
-    expect(@useragent.os).to eq("Windows Phone 8.0")
-  end
-
-  it { expect(@useragent).to be_mobile }
-end
-
-describe "Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko")
-  end
-
-  it "returns '8.0' as its version" do
-    expect(@useragent.version).to eq("8.0")
-  end
-
-  it "returns '11.0' as its real version" do
-    expect(@useragent.real_version).to eq("11.0")
-  end
-
-  it { expect(@useragent).to be_compatibility_view }
-end
-
-describe "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))")
-  end
-
-  it "returns '9.0' as its version" do
-    expect(@useragent.version).to eq("9.0")
-  end
-
-  it "returns '11.0' as its real version" do
-    expect(@useragent.real_version).to eq("11.0")
-  end
-
-  it { expect(@useragent).to be_compatibility_view }
-end
-
-describe "Non-Chrome Frame browsers" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "does not pose as chromeframe" do
-    expect(@useragent.chromeframe).to be_nil
-  end
-end
-
-describe "Chrome Frame installs before version 4.0" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "returns true as chromeframe" do
-    expect(@useragent.chromeframe).to be_truthy
-  end
-
-  it "does not have a version" do
-    expect(@useragent.chromeframe).not_to respond_to(:version)
-  end
-end
-
-describe "Chrome Frame from version 4.0 on" do
-  context "as separate product" do
-    before do
-      @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/4.0")
+    it "returns '11.0' as its version" do
+      expect(useragent.version).to eq("11.0")
     end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it "has a higher version number than IE10" do
+      expect(useragent.version).to be >
+                                   described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '11.0' as its version" do
+      expect(useragent.version).to eq("11.0")
+    end
+
+    it "returns 'Windows 8.1' as its os" do
+      expect(useragent.os).to eq("Windows 8.1")
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '11.0' as its version" do
+      expect(useragent.version).to eq("11.0")
+    end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '11.0' as its version" do
+      expect(useragent.version).to eq("11.0")
+    end
+
+    it "returns 'Windows 8.1' as its os" do
+      expect(useragent.os).to eq("Windows 8.1")
+    end
+
+    it "has a higher version number than IE10" do
+      expect(useragent.version).to be >
+                                   described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '11.0' as its version" do
+      expect(useragent.version).to eq("11.0")
+    end
+
+    it "returns 'Windows 8.1' as its os" do
+      expect(useragent.os).to eq("Windows 8.1")
+    end
+
+    it "has a higher version number than IE10" do
+      expect(useragent.version).to be >
+                                   described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '11.0' as its version" do
+      expect(useragent.version).to eq("11.0")
+    end
+
+    it "returns 'Windows 8.1' as its os" do
+      expect(useragent.os).to eq("Windows 8.1")
+    end
+
+    it "has a higher version number than IE10" do
+      expect(useragent.version).to be >
+                                   described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)").version
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; Trident/8.0; rv:11.0) like Gecko") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '11.0' as its version" do
+      expect(useragent.version).to eq("11.0")
+    end
+
+    it "returns '11.0' as its real version" do
+      expect(useragent.real_version).to eq("11.0")
+    end
+
+    it { expect(useragent).not_to be_compatibility_view }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '10.0' as its version" do
+      expect(useragent.version).to eq("10.0")
+    end
+
+    it "returns 'Windows 8' as its os" do
+      expect(useragent.os).to eq("Windows 8")
+    end
+
+    it "has a higher version number than IE9" do
+      expect(useragent.version).to be >
+                                   described_class.parse("Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)").version
+    end
+
+    it { expect(useragent).not_to be_mobile }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; ARM; Trident/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '7.0' as its version" do
+      expect(useragent.version).to eq("7.0")
+    end
+
+    it "returns 'Windows 8' as its os" do
+      expect(useragent.os).to eq("Windows 8")
+    end
+
+    it { expect(useragent).to be_compatibility_view }
+    it { expect(useragent).not_to be_mobile }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '10.0' as its version" do
+      expect(useragent.version).to eq("10.0")
+    end
+
+    it "returns 'Windows 8' as its os" do
+      expect(useragent.os).to eq("Windows 8")
+    end
+
+    it { expect(useragent).not_to be_compatibility_view }
+    it { expect(useragent).not_to be_mobile }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '9.0' as its version" do
+      expect(useragent.version).to eq("9.0")
+    end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it { expect(useragent).not_to be_mobile }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '9.0' as its version" do
+      expect(useragent.version).to eq("9.0")
+    end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it { expect(useragent).not_to be_compatibility_view }
+    it { expect(useragent).not_to be_mobile }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '7.0' as its version" do
+      expect(useragent.version).to eq("7.0")
+    end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it { expect(useragent).to be_compatibility_view }
+    it { expect(useragent).not_to be_mobile }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '7.0' as its version" do
+      expect(useragent.version).to eq("7.0")
+    end
+
+    it "returns 'Windows Vista' as its os" do
+      expect(useragent.os).to eq("Windows Vista")
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '6.0' as its version" do
+      expect(useragent.version).to eq("6.0")
+    end
+
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
+
+    it "is == 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)'" do
+      expect(useragent).to eq(useragent)
+    end
+
+    it "is not == 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+      expect(useragent).not_to eq(described_class.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)"))
+    end
+
+    it "is > 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+      expect(useragent).to be > described_class.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    end
+
+    it "is not < 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+      expect(useragent).not_to be < described_class.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    end
+
+    it "is >= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+      expect(useragent).to be >= described_class.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    end
+
+    it "is not >= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
+      expect(useragent).not_to be >= described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    end
+
+    it "is <= 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'" do
+      expect(useragent).to be <= described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    end
+
+    it "is not <= 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)'" do
+      expect(useragent).not_to be <= described_class.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)")
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '5.5' as its version" do
+      expect(useragent.version).to eq("5.5")
+    end
+
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '7.0' as its version" do
+      expect(useragent.version).to eq("7.0")
+    end
+
+    it "returns 'Windows Phone OS 7.0' as its os" do
+      expect(useragent.os).to eq("Windows Phone OS 7.0")
+    end
+
+    it { expect(useragent).to be_mobile }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; Vodafone)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "returns '10.0' as its version" do
+      expect(useragent.version).to eq("10.0")
+    end
+
+    it "returns 'Windows Phone 8.0' as its os" do
+      expect(useragent.os).to eq("Windows Phone 8.0")
+    end
+
+    it { expect(useragent).to be_mobile }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (MSIE 8.0; Windows NT 6.0; Trident/7.0; rv:11.0) like Gecko") }
+
+    it "returns '8.0' as its version" do
+      expect(useragent.version).to eq("8.0")
+    end
+
+    it "returns '11.0' as its real version" do
+      expect(useragent.real_version).to eq("11.0")
+    end
+
+    it { expect(useragent).to be_compatibility_view }
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; BOIE9;ENUS))") }
+
+    it "returns '9.0' as its version" do
+      expect(useragent.version).to eq("9.0")
+    end
+
+    it "returns '11.0' as its real version" do
+      expect(useragent.real_version).to eq("11.0")
+    end
+
+    it { expect(useragent).to be_compatibility_view }
+  end
+
+  # Non-Chrome Frame Browsers
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.1)") }
+
+    it_behaves_like "Internet Explorer browser"
+
+    it "does not pose as chromeframe" do
+      expect(useragent.chromeframe).to be_nil
+    end
+  end
+
+  # Chrome Frame install before version 4.0
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe)") }
 
     it_behaves_like "Internet Explorer browser"
 
     it "returns true as chromeframe" do
-      expect(@useragent.chromeframe).to be_truthy
+      expect(useragent.chromeframe).to be_truthy
     end
 
-    it "has a version" do
-      expect(@useragent.chromeframe.version).to eq("4.0")
+    it "does not have a version" do
+      expect(useragent.chromeframe).not_to respond_to(:version)
     end
   end
 
-  context "as versioned comment" do
-    before do
-      @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe/4.0)")
+  context do
+    context "when separate product" do
+      let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/4.0") }
+
+      it_behaves_like "Internet Explorer browser"
+
+      it "returns true as chromeframe" do
+        expect(useragent.chromeframe).to be_truthy
+      end
+
+      it "has a version" do
+        expect(useragent.chromeframe.version).to eq("4.0")
+      end
     end
+
+    context "with versioned comment" do
+      let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; chromeframe/4.0)") }
+
+      it_behaves_like "Internet Explorer browser"
+
+      it "returns true as chromeframe" do
+        expect(useragent.chromeframe).to be_truthy
+      end
+
+      it "has a version" do
+        expect(useragent.chromeframe.version).to eq("4.0")
+      end
+    end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)") }
 
     it_behaves_like "Internet Explorer browser"
 
-    it "returns true as chromeframe" do
-      expect(@useragent.chromeframe).to be_truthy
+    it "is not considered to be in compatibility view" do
+      expect(useragent).not_to be_compatibility_view
     end
-
-    it "has a version" do
-      expect(@useragent.chromeframe.version).to eq("4.0")
-    end
-  end
-end
-
-describe "UserAgent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1;)")
-  end
-
-  it_behaves_like "Internet Explorer browser"
-
-  it "is not considered to be in compatibility view" do
-    expect(@useragent).not_to be_compatibility_view
   end
 end

--- a/spec/browsers/iron_user_agent_spec.rb
+++ b/spec/browsers/iron_user_agent_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples_for "Iron browser" do
-  it "should return 'Iron' as its browser" do
+  it "returns 'Iron' as its browser" do
     expect(@useragent.browser).to eq("Iron")
   end
 
-  it "should return a Version object for version" do
+  it "returns a Version object for version" do
     expect(@useragent.version).to be_a(UserAgent::Version)
   end
 end
@@ -17,17 +17,17 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHT
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4")
   end
 
-  it_should_behave_like "Iron browser"
+  it_behaves_like "Iron browser"
 
-  it "should return '22.0.1250.0' as its version" do
+  it "returns '22.0.1250.0' as its version" do
     expect(@useragent.version).to eq("22.0.1250.0")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 end
@@ -38,17 +38,17 @@ describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1")
   end
 
-  it_should_behave_like "Iron browser"
+  it_behaves_like "Iron browser"
 
-  it "should return '21.0.1200.0' as its version" do
+  it "returns '21.0.1200.0' as its version" do
     expect(@useragent.version).to eq("21.0.1200.0")
   end
 
-  it "should return 'X11' as its platform" do
+  it "returns 'X11' as its platform" do
     expect(@useragent.platform).to eq("X11")
   end
 
-  it "should return 'Linux amd' as its os" do
+  it "returns 'Linux amd' as its os" do
     expect(@useragent.os).to eq("Linux amd64")
   end
 end

--- a/spec/browsers/iron_user_agent_spec.rb
+++ b/spec/browsers/iron_user_agent_spec.rb
@@ -1,12 +1,12 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples_for 'Iron browser' do
+shared_examples_for "Iron browser" do
   it "should return 'Iron' as its browser" do
-    expect(@useragent.browser).to eq('Iron')
+    expect(@useragent.browser).to eq("Iron")
   end
 
-  it 'should return a Version object for version' do
+  it "should return a Version object for version" do
     expect(@useragent.version).to be_a(UserAgent::Version)
   end
 end
@@ -14,41 +14,41 @@ end
 # http://www.useragentstring.com/Iron22.0.2150.0_id_19368.php
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4")
   end
 
-  it_should_behave_like 'Iron browser'
+  it_should_behave_like "Iron browser"
 
   it "should return '22.0.1250.0' as its version" do
-    expect(@useragent.version).to eq('22.0.1250.0')
+    expect(@useragent.version).to eq("22.0.1250.0")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 end
 
 # http://www.useragentstring.com/Iron21.0.1200.0_id_19375.php
 describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1")
   end
 
-  it_should_behave_like 'Iron browser'
+  it_should_behave_like "Iron browser"
 
   it "should return '21.0.1200.0' as its version" do
-    expect(@useragent.version).to eq('21.0.1200.0')
+    expect(@useragent.version).to eq("21.0.1200.0")
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq('X11')
+    expect(@useragent.platform).to eq("X11")
   end
 
   it "should return 'Linux amd' as its os" do
-    expect(@useragent.os).to eq('Linux amd64')
+    expect(@useragent.os).to eq("Linux amd64")
   end
 end

--- a/spec/browsers/iron_user_agent_spec.rb
+++ b/spec/browsers/iron_user_agent_spec.rb
@@ -1,11 +1,12 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples_for "Iron browser" do
+shared_examples_for 'Iron browser' do
   it "should return 'Iron' as its browser" do
-    expect(@useragent.browser).to eq("Iron")
+    expect(@useragent.browser).to eq('Iron')
   end
 
-  it "should return a Version object for version" do
+  it 'should return a Version object for version' do
     expect(@useragent.version).to be_a(UserAgent::Version)
   end
 end
@@ -13,41 +14,41 @@ end
 # http://www.useragentstring.com/Iron22.0.2150.0_id_19368.php
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4')
   end
 
-  it_should_behave_like "Iron browser"
+  it_should_behave_like 'Iron browser'
 
   it "should return '22.0.1250.0' as its version" do
-    expect(@useragent.version).to eq("22.0.1250.0")
+    expect(@useragent.version).to eq('22.0.1250.0')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 end
 
 # http://www.useragentstring.com/Iron21.0.1200.0_id_19375.php
 describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1')
   end
 
-  it_should_behave_like "Iron browser"
+  it_should_behave_like 'Iron browser'
 
   it "should return '21.0.1200.0' as its version" do
-    expect(@useragent.version).to eq("21.0.1200.0")
+    expect(@useragent.version).to eq('21.0.1200.0')
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
+    expect(@useragent.platform).to eq('X11')
   end
 
   it "should return 'Linux amd' as its os" do
-    expect(@useragent.os).to eq("Linux amd64")
+    expect(@useragent.os).to eq('Linux amd64')
   end
 end

--- a/spec/browsers/iron_user_agent_spec.rb
+++ b/spec/browsers/iron_user_agent_spec.rb
@@ -3,52 +3,50 @@ require "user_agent"
 
 shared_examples_for "Iron browser" do
   it "returns 'Iron' as its browser" do
-    expect(@useragent.browser).to eq("Iron")
+    expect(useragent.browser).to eq("Iron")
   end
 
   it "returns a Version object for version" do
-    expect(@useragent.version).to be_a(UserAgent::Version)
+    expect(useragent.version).to be_a(UserAgent::Version)
   end
 end
 
-# http://www.useragentstring.com/Iron22.0.2150.0_id_19368.php
-describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4")
+describe UserAgent do
+  # http://www.useragentstring.com/Iron22.0.2150.0_id_19368.php
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1250.0 Iron/22.0.2150.0 Safari/537.4") }
+
+    it_behaves_like "Iron browser"
+
+    it "returns '22.0.1250.0' as its version" do
+      expect(useragent.version).to eq("22.0.1250.0")
+    end
+
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
   end
 
-  it_behaves_like "Iron browser"
+  # http://www.useragentstring.com/Iron21.0.1200.0_id_19375.php
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1") }
 
-  it "returns '22.0.1250.0' as its version" do
-    expect(@useragent.version).to eq("22.0.1250.0")
-  end
+    it_behaves_like "Iron browser"
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns '21.0.1200.0' as its version" do
+      expect(useragent.version).to eq("21.0.1200.0")
+    end
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
-end
+    it "returns 'X11' as its platform" do
+      expect(useragent.platform).to eq("X11")
+    end
 
-# http://www.useragentstring.com/Iron21.0.1200.0_id_19375.php
-describe "UserAgent: 'Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; Linux amd64) Iron/21.0.1200.0 Chrome/21.0.1200.0 Safari/537.1")
-  end
-
-  it_behaves_like "Iron browser"
-
-  it "returns '21.0.1200.0' as its version" do
-    expect(@useragent.version).to eq("21.0.1200.0")
-  end
-
-  it "returns 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
-  end
-
-  it "returns 'Linux amd' as its os" do
-    expect(@useragent.os).to eq("Linux amd64")
+    it "returns 'Linux amd' as its os" do
+      expect(useragent.os).to eq("Linux amd64")
+    end
   end
 end

--- a/spec/browsers/itunes_user_agent_spec.rb
+++ b/spec/browsers/itunes_user_agent_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples "iTunes" do
-  it "should return 'iTunes' as its browser" do
+  it "returns 'iTunes' as its browser" do
     expect(@useragent.browser).to eq("iTunes")
   end
 
-  it "should return nil as its security" do
+  it "returns nil as its security" do
     expect(@useragent.security).to be_nil
   end
 end
@@ -55,7 +55,7 @@ describe "UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25
   it_behaves_like "iTunes has WebKit build number", "0600.1.25"
 
   # this really only needs tested once since we're fixing the parse error for Windows only
-  it "should return 'OS X 10.10' as its full OS" do
+  it "returns 'OS X 10.10' as its full OS" do
     expect(@useragent.full_os).to eq("OS X 10.10")
   end
 end
@@ -70,7 +70,7 @@ describe "UserAgent: iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Ed
   it_behaves_like "iTunes has version number", "11.1.5"
   it_behaves_like "iTunes has WebKit build number", "537.60.15"
 
-  it "should return 'Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)' as its full OS" do
+  it "returns 'Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)' as its full OS" do
     expect(@useragent.full_os).to eq("Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)")
   end
 end
@@ -85,7 +85,7 @@ describe "UserAgent: iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premiu
   it_behaves_like "iTunes has version number", "12.0.1"
   it_behaves_like "iTunes has WebKit build number", "7600.1017.0.24"
 
-  it "should return 'Microsoft Windows 8 x64 Home Premium Edition (Build 9200)' as its full OS" do
+  it "returns 'Microsoft Windows 8 x64 Home Premium Edition (Build 9200)' as its full OS" do
     expect(@useragent.full_os).to eq("Microsoft Windows 8 x64 Home Premium Edition (Build 9200)")
   end
 end
@@ -109,15 +109,15 @@ describe "UserAgent: iTunes/9.1.1" do
   it_behaves_like "iTunes"
   it_behaves_like "iTunes has version number", "9.1.1"
 
-  it "should return nil for WebKit build number" do
+  it "returns nil for WebKit build number" do
     expect(@useragent.build).to be_nil
   end
 
-  it "should return nil for the OS" do
+  it "returns nil for the OS" do
     expect(@useragent.os).to be_nil
   end
 
-  it "should return nil for the platform" do
+  it "returns nil for the platform" do
     expect(@useragent.platform).to be_nil
   end
 end
@@ -130,15 +130,15 @@ describe "UserAgent: iTunes/10.7 Downcast/2.8.26.1005" do
   it_behaves_like "iTunes"
   it_behaves_like "iTunes has version number", "10.7"
 
-  it "should return nil for WebKit build number" do
+  it "returns nil for WebKit build number" do
     expect(@useragent.build).to be_nil
   end
 
-  it "should return nil for the OS" do
+  it "returns nil for the OS" do
     expect(@useragent.os).to be_nil
   end
 
-  it "should return nil for the platform" do
+  it "returns nil for the platform" do
     expect(@useragent.platform).to be_nil
   end
 end

--- a/spec/browsers/itunes_user_agent_spec.rb
+++ b/spec/browsers/itunes_user_agent_spec.rb
@@ -3,142 +3,130 @@ require "user_agent"
 
 shared_examples "iTunes" do
   it "returns 'iTunes' as its browser" do
-    expect(@useragent.browser).to eq("iTunes")
+    expect(useragent.browser).to eq("iTunes")
   end
 
   it "returns nil as its security" do
-    expect(@useragent.security).to be_nil
+    expect(useragent.security).to be_nil
   end
 end
 
 shared_examples "iTunes runs on" do |platform, os|
   it "should return '#{platform}' as its platform" do
-    expect(@useragent.platform).to eq(platform)
+    expect(useragent.platform).to eq(platform)
   end
 
   it "should return '#{os}' as its OS" do
-    expect(@useragent.os).to eq(os)
+    expect(useragent.os).to eq(os)
   end
 end
 
 shared_examples "iTunes has version number" do |version|
   it "should return '#{version}' as its version" do
-    expect(@useragent.version).to eq(version)
+    expect(useragent.version).to eq(version)
   end
 end
 
 shared_examples "iTunes has WebKit build number" do |version|
   it "should return '#{version}' as its WebKit build number" do
-    expect(@useragent.build).to eq(version)
+    expect(useragent.build).to eq(version)
   end
 end
 
-describe "UserAgent: iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11" do
-  before do
-    @useragent = UserAgent.parse("iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11")
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11") }
+
+    it_behaves_like "iTunes"
+    it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.7.3"
+    it_behaves_like "iTunes has version number", "10.6.1"
+    it_behaves_like "iTunes has WebKit build number", "534.53.11"
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.7.3"
-  it_behaves_like "iTunes has version number", "10.6.1"
-  it_behaves_like "iTunes has WebKit build number", "534.53.11"
-end
+  context do
+    let(:useragent) { described_class.parse("iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25") }
 
-describe "UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25" do
-  before do
-    @useragent = UserAgent.parse("iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25")
+    it_behaves_like "iTunes"
+    it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.10"
+    it_behaves_like "iTunes has version number", "12.0.1"
+    it_behaves_like "iTunes has WebKit build number", "0600.1.25"
+
+    # this really only needs tested once since we're fixing the parse error for Windows only
+    it "returns 'OS X 10.10' as its full OS" do
+      expect(useragent.full_os).to eq("OS X 10.10")
+    end
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.10"
-  it_behaves_like "iTunes has version number", "12.0.1"
-  it_behaves_like "iTunes has WebKit build number", "0600.1.25"
+  context do
+    let(:useragent) { described_class.parse("iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15") }
 
-  # this really only needs tested once since we're fixing the parse error for Windows only
-  it "returns 'OS X 10.10' as its full OS" do
-    expect(@useragent.full_os).to eq("OS X 10.10")
-  end
-end
+    it_behaves_like "iTunes"
+    it_behaves_like "iTunes runs on", "Windows", "Windows 7"
+    it_behaves_like "iTunes has version number", "11.1.5"
+    it_behaves_like "iTunes has WebKit build number", "537.60.15"
 
-describe "UserAgent: iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15" do
-  before do
-    @useragent = UserAgent.parse("iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15")
+    it "returns 'Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)' as its full OS" do
+      expect(useragent.full_os).to eq("Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)")
+    end
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Windows", "Windows 7"
-  it_behaves_like "iTunes has version number", "11.1.5"
-  it_behaves_like "iTunes has WebKit build number", "537.60.15"
+  context do
+    let(:useragent) { described_class.parse("iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24") }
 
-  it "returns 'Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)' as its full OS" do
-    expect(@useragent.full_os).to eq("Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)")
-  end
-end
+    it_behaves_like "iTunes"
+    it_behaves_like "iTunes runs on", "Windows", "Windows 8"
+    it_behaves_like "iTunes has version number", "12.0.1"
+    it_behaves_like "iTunes has WebKit build number", "7600.1017.0.24"
 
-describe "UserAgent: iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24" do
-  before do
-    @useragent = UserAgent.parse("iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24")
+    it "returns 'Microsoft Windows 8 x64 Home Premium Edition (Build 9200)' as its full OS" do
+      expect(useragent.full_os).to eq("Microsoft Windows 8 x64 Home Premium Edition (Build 9200)")
+    end
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Windows", "Windows 8"
-  it_behaves_like "iTunes has version number", "12.0.1"
-  it_behaves_like "iTunes has WebKit build number", "7600.1017.0.24"
+  context do
+    let(:useragent) { described_class.parse("iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25") }
 
-  it "returns 'Microsoft Windows 8 x64 Home Premium Edition (Build 9200)' as its full OS" do
-    expect(@useragent.full_os).to eq("Microsoft Windows 8 x64 Home Premium Edition (Build 9200)")
-  end
-end
-
-describe "UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25" do
-  before do
-    @useragent = UserAgent.parse("iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25")
+    it_behaves_like "iTunes"
+    it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.10.1"
+    it_behaves_like "iTunes has version number", "12.0.1"
+    it_behaves_like "iTunes has WebKit build number", "0600.1.25"
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.10.1"
-  it_behaves_like "iTunes has version number", "12.0.1"
-  it_behaves_like "iTunes has WebKit build number", "0600.1.25"
-end
+  context do
+    let(:useragent) { described_class.parse("iTunes/9.1.1") }
 
-describe "UserAgent: iTunes/9.1.1" do
-  before do
-    @useragent = UserAgent.parse("iTunes/9.1.1")
+    it_behaves_like "iTunes"
+    it_behaves_like "iTunes has version number", "9.1.1"
+
+    it "returns nil for WebKit build number" do
+      expect(useragent.build).to be_nil
+    end
+
+    it "returns nil for the OS" do
+      expect(useragent.os).to be_nil
+    end
+
+    it "returns nil for the platform" do
+      expect(useragent.platform).to be_nil
+    end
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes has version number", "9.1.1"
+  context do
+    let(:useragent) { described_class.parse("iTunes/10.7 Downcast/2.8.26.1005") }
 
-  it "returns nil for WebKit build number" do
-    expect(@useragent.build).to be_nil
-  end
+    it_behaves_like "iTunes"
+    it_behaves_like "iTunes has version number", "10.7"
 
-  it "returns nil for the OS" do
-    expect(@useragent.os).to be_nil
-  end
+    it "returns nil for WebKit build number" do
+      expect(useragent.build).to be_nil
+    end
 
-  it "returns nil for the platform" do
-    expect(@useragent.platform).to be_nil
-  end
-end
+    it "returns nil for the OS" do
+      expect(useragent.os).to be_nil
+    end
 
-describe "UserAgent: iTunes/10.7 Downcast/2.8.26.1005" do
-  before do
-    @useragent = UserAgent.parse("iTunes/10.7 Downcast/2.8.26.1005")
-  end
-
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes has version number", "10.7"
-
-  it "returns nil for WebKit build number" do
-    expect(@useragent.build).to be_nil
-  end
-
-  it "returns nil for the OS" do
-    expect(@useragent.os).to be_nil
-  end
-
-  it "returns nil for the platform" do
-    expect(@useragent.platform).to be_nil
+    it "returns nil for the platform" do
+      expect(useragent.platform).to be_nil
+    end
   end
 end

--- a/spec/browsers/itunes_user_agent_spec.rb
+++ b/spec/browsers/itunes_user_agent_spec.rb
@@ -1,16 +1,17 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples "iTunes" do
+shared_examples 'iTunes' do
   it "should return 'iTunes' as its browser" do
-    expect(@useragent.browser).to eq("iTunes")
+    expect(@useragent.browser).to eq('iTunes')
   end
 
-  it "should return nil as its security" do
+  it 'should return nil as its security' do
     expect(@useragent.security).to be_nil
   end
 end
 
-shared_examples "iTunes runs on" do |platform, os|
+shared_examples 'iTunes runs on' do |platform, os|
   it "should return '#{platform}' as its platform" do
     expect(@useragent.platform).to eq(platform)
   end
@@ -20,124 +21,124 @@ shared_examples "iTunes runs on" do |platform, os|
   end
 end
 
-shared_examples "iTunes has version number" do |version|
+shared_examples 'iTunes has version number' do |version|
   it "should return '#{version}' as its version" do
     expect(@useragent.version).to eq(version)
   end
 end
 
-shared_examples "iTunes has WebKit build number" do |version|
+shared_examples 'iTunes has WebKit build number' do |version|
   it "should return '#{version}' as its WebKit build number" do
     expect(@useragent.build).to eq(version)
   end
 end
 
-describe "UserAgent: iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11" do
+describe 'UserAgent: iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11' do
   before do
-    @useragent = UserAgent.parse("iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11")
+    @useragent = UserAgent.parse('iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11')
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.7.3"
-  it_behaves_like "iTunes has version number", "10.6.1"
-  it_behaves_like "iTunes has WebKit build number", "534.53.11"
+  it_behaves_like 'iTunes'
+  it_behaves_like 'iTunes runs on', 'Macintosh', 'OS X 10.7.3'
+  it_behaves_like 'iTunes has version number', '10.6.1'
+  it_behaves_like 'iTunes has WebKit build number', '534.53.11'
 end
 
-describe "UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25" do
+describe 'UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25' do
   before do
-    @useragent = UserAgent.parse("iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25")
+    @useragent = UserAgent.parse('iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25')
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.10"
-  it_behaves_like "iTunes has version number", "12.0.1"
-  it_behaves_like "iTunes has WebKit build number", "0600.1.25"
+  it_behaves_like 'iTunes'
+  it_behaves_like 'iTunes runs on', 'Macintosh', 'OS X 10.10'
+  it_behaves_like 'iTunes has version number', '12.0.1'
+  it_behaves_like 'iTunes has WebKit build number', '0600.1.25'
 
   # this really only needs tested once since we're fixing the parse error for Windows only
   it "should return 'OS X 10.10' as its full OS" do
-    expect(@useragent.full_os).to eq("OS X 10.10")
+    expect(@useragent.full_os).to eq('OS X 10.10')
   end
 end
 
-describe "UserAgent: iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15" do
+describe 'UserAgent: iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15' do
   before do
-    @useragent = UserAgent.parse("iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15")
+    @useragent = UserAgent.parse('iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15')
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Windows", "Windows 7"
-  it_behaves_like "iTunes has version number", "11.1.5"
-  it_behaves_like "iTunes has WebKit build number", "537.60.15"
+  it_behaves_like 'iTunes'
+  it_behaves_like 'iTunes runs on', 'Windows', 'Windows 7'
+  it_behaves_like 'iTunes has version number', '11.1.5'
+  it_behaves_like 'iTunes has WebKit build number', '537.60.15'
 
   it "should return 'Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)' as its full OS" do
-    expect(@useragent.full_os).to eq("Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)")
+    expect(@useragent.full_os).to eq('Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)')
   end
 end
 
-describe "UserAgent: iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24" do
+describe 'UserAgent: iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24' do
   before do
-    @useragent = UserAgent.parse("iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24")
+    @useragent = UserAgent.parse('iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24')
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Windows", "Windows 8"
-  it_behaves_like "iTunes has version number", "12.0.1"
-  it_behaves_like "iTunes has WebKit build number", "7600.1017.0.24"
+  it_behaves_like 'iTunes'
+  it_behaves_like 'iTunes runs on', 'Windows', 'Windows 8'
+  it_behaves_like 'iTunes has version number', '12.0.1'
+  it_behaves_like 'iTunes has WebKit build number', '7600.1017.0.24'
 
   it "should return 'Microsoft Windows 8 x64 Home Premium Edition (Build 9200)' as its full OS" do
-    expect(@useragent.full_os).to eq("Microsoft Windows 8 x64 Home Premium Edition (Build 9200)")
+    expect(@useragent.full_os).to eq('Microsoft Windows 8 x64 Home Premium Edition (Build 9200)')
   end
 end
 
-describe "UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25" do
+describe 'UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25' do
   before do
-    @useragent = UserAgent.parse("iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25")
+    @useragent = UserAgent.parse('iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25')
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.10.1"
-  it_behaves_like "iTunes has version number", "12.0.1"
-  it_behaves_like "iTunes has WebKit build number", "0600.1.25"
+  it_behaves_like 'iTunes'
+  it_behaves_like 'iTunes runs on', 'Macintosh', 'OS X 10.10.1'
+  it_behaves_like 'iTunes has version number', '12.0.1'
+  it_behaves_like 'iTunes has WebKit build number', '0600.1.25'
 end
 
-describe "UserAgent: iTunes/9.1.1" do
+describe 'UserAgent: iTunes/9.1.1' do
   before do
-    @useragent = UserAgent.parse("iTunes/9.1.1")
+    @useragent = UserAgent.parse('iTunes/9.1.1')
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes has version number", "9.1.1"
+  it_behaves_like 'iTunes'
+  it_behaves_like 'iTunes has version number', '9.1.1'
 
-  it "should return nil for WebKit build number" do
+  it 'should return nil for WebKit build number' do
     expect(@useragent.build).to be_nil
   end
 
-  it "should return nil for the OS" do
+  it 'should return nil for the OS' do
     expect(@useragent.os).to be_nil
   end
 
-  it "should return nil for the platform" do
+  it 'should return nil for the platform' do
     expect(@useragent.platform).to be_nil
   end
 end
 
-describe "UserAgent: iTunes/10.7 Downcast/2.8.26.1005" do
+describe 'UserAgent: iTunes/10.7 Downcast/2.8.26.1005' do
   before do
-    @useragent = UserAgent.parse("iTunes/10.7 Downcast/2.8.26.1005")
+    @useragent = UserAgent.parse('iTunes/10.7 Downcast/2.8.26.1005')
   end
 
-  it_behaves_like "iTunes"
-  it_behaves_like "iTunes has version number", "10.7"
+  it_behaves_like 'iTunes'
+  it_behaves_like 'iTunes has version number', '10.7'
 
-  it "should return nil for WebKit build number" do
+  it 'should return nil for WebKit build number' do
     expect(@useragent.build).to be_nil
   end
 
-  it "should return nil for the OS" do
+  it 'should return nil for the OS' do
     expect(@useragent.os).to be_nil
   end
 
-  it "should return nil for the platform" do
+  it 'should return nil for the platform' do
     expect(@useragent.platform).to be_nil
   end
 end

--- a/spec/browsers/itunes_user_agent_spec.rb
+++ b/spec/browsers/itunes_user_agent_spec.rb
@@ -1,17 +1,17 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples 'iTunes' do
+shared_examples "iTunes" do
   it "should return 'iTunes' as its browser" do
-    expect(@useragent.browser).to eq('iTunes')
+    expect(@useragent.browser).to eq("iTunes")
   end
 
-  it 'should return nil as its security' do
+  it "should return nil as its security" do
     expect(@useragent.security).to be_nil
   end
 end
 
-shared_examples 'iTunes runs on' do |platform, os|
+shared_examples "iTunes runs on" do |platform, os|
   it "should return '#{platform}' as its platform" do
     expect(@useragent.platform).to eq(platform)
   end
@@ -21,124 +21,124 @@ shared_examples 'iTunes runs on' do |platform, os|
   end
 end
 
-shared_examples 'iTunes has version number' do |version|
+shared_examples "iTunes has version number" do |version|
   it "should return '#{version}' as its version" do
     expect(@useragent.version).to eq(version)
   end
 end
 
-shared_examples 'iTunes has WebKit build number' do |version|
+shared_examples "iTunes has WebKit build number" do |version|
   it "should return '#{version}' as its WebKit build number" do
     expect(@useragent.build).to eq(version)
   end
 end
 
-describe 'UserAgent: iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11' do
+describe "UserAgent: iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11" do
   before do
-    @useragent = UserAgent.parse('iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11')
+    @useragent = UserAgent.parse("iTunes/10.6.1 (Macintosh; Intel Mac OS X 10.7.3) AppleWebKit/534.53.11")
   end
 
-  it_behaves_like 'iTunes'
-  it_behaves_like 'iTunes runs on', 'Macintosh', 'OS X 10.7.3'
-  it_behaves_like 'iTunes has version number', '10.6.1'
-  it_behaves_like 'iTunes has WebKit build number', '534.53.11'
+  it_behaves_like "iTunes"
+  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.7.3"
+  it_behaves_like "iTunes has version number", "10.6.1"
+  it_behaves_like "iTunes has WebKit build number", "534.53.11"
 end
 
-describe 'UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25' do
+describe "UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25" do
   before do
-    @useragent = UserAgent.parse('iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25')
+    @useragent = UserAgent.parse("iTunes/12.0.1 (Macintosh; OS X 10.10) AppleWebKit/0600.1.25")
   end
 
-  it_behaves_like 'iTunes'
-  it_behaves_like 'iTunes runs on', 'Macintosh', 'OS X 10.10'
-  it_behaves_like 'iTunes has version number', '12.0.1'
-  it_behaves_like 'iTunes has WebKit build number', '0600.1.25'
+  it_behaves_like "iTunes"
+  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.10"
+  it_behaves_like "iTunes has version number", "12.0.1"
+  it_behaves_like "iTunes has WebKit build number", "0600.1.25"
 
   # this really only needs tested once since we're fixing the parse error for Windows only
   it "should return 'OS X 10.10' as its full OS" do
-    expect(@useragent.full_os).to eq('OS X 10.10')
+    expect(@useragent.full_os).to eq("OS X 10.10")
   end
 end
 
-describe 'UserAgent: iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15' do
+describe "UserAgent: iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15" do
   before do
-    @useragent = UserAgent.parse('iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15')
+    @useragent = UserAgent.parse("iTunes/11.1.5 (Windows; Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)) AppleWebKit/537.60.15")
   end
 
-  it_behaves_like 'iTunes'
-  it_behaves_like 'iTunes runs on', 'Windows', 'Windows 7'
-  it_behaves_like 'iTunes has version number', '11.1.5'
-  it_behaves_like 'iTunes has WebKit build number', '537.60.15'
+  it_behaves_like "iTunes"
+  it_behaves_like "iTunes runs on", "Windows", "Windows 7"
+  it_behaves_like "iTunes has version number", "11.1.5"
+  it_behaves_like "iTunes has WebKit build number", "537.60.15"
 
   it "should return 'Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)' as its full OS" do
-    expect(@useragent.full_os).to eq('Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)')
+    expect(@useragent.full_os).to eq("Microsoft Windows 7 x64 Business Edition Service Pack 1 (Build 7601)")
   end
 end
 
-describe 'UserAgent: iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24' do
+describe "UserAgent: iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24" do
   before do
-    @useragent = UserAgent.parse('iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24')
+    @useragent = UserAgent.parse("iTunes/12.0.1 (Windows; Microsoft Windows 8 x64 Home Premium Edition (Build 9200)) AppleWebKit/7600.1017.0.24")
   end
 
-  it_behaves_like 'iTunes'
-  it_behaves_like 'iTunes runs on', 'Windows', 'Windows 8'
-  it_behaves_like 'iTunes has version number', '12.0.1'
-  it_behaves_like 'iTunes has WebKit build number', '7600.1017.0.24'
+  it_behaves_like "iTunes"
+  it_behaves_like "iTunes runs on", "Windows", "Windows 8"
+  it_behaves_like "iTunes has version number", "12.0.1"
+  it_behaves_like "iTunes has WebKit build number", "7600.1017.0.24"
 
   it "should return 'Microsoft Windows 8 x64 Home Premium Edition (Build 9200)' as its full OS" do
-    expect(@useragent.full_os).to eq('Microsoft Windows 8 x64 Home Premium Edition (Build 9200)')
+    expect(@useragent.full_os).to eq("Microsoft Windows 8 x64 Home Premium Edition (Build 9200)")
   end
 end
 
-describe 'UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25' do
+describe "UserAgent: iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25" do
   before do
-    @useragent = UserAgent.parse('iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25')
+    @useragent = UserAgent.parse("iTunes/12.0.1 (Macintosh; OS X 10.10.1) AppleWebKit/0600.1.25")
   end
 
-  it_behaves_like 'iTunes'
-  it_behaves_like 'iTunes runs on', 'Macintosh', 'OS X 10.10.1'
-  it_behaves_like 'iTunes has version number', '12.0.1'
-  it_behaves_like 'iTunes has WebKit build number', '0600.1.25'
+  it_behaves_like "iTunes"
+  it_behaves_like "iTunes runs on", "Macintosh", "OS X 10.10.1"
+  it_behaves_like "iTunes has version number", "12.0.1"
+  it_behaves_like "iTunes has WebKit build number", "0600.1.25"
 end
 
-describe 'UserAgent: iTunes/9.1.1' do
+describe "UserAgent: iTunes/9.1.1" do
   before do
-    @useragent = UserAgent.parse('iTunes/9.1.1')
+    @useragent = UserAgent.parse("iTunes/9.1.1")
   end
 
-  it_behaves_like 'iTunes'
-  it_behaves_like 'iTunes has version number', '9.1.1'
+  it_behaves_like "iTunes"
+  it_behaves_like "iTunes has version number", "9.1.1"
 
-  it 'should return nil for WebKit build number' do
+  it "should return nil for WebKit build number" do
     expect(@useragent.build).to be_nil
   end
 
-  it 'should return nil for the OS' do
+  it "should return nil for the OS" do
     expect(@useragent.os).to be_nil
   end
 
-  it 'should return nil for the platform' do
+  it "should return nil for the platform" do
     expect(@useragent.platform).to be_nil
   end
 end
 
-describe 'UserAgent: iTunes/10.7 Downcast/2.8.26.1005' do
+describe "UserAgent: iTunes/10.7 Downcast/2.8.26.1005" do
   before do
-    @useragent = UserAgent.parse('iTunes/10.7 Downcast/2.8.26.1005')
+    @useragent = UserAgent.parse("iTunes/10.7 Downcast/2.8.26.1005")
   end
 
-  it_behaves_like 'iTunes'
-  it_behaves_like 'iTunes has version number', '10.7'
+  it_behaves_like "iTunes"
+  it_behaves_like "iTunes has version number", "10.7"
 
-  it 'should return nil for WebKit build number' do
+  it "should return nil for WebKit build number" do
     expect(@useragent.build).to be_nil
   end
 
-  it 'should return nil for the OS' do
+  it "should return nil for the OS" do
     expect(@useragent.os).to be_nil
   end
 
-  it 'should return nil for the platform' do
+  it "should return nil for the platform" do
     expect(@useragent.platform).to be_nil
   end
 end

--- a/spec/browsers/libavformat_user_agent_spec.rb
+++ b/spec/browsers/libavformat_user_agent_spec.rb
@@ -2,15 +2,15 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples "libavformat" do
-  it "should return 'libavformat' as its browser" do
+  it "returns 'libavformat' as its browser" do
     expect(@useragent.browser).to eq("libavformat")
   end
 
-  it "should return nil as its OS" do
+  it "returns nil as its OS" do
     expect(@useragent.os).to be_nil
   end
 
-  it "should return nil as its platform" do
+  it "returns nil as its platform" do
     expect(@useragent.platform).to be_nil
   end
 end

--- a/spec/browsers/libavformat_user_agent_spec.rb
+++ b/spec/browsers/libavformat_user_agent_spec.rb
@@ -3,38 +3,36 @@ require "user_agent"
 
 shared_examples "libavformat" do
   it "returns 'libavformat' as its browser" do
-    expect(@useragent.browser).to eq("libavformat")
+    expect(useragent.browser).to eq("libavformat")
   end
 
   it "returns nil as its OS" do
-    expect(@useragent.os).to be_nil
+    expect(useragent.os).to be_nil
   end
 
   it "returns nil as its platform" do
-    expect(@useragent.platform).to be_nil
+    expect(useragent.platform).to be_nil
   end
 end
 
 shared_examples "libavformat has version number" do |version|
   it "should return '#{version}' as its version" do
-    expect(@useragent.version).to eq(version)
+    expect(useragent.version).to eq(version)
   end
 end
 
-describe "UserAgent: Lavf/56.4.101" do
-  before do
-    @useragent = UserAgent.parse("Lavf/56.4.101")
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Lavf/56.4.101") }
+
+    it_behaves_like "libavformat"
+    it_behaves_like "libavformat has version number", "56.4.101"
   end
 
-  it_behaves_like "libavformat"
-  it_behaves_like "libavformat has version number", "56.4.101"
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/4.1.0.3856") }
 
-describe "UserAgent: NSPlayer/4.1.0.3856" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/4.1.0.3856")
+    it_behaves_like "libavformat"
+    it_behaves_like "libavformat has version number", nil
   end
-
-  it_behaves_like "libavformat"
-  it_behaves_like "libavformat has version number", nil
 end

--- a/spec/browsers/libavformat_user_agent_spec.rb
+++ b/spec/browsers/libavformat_user_agent_spec.rb
@@ -1,40 +1,40 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples 'libavformat' do
+shared_examples "libavformat" do
   it "should return 'libavformat' as its browser" do
-    expect(@useragent.browser).to eq('libavformat')
+    expect(@useragent.browser).to eq("libavformat")
   end
 
-  it 'should return nil as its OS' do
+  it "should return nil as its OS" do
     expect(@useragent.os).to be_nil
   end
 
-  it 'should return nil as its platform' do
+  it "should return nil as its platform" do
     expect(@useragent.platform).to be_nil
   end
 end
 
-shared_examples 'libavformat has version number' do |version|
+shared_examples "libavformat has version number" do |version|
   it "should return '#{version}' as its version" do
     expect(@useragent.version).to eq(version)
   end
 end
 
-describe 'UserAgent: Lavf/56.4.101' do
+describe "UserAgent: Lavf/56.4.101" do
   before do
-    @useragent = UserAgent.parse('Lavf/56.4.101')
+    @useragent = UserAgent.parse("Lavf/56.4.101")
   end
 
-  it_behaves_like 'libavformat'
-  it_behaves_like 'libavformat has version number', '56.4.101'
+  it_behaves_like "libavformat"
+  it_behaves_like "libavformat has version number", "56.4.101"
 end
 
-describe 'UserAgent: NSPlayer/4.1.0.3856' do
+describe "UserAgent: NSPlayer/4.1.0.3856" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/4.1.0.3856')
+    @useragent = UserAgent.parse("NSPlayer/4.1.0.3856")
   end
 
-  it_behaves_like 'libavformat'
-  it_behaves_like 'libavformat has version number', nil
+  it_behaves_like "libavformat"
+  it_behaves_like "libavformat has version number", nil
 end

--- a/spec/browsers/libavformat_user_agent_spec.rb
+++ b/spec/browsers/libavformat_user_agent_spec.rb
@@ -1,39 +1,40 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples "libavformat" do
+shared_examples 'libavformat' do
   it "should return 'libavformat' as its browser" do
-    expect(@useragent.browser).to eq("libavformat")
+    expect(@useragent.browser).to eq('libavformat')
   end
 
-  it "should return nil as its OS" do
+  it 'should return nil as its OS' do
     expect(@useragent.os).to be_nil
   end
 
-  it "should return nil as its platform" do
+  it 'should return nil as its platform' do
     expect(@useragent.platform).to be_nil
   end
 end
 
-shared_examples "libavformat has version number" do |version|
+shared_examples 'libavformat has version number' do |version|
   it "should return '#{version}' as its version" do
     expect(@useragent.version).to eq(version)
   end
 end
 
-describe "UserAgent: Lavf/56.4.101" do
+describe 'UserAgent: Lavf/56.4.101' do
   before do
-    @useragent = UserAgent.parse("Lavf/56.4.101")
+    @useragent = UserAgent.parse('Lavf/56.4.101')
   end
 
-  it_behaves_like "libavformat"
-  it_behaves_like "libavformat has version number", "56.4.101"
+  it_behaves_like 'libavformat'
+  it_behaves_like 'libavformat has version number', '56.4.101'
 end
 
-describe "UserAgent: NSPlayer/4.1.0.3856" do
+describe 'UserAgent: NSPlayer/4.1.0.3856' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/4.1.0.3856")
+    @useragent = UserAgent.parse('NSPlayer/4.1.0.3856')
   end
 
-  it_behaves_like "libavformat"
-  it_behaves_like "libavformat has version number", nil
+  it_behaves_like 'libavformat'
+  it_behaves_like 'libavformat has version number', nil
 end

--- a/spec/browsers/opera_user_agent_spec.rb
+++ b/spec/browsers/opera_user_agent_spec.rb
@@ -1,11 +1,12 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples_for "Opera browser" do
+shared_examples_for 'Opera browser' do
   it "should return 'Opera' as its browser" do
-    expect(@useragent.browser).to eq("Opera")
+    expect(@useragent.browser).to eq('Opera')
   end
 
-  it "should return a Version object for version" do
+  it 'should return a Version object for version' do
     expect(@useragent.version).to be_a(UserAgent::Version)
   end
 end
@@ -13,141 +14,141 @@ end
 # http://www.useragentstring.com/Opera12.14_id_19612.php
 describe "UserAgent: 'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14")
+    @useragent = UserAgent.parse('Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '12.14' as its version" do
-    expect(@useragent.version).to eq("12.14")
+    expect(@useragent.version).to eq('12.14')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq("Windows Vista")
+    expect(@useragent.os).to eq('Windows Vista')
   end
 end
 
 describe "UserAgent: 'Opera/9.27 (Macintosh; Intel Mac OS X; U; en)'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.27 (Macintosh; Intel Mac OS X; U; en)")
+    @useragent = UserAgent.parse('Opera/9.27 (Macintosh; Intel Mac OS X; U; en)')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '9.27' as its version" do
-    expect(@useragent.version).to eq("9.27")
+    expect(@useragent.version).to eq('9.27')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'Intel Mac OS X' as its os" do
-    expect(@useragent.os).to eq("Intel Mac OS X")
+    expect(@useragent.os).to eq('Intel Mac OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
 describe "UserAgent: 'Opera/9.27 (Windows NT 5.1; U; en)'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.27 (Windows NT 5.1; U; en)")
+    @useragent = UserAgent.parse('Opera/9.27 (Windows NT 5.1; U; en)')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '9.27' as its version" do
-    expect(@useragent.version).to eq("9.27")
+    expect(@useragent.version).to eq('9.27')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
 describe "UserAgent: 'Opera/9.80'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.80")
+    @useragent = UserAgent.parse('Opera/9.80')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '9.80' as its version" do
-    expect(@useragent.version).to eq("9.80")
+    expect(@useragent.version).to eq('9.80')
   end
 
-  it "should return nil as its platform" do
+  it 'should return nil as its platform' do
     expect(@useragent.platform).to be_nil
   end
 
-  it "should return nil as its os" do
+  it 'should return nil as its os' do
     expect(@useragent.os).to be_nil
   end
 
-  it "should return nil as its localization" do
+  it 'should return nil as its localization' do
     expect(@useragent.localization).to be_nil
   end
 end
 
 describe "UserAgent: 'Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10")
+    @useragent = UserAgent.parse('Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '10.10' as its version" do
-    expect(@useragent.version).to eq("10.10")
+    expect(@useragent.version).to eq('10.10')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'Intel Mac OS X' as its os" do
-    expect(@useragent.os).to eq("Intel Mac OS X")
+    expect(@useragent.os).to eq('Intel Mac OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
 describe "UserAgent: 'Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10")
+    @useragent = UserAgent.parse('Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '10.10' as its version" do
-    expect(@useragent.version).to eq("10.10")
+    expect(@useragent.version).to eq('10.10')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq("Windows Vista")
+    expect(@useragent.os).to eq('Windows Vista')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
@@ -156,17 +157,17 @@ describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0;
     @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'")
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it { expect(@useragent).to be_mobile }
 end
 
 describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54")
+    @useragent = UserAgent.parse('Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it { expect(@useragent).to be_mobile }
 end
@@ -174,49 +175,49 @@ end
 # http://www.useragentstring.com/Opera%20Mini9.80_id_17936.php
 describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54")
+    @useragent = UserAgent.parse('Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '9.80' as its version" do
-    expect(@useragent.version).to eq("9.80")
+    expect(@useragent.version).to eq('9.80')
   end
 end
 
 # http://www.useragentstring.com/Opera%20Mini7.1.32694_id_19147.php
 describe "UserAgent: 'Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10'" do
   before do
-    @useragent = UserAgent.parse("Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10")
+    @useragent = UserAgent.parse('Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '7.1.32694' as its version" do
-    expect(@useragent.version).to eq("7.1.32694")
+    expect(@useragent.version).to eq('7.1.32694')
   end
 end
 
-describe "Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485" do
+describe 'Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485' do
   before do
-    @useragent = UserAgent.parse("Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485")
+    @useragent = UserAgent.parse('Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '6.0.3' as its version" do
-    expect(@useragent.version).to eq("6.0.3")
+    expect(@useragent.version).to eq('6.0.3')
   end
 end
 
-describe "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48" do
+describe 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48')
   end
 
-  it_should_behave_like "Opera browser"
+  it_should_behave_like 'Opera browser'
 
   it "should return '28.0.1750.48' as it's version" do
-    expect(@useragent.version).to eq("28.0.1750.48")
+    expect(@useragent.version).to eq('28.0.1750.48')
   end
 end

--- a/spec/browsers/opera_user_agent_spec.rb
+++ b/spec/browsers/opera_user_agent_spec.rb
@@ -3,237 +3,215 @@ require "user_agent"
 
 shared_examples_for "Opera browser" do
   it "returns 'Opera' as its browser" do
-    expect(@useragent.browser).to eq("Opera")
+    expect(useragent.browser).to eq("Opera")
   end
 
   it "returns a Version object for version" do
-    expect(@useragent.version).to be_a(UserAgent::Version)
+    expect(useragent.version).to be_a(UserAgent::Version)
   end
 end
 
-# http://www.useragentstring.com/Opera12.14_id_19612.php
-describe "UserAgent: 'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14")
+describe UserAgent do
+  # http://www.useragentstring.com/Opera12.14_id_19612.php
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14") }
+
+    it_behaves_like "Opera browser"
+
+    it "returns '12.14' as its version" do
+      expect(useragent.version).to eq("12.14")
+    end
+
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
+
+    it "returns 'Windows Vista' as its os" do
+      expect(useragent.os).to eq("Windows Vista")
+    end
+
+    it "returns nil as its security" do
+      expect(useragent.security).to eq(nil)
+    end
   end
 
-  it_behaves_like "Opera browser"
+  context do
+    let(:useragent) { described_class.parse("Opera/9.27 (Macintosh; Intel Mac OS X; U; en)") }
 
-  it "returns '12.14' as its version" do
-    expect(@useragent.version).to eq("12.14")
+    it_behaves_like "Opera browser"
+
+    it "returns '9.27' as its version" do
+      expect(useragent.version).to eq("9.27")
+    end
+
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
+
+    it "returns 'Intel Mac OS X' as its os" do
+      expect(useragent.os).to eq("Intel Mac OS X")
+    end
+
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
+
+    it "returns strong as its security" do
+      expect(useragent.security).to eq(:strong)
+    end
   end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+  context do
+    let(:useragent) { described_class.parse("Opera/9.27 (Windows NT 5.1; U; en)") }
+
+    it_behaves_like "Opera browser"
+
+    it "returns '9.27' as its version" do
+      expect(useragent.version).to eq("9.27")
+    end
+
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
+
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
+
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq("Windows Vista")
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80") }
+
+    it_behaves_like "Opera browser"
+
+    it "returns '9.80' as its version" do
+      expect(useragent.version).to eq("9.80")
+    end
+
+    it "returns nil as its platform" do
+      expect(useragent.platform).to be_nil
+    end
+
+    it "returns nil as its os" do
+      expect(useragent.os).to be_nil
+    end
+
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
+
+    it "returns strong as its security" do
+      expect(useragent.security).to eq(:strong)
+    end
   end
 
-  it "returns nil as its security" do
-    expect(@useragent.security).to eq(nil)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10") }
 
-describe "UserAgent: 'Opera/9.27 (Macintosh; Intel Mac OS X; U; en)'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.27 (Macintosh; Intel Mac OS X; U; en)")
-  end
+    it_behaves_like "Opera browser"
 
-  it_behaves_like "Opera browser"
+    it "returns '10.10' as its version" do
+      expect(useragent.version).to eq("10.10")
+    end
 
-  it "returns '9.27' as its version" do
-    expect(@useragent.version).to eq("9.27")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'Intel Mac OS X' as its os" do
+      expect(useragent.os).to eq("Intel Mac OS X")
+    end
 
-  it "returns 'Intel Mac OS X' as its os" do
-    expect(@useragent.os).to eq("Intel Mac OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10") }
+
+    it_behaves_like "Opera browser"
+
+    it "returns '10.10' as its version" do
+      expect(useragent.version).to eq("10.10")
+    end
+
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
+
+    it "returns 'Windows Vista' as its os" do
+      expect(useragent.os).to eq("Windows Vista")
+    end
+
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns strong as its security" do
-    expect(@useragent.security).to eq(:strong)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'") }
 
-describe "UserAgent: 'Opera/9.27 (Windows NT 5.1; U; en)'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.27 (Windows NT 5.1; U; en)")
-  end
+    it_behaves_like "Opera browser"
 
-  it_behaves_like "Opera browser"
+    it { expect(useragent).to be_mobile }
 
-  it "returns '9.27' as its version" do
-    expect(@useragent.version).to eq("9.27")
+    it "returns strong as its security" do
+      expect(useragent.security).to eq(:strong)
+    end
   end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54") }
+
+    it_behaves_like "Opera browser"
+
+    it { expect(useragent).to be_mobile }
   end
 
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+  # http://www.useragentstring.com/Opera%20Mini9.80_id_17936.php
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54") }
+
+    it_behaves_like "Opera browser"
+
+    it "returns '9.80' as its version" do
+      expect(useragent.version).to eq("9.80")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
+  # http://www.useragentstring.com/Opera%20Mini7.1.32694_id_19147.php
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10") }
 
-describe "UserAgent: 'Opera/9.80'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80")
-  end
+    it_behaves_like "Opera browser"
 
-  it_behaves_like "Opera browser"
-
-  it "returns '9.80' as its version" do
-    expect(@useragent.version).to eq("9.80")
+    it "returns '7.1.32694' as its version" do
+      expect(useragent.version).to eq("7.1.32694")
+    end
   end
 
-  it "returns nil as its platform" do
-    expect(@useragent.platform).to be_nil
+  context do
+    let(:useragent) { described_class.parse("Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485") }
+
+    it_behaves_like "Opera browser"
+
+    it "returns '6.0.3' as its version" do
+      expect(useragent.version).to eq("6.0.3")
+    end
   end
 
-  it "returns nil as its os" do
-    expect(@useragent.os).to be_nil
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48") }
 
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
-  end
+    it_behaves_like "Opera browser"
 
-  it "returns strong as its security" do
-    expect(@useragent.security).to eq(:strong)
-  end
-end
-
-describe "UserAgent: 'Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10")
-  end
-
-  it_behaves_like "Opera browser"
-
-  it "returns '10.10' as its version" do
-    expect(@useragent.version).to eq("10.10")
-  end
-
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
-
-  it "returns 'Intel Mac OS X' as its os" do
-    expect(@useragent.os).to eq("Intel Mac OS X")
-  end
-
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
-
-describe "UserAgent: 'Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10")
-  end
-
-  it_behaves_like "Opera browser"
-
-  it "returns '10.10' as its version" do
-    expect(@useragent.version).to eq("10.10")
-  end
-
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
-
-  it "returns 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq("Windows Vista")
-  end
-
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
-
-describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'")
-  end
-
-  it_behaves_like "Opera browser"
-
-  it { expect(@useragent).to be_mobile }
-
-  it "returns strong as its security" do
-    expect(@useragent.security).to eq(:strong)
-  end
-end
-
-describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54")
-  end
-
-  it_behaves_like "Opera browser"
-
-  it { expect(@useragent).to be_mobile }
-end
-
-# http://www.useragentstring.com/Opera%20Mini9.80_id_17936.php
-describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54")
-  end
-
-  it_behaves_like "Opera browser"
-
-  it "returns '9.80' as its version" do
-    expect(@useragent.version).to eq("9.80")
-  end
-end
-
-# http://www.useragentstring.com/Opera%20Mini7.1.32694_id_19147.php
-describe "UserAgent: 'Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10'" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10")
-  end
-
-  it_behaves_like "Opera browser"
-
-  it "returns '7.1.32694' as its version" do
-    expect(@useragent.version).to eq("7.1.32694")
-  end
-end
-
-describe "Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485" do
-  before do
-    @useragent = UserAgent.parse("Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485")
-  end
-
-  it_behaves_like "Opera browser"
-
-  it "returns '6.0.3' as its version" do
-    expect(@useragent.version).to eq("6.0.3")
-  end
-end
-
-describe "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48")
-  end
-
-  it_behaves_like "Opera browser"
-
-  it "returns '28.0.1750.48' as it's version" do
-    expect(@useragent.version).to eq("28.0.1750.48")
+    it "returns '28.0.1750.48' as it's version" do
+      expect(useragent.version).to eq("28.0.1750.48")
+    end
   end
 end

--- a/spec/browsers/opera_user_agent_spec.rb
+++ b/spec/browsers/opera_user_agent_spec.rb
@@ -1,12 +1,12 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples_for 'Opera browser' do
+shared_examples_for "Opera browser" do
   it "should return 'Opera' as its browser" do
-    expect(@useragent.browser).to eq('Opera')
+    expect(@useragent.browser).to eq("Opera")
   end
 
-  it 'should return a Version object for version' do
+  it "should return a Version object for version" do
     expect(@useragent.version).to be_a(UserAgent::Version)
   end
 end
@@ -14,141 +14,141 @@ end
 # http://www.useragentstring.com/Opera12.14_id_19612.php
 describe "UserAgent: 'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14')
+    @useragent = UserAgent.parse("Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '12.14' as its version" do
-    expect(@useragent.version).to eq('12.14')
+    expect(@useragent.version).to eq("12.14")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq('Windows Vista')
+    expect(@useragent.os).to eq("Windows Vista")
   end
 end
 
 describe "UserAgent: 'Opera/9.27 (Macintosh; Intel Mac OS X; U; en)'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.27 (Macintosh; Intel Mac OS X; U; en)')
+    @useragent = UserAgent.parse("Opera/9.27 (Macintosh; Intel Mac OS X; U; en)")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '9.27' as its version" do
-    expect(@useragent.version).to eq('9.27')
+    expect(@useragent.version).to eq("9.27")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'Intel Mac OS X' as its os" do
-    expect(@useragent.os).to eq('Intel Mac OS X')
+    expect(@useragent.os).to eq("Intel Mac OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
 describe "UserAgent: 'Opera/9.27 (Windows NT 5.1; U; en)'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.27 (Windows NT 5.1; U; en)')
+    @useragent = UserAgent.parse("Opera/9.27 (Windows NT 5.1; U; en)")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '9.27' as its version" do
-    expect(@useragent.version).to eq('9.27')
+    expect(@useragent.version).to eq("9.27")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
 describe "UserAgent: 'Opera/9.80'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.80')
+    @useragent = UserAgent.parse("Opera/9.80")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '9.80' as its version" do
-    expect(@useragent.version).to eq('9.80')
+    expect(@useragent.version).to eq("9.80")
   end
 
-  it 'should return nil as its platform' do
+  it "should return nil as its platform" do
     expect(@useragent.platform).to be_nil
   end
 
-  it 'should return nil as its os' do
+  it "should return nil as its os" do
     expect(@useragent.os).to be_nil
   end
 
-  it 'should return nil as its localization' do
+  it "should return nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
 
 describe "UserAgent: 'Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10')
+    @useragent = UserAgent.parse("Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '10.10' as its version" do
-    expect(@useragent.version).to eq('10.10')
+    expect(@useragent.version).to eq("10.10")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'Intel Mac OS X' as its os" do
-    expect(@useragent.os).to eq('Intel Mac OS X')
+    expect(@useragent.os).to eq("Intel Mac OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
 describe "UserAgent: 'Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10')
+    @useragent = UserAgent.parse("Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '10.10' as its version" do
-    expect(@useragent.version).to eq('10.10')
+    expect(@useragent.version).to eq("10.10")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows Vista' as its os" do
-    expect(@useragent.os).to eq('Windows Vista')
+    expect(@useragent.os).to eq("Windows Vista")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
@@ -157,17 +157,17 @@ describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0;
     @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it { expect(@useragent).to be_mobile }
 end
 
 describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54')
+    @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it { expect(@useragent).to be_mobile }
 end
@@ -175,49 +175,49 @@ end
 # http://www.useragentstring.com/Opera%20Mini9.80_id_17936.php
 describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54')
+    @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '9.80' as its version" do
-    expect(@useragent.version).to eq('9.80')
+    expect(@useragent.version).to eq("9.80")
   end
 end
 
 # http://www.useragentstring.com/Opera%20Mini7.1.32694_id_19147.php
 describe "UserAgent: 'Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10'" do
   before do
-    @useragent = UserAgent.parse('Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10')
+    @useragent = UserAgent.parse("Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '7.1.32694' as its version" do
-    expect(@useragent.version).to eq('7.1.32694')
+    expect(@useragent.version).to eq("7.1.32694")
   end
 end
 
-describe 'Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485' do
+describe "Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485" do
   before do
-    @useragent = UserAgent.parse('Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485')
+    @useragent = UserAgent.parse("Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '6.0.3' as its version" do
-    expect(@useragent.version).to eq('6.0.3')
+    expect(@useragent.version).to eq("6.0.3")
   end
 end
 
-describe 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48' do
+describe "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48")
   end
 
-  it_should_behave_like 'Opera browser'
+  it_should_behave_like "Opera browser"
 
   it "should return '28.0.1750.48' as it's version" do
-    expect(@useragent.version).to eq('28.0.1750.48')
+    expect(@useragent.version).to eq("28.0.1750.48")
   end
 end

--- a/spec/browsers/opera_user_agent_spec.rb
+++ b/spec/browsers/opera_user_agent_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples_for "Opera browser" do
-  it "should return 'Opera' as its browser" do
+  it "returns 'Opera' as its browser" do
     expect(@useragent.browser).to eq("Opera")
   end
 
-  it "should return a Version object for version" do
+  it "returns a Version object for version" do
     expect(@useragent.version).to be_a(UserAgent::Version)
   end
 end
@@ -17,18 +17,22 @@ describe "UserAgent: 'Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14'
     @useragent = UserAgent.parse("Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '12.14' as its version" do
+  it "returns '12.14' as its version" do
     expect(@useragent.version).to eq("12.14")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows Vista' as its os" do
+  it "returns 'Windows Vista' as its os" do
     expect(@useragent.os).to eq("Windows Vista")
+  end
+
+  it "returns nil as its security" do
+    expect(@useragent.security).to eq(nil)
   end
 end
 
@@ -37,22 +41,26 @@ describe "UserAgent: 'Opera/9.27 (Macintosh; Intel Mac OS X; U; en)'" do
     @useragent = UserAgent.parse("Opera/9.27 (Macintosh; Intel Mac OS X; U; en)")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '9.27' as its version" do
+  it "returns '9.27' as its version" do
     expect(@useragent.version).to eq("9.27")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'Intel Mac OS X' as its os" do
+  it "returns 'Intel Mac OS X' as its os" do
     expect(@useragent.os).to eq("Intel Mac OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
+  end
+
+  it "returns strong as its security" do
+    expect(@useragent.security).to eq(:strong)
   end
 end
 
@@ -61,21 +69,21 @@ describe "UserAgent: 'Opera/9.27 (Windows NT 5.1; U; en)'" do
     @useragent = UserAgent.parse("Opera/9.27 (Windows NT 5.1; U; en)")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '9.27' as its version" do
+  it "returns '9.27' as its version" do
     expect(@useragent.version).to eq("9.27")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -85,22 +93,26 @@ describe "UserAgent: 'Opera/9.80'" do
     @useragent = UserAgent.parse("Opera/9.80")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '9.80' as its version" do
+  it "returns '9.80' as its version" do
     expect(@useragent.version).to eq("9.80")
   end
 
-  it "should return nil as its platform" do
+  it "returns nil as its platform" do
     expect(@useragent.platform).to be_nil
   end
 
-  it "should return nil as its os" do
+  it "returns nil as its os" do
     expect(@useragent.os).to be_nil
   end
 
-  it "should return nil as its localization" do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
+  end
+
+  it "returns strong as its security" do
+    expect(@useragent.security).to eq(:strong)
   end
 end
 
@@ -109,21 +121,21 @@ describe "UserAgent: 'Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.1
     @useragent = UserAgent.parse("Opera/9.80 (Macintosh; Intel Mac OS X; U; en) Presto/2.2.15 Version/10.10")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '10.10' as its version" do
+  it "returns '10.10' as its version" do
     expect(@useragent.version).to eq("10.10")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'Intel Mac OS X' as its os" do
+  it "returns 'Intel Mac OS X' as its os" do
     expect(@useragent.os).to eq("Intel Mac OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -133,21 +145,21 @@ describe "UserAgent: 'Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/1
     @useragent = UserAgent.parse("Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.15 Version/10.10")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '10.10' as its version" do
+  it "returns '10.10' as its version" do
     expect(@useragent.version).to eq("10.10")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows Vista' as its os" do
+  it "returns 'Windows Vista' as its os" do
     expect(@useragent.os).to eq("Windows Vista")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -157,9 +169,13 @@ describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0;
     @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9 (Compatible; MSIE:9.0; iPhone; BlackBerry9700; AppleWebKit/24.746; U; en) Presto/2.5.25 Version/10.54'")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
   it { expect(@useragent).to be_mobile }
+
+  it "returns strong as its security" do
+    expect(@useragent.security).to eq(:strong)
+  end
 end
 
 describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54'" do
@@ -167,7 +183,7 @@ describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en
     @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (J2ME/23.377; U; en) Presto/2.5.25 Version/10.54")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
   it { expect(@useragent).to be_mobile }
 end
@@ -178,9 +194,9 @@ describe "UserAgent: 'Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera
     @useragent = UserAgent.parse("Opera/9.80 (J2ME/MIDP; Opera Mini/9.80 (S60; SymbOS; Opera Mobi/23.348; U; en) Presto/2.5.25 Version/10.54")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '9.80' as its version" do
+  it "returns '9.80' as its version" do
     expect(@useragent.version).to eq("9.80")
   end
 end
@@ -191,9 +207,9 @@ describe "UserAgent: 'Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) P
     @useragent = UserAgent.parse("Opera/9.80 (iPhone; Opera Mini/7.1.32694/27.1407; U; en) Presto/2.8.119 Version/11.10")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '7.1.32694' as its version" do
+  it "returns '7.1.32694' as its version" do
     expect(@useragent.version).to eq("7.1.32694")
   end
 end
@@ -203,9 +219,9 @@ describe "Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320
     @useragent = UserAgent.parse("Opera/9.80 (BREW Opera Mini/6.0.3/27.2354 U es) Presto/2.8.119 240X320 Samsung SCH-U485")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '6.0.3' as its version" do
+  it "returns '6.0.3' as its version" do
     expect(@useragent.version).to eq("6.0.3")
   end
 end
@@ -215,9 +231,9 @@ describe "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.89 Safari/537.36 OPR/28.0.1750.48")
   end
 
-  it_should_behave_like "Opera browser"
+  it_behaves_like "Opera browser"
 
-  it "should return '28.0.1750.48' as it's version" do
+  it "returns '28.0.1750.48' as it's version" do
     expect(@useragent.version).to eq("28.0.1750.48")
   end
 end

--- a/spec/browsers/other_user_agent_spec.rb
+++ b/spec/browsers/other_user_agent_spec.rb
@@ -6,19 +6,19 @@ describe "UserAgent: nil" do
     @useragent = UserAgent.parse(nil)
   end
 
-  it "should return 'Mozilla' as its browser" do
+  it "returns 'Mozilla' as its browser" do
     expect(@useragent.browser).to eq("Mozilla")
   end
 
-  it "should return '4.0' as its version" do
+  it "returns '4.0' as its version" do
     expect(@useragent.version).to eq("4.0")
   end
 
-  it "should return nil as its platform" do
+  it "returns nil as its platform" do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it "should return nil as its os" do
+  it "returns nil as its os" do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -31,19 +31,19 @@ describe "UserAgent: ''" do
     @useragent = UserAgent.parse("")
   end
 
-  it "should return 'Mozilla' as its browser" do
+  it "returns 'Mozilla' as its browser" do
     expect(@useragent.browser).to eq("Mozilla")
   end
 
-  it "should return '4.0' as its version" do
+  it "returns '4.0' as its version" do
     expect(@useragent.version).to eq("4.0")
   end
 
-  it "should return nil as its platform" do
+  it "returns nil as its platform" do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it "should return nil as its os" do
+  it "returns nil as its os" do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -56,19 +56,19 @@ describe "UserAgent: 'Mozilla/4.0 (compatible)'" do
     @useragent = UserAgent.parse("Mozilla/4.0 (compatible)")
   end
 
-  it "should return 'Mozilla' as its browser" do
+  it "returns 'Mozilla' as its browser" do
     expect(@useragent.browser).to eq("Mozilla")
   end
 
-  it "should return '4.0' as its version" do
+  it "returns '4.0' as its version" do
     expect(@useragent.version).to eq("4.0")
   end
 
-  it "should return nil as its platform" do
+  it "returns nil as its platform" do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it "should return nil as its os" do
+  it "returns nil as its os" do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -81,19 +81,19 @@ describe "UserAgent: 'Mozilla/5.0'" do
     @useragent = UserAgent.parse("Mozilla/5.0")
   end
 
-  it "should return 'Mozilla' as its browser" do
+  it "returns 'Mozilla' as its browser" do
     expect(@useragent.browser).to eq("Mozilla")
   end
 
-  it "should return '5.0' as its version" do
+  it "returns '5.0' as its version" do
     expect(@useragent.version).to eq("5.0")
   end
 
-  it "should return nil as its platform" do
+  it "returns nil as its platform" do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it "should return nil as its os" do
+  it "returns nil as its os" do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -106,15 +106,15 @@ describe "UserAgent: 'amaya/9.51 libwww/5.4.0'" do
     @useragent = UserAgent.parse("amaya/9.51 libwww/5.4.0")
   end
 
-  it "should return 'amaya' as its browser" do
+  it "returns 'amaya' as its browser" do
     expect(@useragent.browser).to eq("amaya")
   end
 
-  it "should return '9.51' as its version" do
+  it "returns '9.51' as its version" do
     expect(@useragent.version).to eq("9.51")
   end
 
-  it "should return '5.4.0' as its libwww version" do
+  it "returns '5.4.0' as its libwww version" do
     expect(@useragent.libwww.version).to eq("5.4.0")
   end
 end
@@ -124,7 +124,7 @@ describe "UserAgent: 'Rails Testing'" do
     @useragent = UserAgent.parse("Rails Testing")
   end
 
-  it "should return 'Rails' as its browser" do
+  it "returns 'Rails' as its browser" do
     expect(@useragent.browser).to eq("Rails")
   end
 
@@ -139,11 +139,11 @@ describe "UserAgent: 'Python-urllib/2.7'" do
     @useragent = UserAgent.parse("Python-urllib/2.7")
   end
 
-  it "should return 'Python-urllib' as its browser" do
+  it "returns 'Python-urllib' as its browser" do
     expect(@useragent.browser).to eq("Python-urllib")
   end
 
-  it "should return '2.7' as its version" do
+  it "returns '2.7' as its version" do
     expect(@useragent.version).to eq("2.7")
   end
 
@@ -157,11 +157,11 @@ describe "UserAgent: 'check_http/v1.4.15 (nagios-plugins 1.4.15)'" do
     @useragent = UserAgent.parse("check_http/v1.4.15 (nagios-plugins 1.4.15)")
   end
 
-  it "should return 'check_http' as its browser" do
+  it "returns 'check_http' as its browser" do
     expect(@useragent.browser).to eq("check_http")
   end
 
-  it "should return 'v1.4.15' as its version" do
+  it "returns 'v1.4.15' as its version" do
     expect(@useragent.version).to eq("v1.4.15")
   end
 
@@ -175,7 +175,7 @@ describe "UserAgent: '/WebTest.pm'" do
     @useragent = UserAgent.parse("/WebTest.pm")
   end
 
-  it "should return nil as its browser" do
+  it "returns nil as its browser" do
     expect(@useragent.browser).to eq(nil)
   end
 end

--- a/spec/browsers/other_user_agent_spec.rb
+++ b/spec/browsers/other_user_agent_spec.rb
@@ -1,181 +1,165 @@
 require "spec_helper"
 require "user_agent"
 
-describe "UserAgent: nil" do
-  before do
-    @useragent = UserAgent.parse(nil)
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse(nil) }
+
+    it "returns 'Mozilla' as its browser" do
+      expect(useragent.browser).to eq("Mozilla")
+    end
+
+    it "returns '4.0' as its version" do
+      expect(useragent.version).to eq("4.0")
+    end
+
+    it "returns nil as its platform" do
+      expect(useragent.platform).to eq(nil)
+    end
+
+    it "returns nil as its os" do
+      expect(useragent.os).to eq(nil)
+    end
+
+    it { expect(useragent).not_to be_mobile }
+    it { expect(useragent).not_to be_bot }
   end
 
-  it "returns 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq("Mozilla")
+  context do
+    let(:useragent) { described_class.parse("") }
+
+    it "returns 'Mozilla' as its browser" do
+      expect(useragent.browser).to eq("Mozilla")
+    end
+
+    it "returns '4.0' as its version" do
+      expect(useragent.version).to eq("4.0")
+    end
+
+    it "returns nil as its platform" do
+      expect(useragent.platform).to eq(nil)
+    end
+
+    it "returns nil as its os" do
+      expect(useragent.os).to eq(nil)
+    end
+
+    it { expect(useragent).not_to be_mobile }
+    it { expect(useragent).not_to be_bot }
   end
 
-  it "returns '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
+  context do
+    let(:useragent) { described_class.parse("Mozilla/4.0 (compatible)") }
+
+    it "returns 'Mozilla' as its browser" do
+      expect(useragent.browser).to eq("Mozilla")
+    end
+
+    it "returns '4.0' as its version" do
+      expect(useragent.version).to eq("4.0")
+    end
+
+    it "returns nil as its platform" do
+      expect(useragent.platform).to eq(nil)
+    end
+
+    it "returns nil as its os" do
+      expect(useragent.os).to eq(nil)
+    end
+
+    it { expect(useragent).not_to be_mobile }
+    it { expect(useragent).not_to be_bot }
   end
 
-  it "returns nil as its platform" do
-    expect(@useragent.platform).to eq(nil)
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0") }
+
+    it "returns 'Mozilla' as its browser" do
+      expect(useragent.browser).to eq("Mozilla")
+    end
+
+    it "returns '5.0' as its version" do
+      expect(useragent.version).to eq("5.0")
+    end
+
+    it "returns nil as its platform" do
+      expect(useragent.platform).to eq(nil)
+    end
+
+    it "returns nil as its os" do
+      expect(useragent.os).to eq(nil)
+    end
+
+    it { expect(useragent).not_to be_mobile }
+    it { expect(useragent).not_to be_bot }
   end
 
-  it "returns nil as its os" do
-    expect(@useragent.os).to eq(nil)
+  context do
+    let(:useragent) { described_class.parse("amaya/9.51 libwww/5.4.0") }
+
+    it "returns 'amaya' as its browser" do
+      expect(useragent.browser).to eq("amaya")
+    end
+
+    it "returns '9.51' as its version" do
+      expect(useragent.version).to eq("9.51")
+    end
+
+    it "returns '5.4.0' as its libwww version" do
+      expect(useragent.libwww.version).to eq("5.4.0")
+    end
   end
 
-  it { expect(@useragent).not_to be_mobile }
-  it { expect(@useragent).not_to be_bot }
-end
+  context do
+    let(:useragent) { described_class.parse("Rails Testing") }
 
-describe "UserAgent: ''" do
-  before do
-    @useragent = UserAgent.parse("")
+    it "returns 'Rails' as its browser" do
+      expect(useragent.browser).to eq("Rails")
+    end
+
+    it { expect(useragent.version).to be_nil }
+    it { expect(useragent.platform).to be_nil }
+    it { expect(useragent.os).to be_nil }
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it "returns 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq("Mozilla")
+  context do
+    let(:useragent) { described_class.parse("Python-urllib/2.7") }
+
+    it "returns 'Python-urllib' as its browser" do
+      expect(useragent.browser).to eq("Python-urllib")
+    end
+
+    it "returns '2.7' as its version" do
+      expect(useragent.version).to eq("2.7")
+    end
+
+    it { expect(useragent.platform).to be_nil }
+    it { expect(useragent.os).to be_nil }
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it "returns '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
+  context do
+    let(:useragent) { described_class.parse("check_http/v1.4.15 (nagios-plugins 1.4.15)") }
+
+    it "returns 'check_http' as its browser" do
+      expect(useragent.browser).to eq("check_http")
+    end
+
+    it "returns 'v1.4.15' as its version" do
+      expect(useragent.version).to eq("v1.4.15")
+    end
+
+    it { expect(useragent.platform).to be_nil }
+    it { expect(useragent.os).to be_nil }
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it "returns nil as its platform" do
-    expect(@useragent.platform).to eq(nil)
-  end
+  context do
+    let(:useragent) { described_class.parse("/WebTest.pm") }
 
-  it "returns nil as its os" do
-    expect(@useragent.os).to eq(nil)
-  end
-
-  it { expect(@useragent).not_to be_mobile }
-  it { expect(@useragent).not_to be_bot }
-end
-
-describe "UserAgent: 'Mozilla/4.0 (compatible)'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible)")
-  end
-
-  it "returns 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq("Mozilla")
-  end
-
-  it "returns '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
-  end
-
-  it "returns nil as its platform" do
-    expect(@useragent.platform).to eq(nil)
-  end
-
-  it "returns nil as its os" do
-    expect(@useragent.os).to eq(nil)
-  end
-
-  it { expect(@useragent).not_to be_mobile }
-  it { expect(@useragent).not_to be_bot }
-end
-
-describe "UserAgent: 'Mozilla/5.0'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0")
-  end
-
-  it "returns 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq("Mozilla")
-  end
-
-  it "returns '5.0' as its version" do
-    expect(@useragent.version).to eq("5.0")
-  end
-
-  it "returns nil as its platform" do
-    expect(@useragent.platform).to eq(nil)
-  end
-
-  it "returns nil as its os" do
-    expect(@useragent.os).to eq(nil)
-  end
-
-  it { expect(@useragent).not_to be_mobile }
-  it { expect(@useragent).not_to be_bot }
-end
-
-describe "UserAgent: 'amaya/9.51 libwww/5.4.0'" do
-  before do
-    @useragent = UserAgent.parse("amaya/9.51 libwww/5.4.0")
-  end
-
-  it "returns 'amaya' as its browser" do
-    expect(@useragent.browser).to eq("amaya")
-  end
-
-  it "returns '9.51' as its version" do
-    expect(@useragent.version).to eq("9.51")
-  end
-
-  it "returns '5.4.0' as its libwww version" do
-    expect(@useragent.libwww.version).to eq("5.4.0")
-  end
-end
-
-describe "UserAgent: 'Rails Testing'" do
-  before do
-    @useragent = UserAgent.parse("Rails Testing")
-  end
-
-  it "returns 'Rails' as its browser" do
-    expect(@useragent.browser).to eq("Rails")
-  end
-
-  it { expect(@useragent.version).to be_nil }
-  it { expect(@useragent.platform).to be_nil }
-  it { expect(@useragent.os).to be_nil }
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: 'Python-urllib/2.7'" do
-  before do
-    @useragent = UserAgent.parse("Python-urllib/2.7")
-  end
-
-  it "returns 'Python-urllib' as its browser" do
-    expect(@useragent.browser).to eq("Python-urllib")
-  end
-
-  it "returns '2.7' as its version" do
-    expect(@useragent.version).to eq("2.7")
-  end
-
-  it { expect(@useragent.platform).to be_nil }
-  it { expect(@useragent.os).to be_nil }
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: 'check_http/v1.4.15 (nagios-plugins 1.4.15)'" do
-  before do
-    @useragent = UserAgent.parse("check_http/v1.4.15 (nagios-plugins 1.4.15)")
-  end
-
-  it "returns 'check_http' as its browser" do
-    expect(@useragent.browser).to eq("check_http")
-  end
-
-  it "returns 'v1.4.15' as its version" do
-    expect(@useragent.version).to eq("v1.4.15")
-  end
-
-  it { expect(@useragent.platform).to be_nil }
-  it { expect(@useragent.os).to be_nil }
-  it { expect(@useragent).not_to be_mobile }
-end
-
-describe "UserAgent: '/WebTest.pm'" do
-  before do
-    @useragent = UserAgent.parse("/WebTest.pm")
-  end
-
-  it "returns nil as its browser" do
-    expect(@useragent.browser).to eq(nil)
+    it "returns nil as its browser" do
+      expect(useragent.browser).to eq(nil)
+    end
   end
 end

--- a/spec/browsers/other_user_agent_spec.rb
+++ b/spec/browsers/other_user_agent_spec.rb
@@ -1,23 +1,24 @@
+require 'spec_helper'
 require 'user_agent'
 
-describe "UserAgent: nil" do
+describe 'UserAgent: nil' do
   before do
     @useragent = UserAgent.parse(nil)
   end
 
   it "should return 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq("Mozilla")
+    expect(@useragent.browser).to eq('Mozilla')
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
+    expect(@useragent.version).to eq('4.0')
   end
 
-  it "should return nil as its platform" do
+  it 'should return nil as its platform' do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it "should return nil as its os" do
+  it 'should return nil as its os' do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -31,18 +32,18 @@ describe "UserAgent: ''" do
   end
 
   it "should return 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq("Mozilla")
+    expect(@useragent.browser).to eq('Mozilla')
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
+    expect(@useragent.version).to eq('4.0')
   end
 
-  it "should return nil as its platform" do
+  it 'should return nil as its platform' do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it "should return nil as its os" do
+  it 'should return nil as its os' do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -52,22 +53,22 @@ end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible)'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/4.0 (compatible)")
+    @useragent = UserAgent.parse('Mozilla/4.0 (compatible)')
   end
 
   it "should return 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq("Mozilla")
+    expect(@useragent.browser).to eq('Mozilla')
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
+    expect(@useragent.version).to eq('4.0')
   end
 
-  it "should return nil as its platform" do
+  it 'should return nil as its platform' do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it "should return nil as its os" do
+  it 'should return nil as its os' do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -77,22 +78,22 @@ end
 
 describe "UserAgent: 'Mozilla/5.0'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0")
+    @useragent = UserAgent.parse('Mozilla/5.0')
   end
 
   it "should return 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq("Mozilla")
+    expect(@useragent.browser).to eq('Mozilla')
   end
 
   it "should return '5.0' as its version" do
-    expect(@useragent.version).to eq("5.0")
+    expect(@useragent.version).to eq('5.0')
   end
 
-  it "should return nil as its platform" do
+  it 'should return nil as its platform' do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it "should return nil as its os" do
+  it 'should return nil as its os' do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -102,29 +103,29 @@ end
 
 describe "UserAgent: 'amaya/9.51 libwww/5.4.0'" do
   before do
-    @useragent = UserAgent.parse("amaya/9.51 libwww/5.4.0")
+    @useragent = UserAgent.parse('amaya/9.51 libwww/5.4.0')
   end
 
   it "should return 'amaya' as its browser" do
-    expect(@useragent.browser).to eq("amaya")
+    expect(@useragent.browser).to eq('amaya')
   end
 
   it "should return '9.51' as its version" do
-    expect(@useragent.version).to eq("9.51")
+    expect(@useragent.version).to eq('9.51')
   end
 
   it "should return '5.4.0' as its libwww version" do
-    expect(@useragent.libwww.version).to eq("5.4.0")
+    expect(@useragent.libwww.version).to eq('5.4.0')
   end
 end
 
 describe "UserAgent: 'Rails Testing'" do
   before do
-    @useragent = UserAgent.parse("Rails Testing")
+    @useragent = UserAgent.parse('Rails Testing')
   end
 
   it "should return 'Rails' as its browser" do
-    expect(@useragent.browser).to eq("Rails")
+    expect(@useragent.browser).to eq('Rails')
   end
 
   it { expect(@useragent.version).to be_nil }
@@ -135,15 +136,15 @@ end
 
 describe "UserAgent: 'Python-urllib/2.7'" do
   before do
-    @useragent = UserAgent.parse("Python-urllib/2.7")
+    @useragent = UserAgent.parse('Python-urllib/2.7')
   end
 
   it "should return 'Python-urllib' as its browser" do
-    expect(@useragent.browser).to eq("Python-urllib")
+    expect(@useragent.browser).to eq('Python-urllib')
   end
 
   it "should return '2.7' as its version" do
-    expect(@useragent.version).to eq("2.7")
+    expect(@useragent.version).to eq('2.7')
   end
 
   it { expect(@useragent.platform).to be_nil }
@@ -153,15 +154,15 @@ end
 
 describe "UserAgent: 'check_http/v1.4.15 (nagios-plugins 1.4.15)'" do
   before do
-    @useragent = UserAgent.parse("check_http/v1.4.15 (nagios-plugins 1.4.15)")
+    @useragent = UserAgent.parse('check_http/v1.4.15 (nagios-plugins 1.4.15)')
   end
 
   it "should return 'check_http' as its browser" do
-    expect(@useragent.browser).to eq("check_http")
+    expect(@useragent.browser).to eq('check_http')
   end
 
   it "should return 'v1.4.15' as its version" do
-    expect(@useragent.version).to eq("v1.4.15")
+    expect(@useragent.version).to eq('v1.4.15')
   end
 
   it { expect(@useragent.platform).to be_nil }
@@ -171,10 +172,10 @@ end
 
 describe "UserAgent: '/WebTest.pm'" do
   before do
-    @useragent = UserAgent.parse("/WebTest.pm")
+    @useragent = UserAgent.parse('/WebTest.pm')
   end
 
-  it "should return nil as its browser" do
+  it 'should return nil as its browser' do
     expect(@useragent.browser).to eq(nil)
   end
 end

--- a/spec/browsers/other_user_agent_spec.rb
+++ b/spec/browsers/other_user_agent_spec.rb
@@ -1,24 +1,24 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-describe 'UserAgent: nil' do
+describe "UserAgent: nil" do
   before do
     @useragent = UserAgent.parse(nil)
   end
 
   it "should return 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq('Mozilla')
+    expect(@useragent.browser).to eq("Mozilla")
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq('4.0')
+    expect(@useragent.version).to eq("4.0")
   end
 
-  it 'should return nil as its platform' do
+  it "should return nil as its platform" do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it 'should return nil as its os' do
+  it "should return nil as its os" do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -28,22 +28,22 @@ end
 
 describe "UserAgent: ''" do
   before do
-    @useragent = UserAgent.parse('')
+    @useragent = UserAgent.parse("")
   end
 
   it "should return 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq('Mozilla')
+    expect(@useragent.browser).to eq("Mozilla")
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq('4.0')
+    expect(@useragent.version).to eq("4.0")
   end
 
-  it 'should return nil as its platform' do
+  it "should return nil as its platform" do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it 'should return nil as its os' do
+  it "should return nil as its os" do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -53,22 +53,22 @@ end
 
 describe "UserAgent: 'Mozilla/4.0 (compatible)'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/4.0 (compatible)')
+    @useragent = UserAgent.parse("Mozilla/4.0 (compatible)")
   end
 
   it "should return 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq('Mozilla')
+    expect(@useragent.browser).to eq("Mozilla")
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq('4.0')
+    expect(@useragent.version).to eq("4.0")
   end
 
-  it 'should return nil as its platform' do
+  it "should return nil as its platform" do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it 'should return nil as its os' do
+  it "should return nil as its os" do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -78,22 +78,22 @@ end
 
 describe "UserAgent: 'Mozilla/5.0'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0')
+    @useragent = UserAgent.parse("Mozilla/5.0")
   end
 
   it "should return 'Mozilla' as its browser" do
-    expect(@useragent.browser).to eq('Mozilla')
+    expect(@useragent.browser).to eq("Mozilla")
   end
 
   it "should return '5.0' as its version" do
-    expect(@useragent.version).to eq('5.0')
+    expect(@useragent.version).to eq("5.0")
   end
 
-  it 'should return nil as its platform' do
+  it "should return nil as its platform" do
     expect(@useragent.platform).to eq(nil)
   end
 
-  it 'should return nil as its os' do
+  it "should return nil as its os" do
     expect(@useragent.os).to eq(nil)
   end
 
@@ -103,29 +103,29 @@ end
 
 describe "UserAgent: 'amaya/9.51 libwww/5.4.0'" do
   before do
-    @useragent = UserAgent.parse('amaya/9.51 libwww/5.4.0')
+    @useragent = UserAgent.parse("amaya/9.51 libwww/5.4.0")
   end
 
   it "should return 'amaya' as its browser" do
-    expect(@useragent.browser).to eq('amaya')
+    expect(@useragent.browser).to eq("amaya")
   end
 
   it "should return '9.51' as its version" do
-    expect(@useragent.version).to eq('9.51')
+    expect(@useragent.version).to eq("9.51")
   end
 
   it "should return '5.4.0' as its libwww version" do
-    expect(@useragent.libwww.version).to eq('5.4.0')
+    expect(@useragent.libwww.version).to eq("5.4.0")
   end
 end
 
 describe "UserAgent: 'Rails Testing'" do
   before do
-    @useragent = UserAgent.parse('Rails Testing')
+    @useragent = UserAgent.parse("Rails Testing")
   end
 
   it "should return 'Rails' as its browser" do
-    expect(@useragent.browser).to eq('Rails')
+    expect(@useragent.browser).to eq("Rails")
   end
 
   it { expect(@useragent.version).to be_nil }
@@ -136,15 +136,15 @@ end
 
 describe "UserAgent: 'Python-urllib/2.7'" do
   before do
-    @useragent = UserAgent.parse('Python-urllib/2.7')
+    @useragent = UserAgent.parse("Python-urllib/2.7")
   end
 
   it "should return 'Python-urllib' as its browser" do
-    expect(@useragent.browser).to eq('Python-urllib')
+    expect(@useragent.browser).to eq("Python-urllib")
   end
 
   it "should return '2.7' as its version" do
-    expect(@useragent.version).to eq('2.7')
+    expect(@useragent.version).to eq("2.7")
   end
 
   it { expect(@useragent.platform).to be_nil }
@@ -154,15 +154,15 @@ end
 
 describe "UserAgent: 'check_http/v1.4.15 (nagios-plugins 1.4.15)'" do
   before do
-    @useragent = UserAgent.parse('check_http/v1.4.15 (nagios-plugins 1.4.15)')
+    @useragent = UserAgent.parse("check_http/v1.4.15 (nagios-plugins 1.4.15)")
   end
 
   it "should return 'check_http' as its browser" do
-    expect(@useragent.browser).to eq('check_http')
+    expect(@useragent.browser).to eq("check_http")
   end
 
   it "should return 'v1.4.15' as its version" do
-    expect(@useragent.version).to eq('v1.4.15')
+    expect(@useragent.version).to eq("v1.4.15")
   end
 
   it { expect(@useragent.platform).to be_nil }
@@ -172,10 +172,10 @@ end
 
 describe "UserAgent: '/WebTest.pm'" do
   before do
-    @useragent = UserAgent.parse('/WebTest.pm')
+    @useragent = UserAgent.parse("/WebTest.pm")
   end
 
-  it 'should return nil as its browser' do
+  it "should return nil as its browser" do
     expect(@useragent.browser).to eq(nil)
   end
 end

--- a/spec/browsers/playstation_user_agent_spec.rb
+++ b/spec/browsers/playstation_user_agent_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'user_agent'
 
 shared_examples 'PlayStation 3' do
@@ -14,9 +15,9 @@ shared_examples 'PlayStation 3' do
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)" do
+describe 'UserAgent: Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)')
   end
 
   it_behaves_like 'PlayStation 3'
@@ -25,14 +26,14 @@ describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTM
     expect(@useragent.os).to eq('PLAYSTATION 3 4.75')
   end
 
-  it "returns 4.75 as its version" do
+  it 'returns 4.75 as its version' do
     expect(@useragent.version.to_a).to eq([4, 75])
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3; 1.00)" do
+describe 'UserAgent: Mozilla/5.0 (PLAYSTATION 3; 1.00)' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PLAYSTATION 3; 1.00)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (PLAYSTATION 3; 1.00)')
   end
 
   it_behaves_like 'PlayStation 3'
@@ -41,14 +42,14 @@ describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3; 1.00)" do
     expect(@useragent.os).to eq('PLAYSTATION 3 1.00')
   end
 
-  it "returns 1.0 as its version" do
+  it 'returns 1.0 as its version' do
     expect(@useragent.version.to_a).to eq([1, 0])
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2" do
+describe 'UserAgent: Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2")
+    @useragent = UserAgent.parse('Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2')
   end
 
   it "returns 'Silk' as its browser" do
@@ -63,7 +64,7 @@ describe "UserAgent: Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHT
     expect(@useragent.os).to eq('PlayStation Vita 3.52')
   end
 
-  it "returns 3.2 as its version" do
+  it 'returns 3.2 as its version' do
     expect(@useragent.version.to_a).to eq([3, 2])
   end
 
@@ -72,9 +73,9 @@ describe "UserAgent: Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHT
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)" do
+describe 'UserAgent: Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)')
   end
 
   it "returns 'PS4 Internet Browser' as its browser" do
@@ -89,7 +90,7 @@ describe "UserAgent: Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML,
     expect(@useragent.os).to eq('PlayStation 4 2.57')
   end
 
-  it "returns 2.57 as its version" do
+  it 'returns 2.57 as its version' do
     expect(@useragent.version.to_a).to eq([2, 57])
   end
 

--- a/spec/browsers/playstation_user_agent_spec.rb
+++ b/spec/browsers/playstation_user_agent_spec.rb
@@ -98,3 +98,13 @@ describe "UserAgent: Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML,
     expect(@useragent.mobile?).to be false
   end
 end
+
+describe "Mozilla/5.0 (PlayStation Vita 2.06) AppleWebKit/536.26 (KHTML, like Gecko)" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (PlayStation Vita 2.06) AppleWebKit/536.26 (KHTML, like Gecko)")
+  end
+
+  it "return '2.06' as its version" do
+    expect(@useragent.version.to_a).to eq([2, 0o6])
+  end
+end

--- a/spec/browsers/playstation_user_agent_spec.rb
+++ b/spec/browsers/playstation_user_agent_spec.rb
@@ -1,100 +1,100 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples 'PlayStation 3' do
+shared_examples "PlayStation 3" do
   it "returns 'PlayStation 3' as its platform" do
-    expect(@useragent.platform).to eq('PlayStation 3')
+    expect(@useragent.platform).to eq("PlayStation 3")
   end
 
   it "returns 'PS3 Internet Browser' as its browser" do
-    expect(@useragent.browser).to eq('PS3 Internet Browser')
+    expect(@useragent.browser).to eq("PS3 Internet Browser")
   end
 
-  it 'returns false for mobile?' do
+  it "returns false for mobile?" do
     expect(@useragent.mobile?).to be false
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)' do
+describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)")
   end
 
-  it_behaves_like 'PlayStation 3'
+  it_behaves_like "PlayStation 3"
 
   it "returns 'PLAYSTATION 3 4.75' as its operating system" do
-    expect(@useragent.os).to eq('PLAYSTATION 3 4.75')
+    expect(@useragent.os).to eq("PLAYSTATION 3 4.75")
   end
 
-  it 'returns 4.75 as its version' do
+  it "returns 4.75 as its version" do
     expect(@useragent.version.to_a).to eq([4, 75])
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (PLAYSTATION 3; 1.00)' do
+describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3; 1.00)" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (PLAYSTATION 3; 1.00)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (PLAYSTATION 3; 1.00)")
   end
 
-  it_behaves_like 'PlayStation 3'
+  it_behaves_like "PlayStation 3"
 
   it "returns 'PLAYSTATION 3 1.00' as its operating system" do
-    expect(@useragent.os).to eq('PLAYSTATION 3 1.00')
+    expect(@useragent.os).to eq("PLAYSTATION 3 1.00")
   end
 
-  it 'returns 1.0 as its version' do
+  it "returns 1.0 as its version" do
     expect(@useragent.version.to_a).to eq([1, 0])
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2' do
+describe "UserAgent: Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2')
+    @useragent = UserAgent.parse("Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2")
   end
 
   it "returns 'Silk' as its browser" do
-    expect(@useragent.browser).to eq('Silk')
+    expect(@useragent.browser).to eq("Silk")
   end
 
   it "returns 'PlayStation Vita' as its platform" do
-    expect(@useragent.platform).to eq('PlayStation Vita')
+    expect(@useragent.platform).to eq("PlayStation Vita")
   end
 
   it "returns 'PlayStation Vita 3.52' as its operating system" do
-    expect(@useragent.os).to eq('PlayStation Vita 3.52')
+    expect(@useragent.os).to eq("PlayStation Vita 3.52")
   end
 
-  it 'returns 3.2 as its version' do
+  it "returns 3.2 as its version" do
     expect(@useragent.version.to_a).to eq([3, 2])
   end
 
-  it 'returns true for mobile?' do
+  it "returns true for mobile?" do
     expect(@useragent.mobile?).to be true
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)' do
+describe "UserAgent: Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)")
   end
 
   it "returns 'PS4 Internet Browser' as its browser" do
-    expect(@useragent.browser).to eq('PS4 Internet Browser')
+    expect(@useragent.browser).to eq("PS4 Internet Browser")
   end
 
   it "returns 'PlayStation 4' as its platform" do
-    expect(@useragent.platform).to eq('PlayStation 4')
+    expect(@useragent.platform).to eq("PlayStation 4")
   end
 
   it "returns 'PlayStation 4 2.57' as its operating system" do
-    expect(@useragent.os).to eq('PlayStation 4 2.57')
+    expect(@useragent.os).to eq("PlayStation 4 2.57")
   end
 
-  it 'returns 2.57 as its version' do
+  it "returns 2.57 as its version" do
     expect(@useragent.version.to_a).to eq([2, 57])
   end
 
-  it 'returns false for mobile?' do
+  it "returns false for mobile?" do
     expect(@useragent.mobile?).to be false
   end
 end

--- a/spec/browsers/playstation_user_agent_spec.rb
+++ b/spec/browsers/playstation_user_agent_spec.rb
@@ -3,108 +3,100 @@ require "user_agent"
 
 shared_examples "PlayStation 3" do
   it "returns 'PlayStation 3' as its platform" do
-    expect(@useragent.platform).to eq("PlayStation 3")
+    expect(useragent.platform).to eq("PlayStation 3")
   end
 
   it "returns 'PS3 Internet Browser' as its browser" do
-    expect(@useragent.browser).to eq("PS3 Internet Browser")
+    expect(useragent.browser).to eq("PS3 Internet Browser")
   end
 
   it "returns false for mobile?" do
-    expect(@useragent.mobile?).to be false
+    expect(useragent.mobile?).to be false
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)")
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (PLAYSTATION 3 4.75) AppleWebKit/531.22.8 (KHTML, like Gecko)") }
+
+    it_behaves_like "PlayStation 3"
+
+    it "returns 'PLAYSTATION 3 4.75' as its operating system" do
+      expect(useragent.os).to eq("PLAYSTATION 3 4.75")
+    end
+
+    it "returns 4.75 as its version" do
+      expect(useragent.version.to_a).to eq([4, 75])
+    end
   end
 
-  it_behaves_like "PlayStation 3"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (PLAYSTATION 3; 1.00)") }
 
-  it "returns 'PLAYSTATION 3 4.75' as its operating system" do
-    expect(@useragent.os).to eq("PLAYSTATION 3 4.75")
+    it_behaves_like "PlayStation 3"
+
+    it "returns 'PLAYSTATION 3 1.00' as its operating system" do
+      expect(useragent.os).to eq("PLAYSTATION 3 1.00")
+    end
+
+    it "returns 1.0 as its version" do
+      expect(useragent.version.to_a).to eq([1, 0])
+    end
   end
 
-  it "returns 4.75 as its version" do
-    expect(@useragent.version.to_a).to eq([4, 75])
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2") }
 
-describe "UserAgent: Mozilla/5.0 (PLAYSTATION 3; 1.00)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PLAYSTATION 3; 1.00)")
-  end
+    it "returns 'Silk' as its browser" do
+      expect(useragent.browser).to eq("Silk")
+    end
 
-  it_behaves_like "PlayStation 3"
+    it "returns 'PlayStation Vita' as its platform" do
+      expect(useragent.platform).to eq("PlayStation Vita")
+    end
 
-  it "returns 'PLAYSTATION 3 1.00' as its operating system" do
-    expect(@useragent.os).to eq("PLAYSTATION 3 1.00")
-  end
+    it "returns 'PlayStation Vita 3.52' as its operating system" do
+      expect(useragent.os).to eq("PlayStation Vita 3.52")
+    end
 
-  it "returns 1.0 as its version" do
-    expect(@useragent.version.to_a).to eq([1, 0])
-  end
-end
+    it "returns 3.2 as its version" do
+      expect(useragent.version.to_a).to eq([3, 2])
+    end
 
-describe "UserAgent: Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PlayStation Vita 3.52) AppleWebKit/537.73 (KHTML, like Gecko) Silk/3.2")
+    it "returns true for mobile?" do
+      expect(useragent.mobile?).to be true
+    end
   end
 
-  it "returns 'Silk' as its browser" do
-    expect(@useragent.browser).to eq("Silk")
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)") }
+
+    it "returns 'PS4 Internet Browser' as its browser" do
+      expect(useragent.browser).to eq("PS4 Internet Browser")
+    end
+
+    it "returns 'PlayStation 4' as its platform" do
+      expect(useragent.platform).to eq("PlayStation 4")
+    end
+
+    it "returns 'PlayStation 4 2.57' as its operating system" do
+      expect(useragent.os).to eq("PlayStation 4 2.57")
+    end
+
+    it "returns 2.57 as its version" do
+      expect(useragent.version.to_a).to eq([2, 57])
+    end
+
+    it "returns false for mobile?" do
+      expect(useragent.mobile?).to be false
+    end
   end
 
-  it "returns 'PlayStation Vita' as its platform" do
-    expect(@useragent.platform).to eq("PlayStation Vita")
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (PlayStation Vita 2.06) AppleWebKit/536.26 (KHTML, like Gecko)") }
 
-  it "returns 'PlayStation Vita 3.52' as its operating system" do
-    expect(@useragent.os).to eq("PlayStation Vita 3.52")
-  end
-
-  it "returns 3.2 as its version" do
-    expect(@useragent.version.to_a).to eq([3, 2])
-  end
-
-  it "returns true for mobile?" do
-    expect(@useragent.mobile?).to be true
-  end
-end
-
-describe "UserAgent: Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PlayStation 4 2.57) AppleWebKit/537.73 (KHTML, like Gecko)")
-  end
-
-  it "returns 'PS4 Internet Browser' as its browser" do
-    expect(@useragent.browser).to eq("PS4 Internet Browser")
-  end
-
-  it "returns 'PlayStation 4' as its platform" do
-    expect(@useragent.platform).to eq("PlayStation 4")
-  end
-
-  it "returns 'PlayStation 4 2.57' as its operating system" do
-    expect(@useragent.os).to eq("PlayStation 4 2.57")
-  end
-
-  it "returns 2.57 as its version" do
-    expect(@useragent.version.to_a).to eq([2, 57])
-  end
-
-  it "returns false for mobile?" do
-    expect(@useragent.mobile?).to be false
-  end
-end
-
-describe "Mozilla/5.0 (PlayStation Vita 2.06) AppleWebKit/536.26 (KHTML, like Gecko)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (PlayStation Vita 2.06) AppleWebKit/536.26 (KHTML, like Gecko)")
-  end
-
-  it "return '2.06' as its version" do
-    expect(@useragent.version.to_a).to eq([2, 0o6])
+    it "return '2.06' as its version" do
+      expect(useragent.version.to_a).to eq([2, 0o6])
+    end
   end
 end

--- a/spec/browsers/podcast_addict_user_agent_spec.rb
+++ b/spec/browsers/podcast_addict_user_agent_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'user_agent'
 
 shared_examples 'Podcast Addict' do
@@ -22,9 +23,9 @@ shared_examples 'Podcast Addict' do
   end
 end
 
-describe "UserAgent: Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)" do
+describe 'UserAgent: Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)' do
   before do
-    @useragent = UserAgent.parse("Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)")
+    @useragent = UserAgent.parse('Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)')
   end
 
   it_behaves_like 'Podcast Addict'
@@ -46,9 +47,9 @@ describe "UserAgent: Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-
   end
 end
 
-describe "UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)" do
+describe 'UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)' do
   before do
-    @useragent = UserAgent.parse("Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)")
+    @useragent = UserAgent.parse('Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)')
   end
 
   it_behaves_like 'Podcast Addict'
@@ -70,9 +71,9 @@ describe "UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT109
   end
 end
 
-describe "UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)" do
+describe 'UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)' do
   before do
-    @useragent = UserAgent.parse("Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)")
+    @useragent = UserAgent.parse('Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)')
   end
 
   it_behaves_like 'Podcast Addict'
@@ -94,9 +95,9 @@ describe "UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MP
   end
 end
 
-describe "UserAgent: Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30" do
+describe 'UserAgent: Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30' do
   before do
-    @useragent = UserAgent.parse("Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30")
+    @useragent = UserAgent.parse('Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30')
   end
 
   it_behaves_like 'Podcast Addict'

--- a/spec/browsers/podcast_addict_user_agent_spec.rb
+++ b/spec/browsers/podcast_addict_user_agent_spec.rb
@@ -1,120 +1,120 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples 'Podcast Addict' do
+shared_examples "Podcast Addict" do
   it "returns 'Podcast Addict' as its browser" do
-    expect(@useragent.browser).to eq('Podcast Addict')
+    expect(@useragent.browser).to eq("Podcast Addict")
   end
 
-  it 'returns nil as its version' do
+  it "returns nil as its version" do
     expect(@useragent.version).to be_nil
   end
 
   it "returns 'Android' as its platform" do
-    expect(@useragent.platform).to eq('Android')
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "returns ':strong' as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 
-  it 'is a mobile user agent' do
+  it "is a mobile user agent" do
     expect(@useragent.mobile?).to be true
   end
 end
 
-describe 'UserAgent: Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)' do
+describe "UserAgent: Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)" do
   before do
-    @useragent = UserAgent.parse('Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)')
+    @useragent = UserAgent.parse("Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)")
   end
 
-  it_behaves_like 'Podcast Addict'
+  it_behaves_like "Podcast Addict"
 
   it "returns 'Android 4.4.2' as its operating system" do
-    expect(@useragent.os).to eq('Android 4.4.2')
+    expect(@useragent.os).to eq("Android 4.4.2")
   end
 
   it "returns 'LG-D631' as its device" do
-    expect(@useragent.device).to eq('LG-D631')
+    expect(@useragent.device).to eq("LG-D631")
   end
 
   it "returns 'KOT49I.D63110b' as its device build" do
-    expect(@useragent.device_build).to eq('KOT49I.D63110b')
+    expect(@useragent.device_build).to eq("KOT49I.D63110b")
   end
 
-  it 'returns nil as its localization' do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
 
-describe 'UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)' do
+describe "UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)" do
   before do
-    @useragent = UserAgent.parse('Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)')
+    @useragent = UserAgent.parse("Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)")
   end
 
-  it_behaves_like 'Podcast Addict'
+  it_behaves_like "Podcast Addict"
 
   it "returns 'Android 5.1' as its operating system" do
-    expect(@useragent.os).to eq('Android 5.1')
+    expect(@useragent.os).to eq("Android 5.1")
   end
 
   it "returns 'XT1093' as its device" do
-    expect(@useragent.device).to eq('XT1093')
+    expect(@useragent.device).to eq("XT1093")
   end
 
   it "returns 'LPE23.32-21.3' as its device build" do
-    expect(@useragent.device_build).to eq('LPE23.32-21.3')
+    expect(@useragent.device_build).to eq("LPE23.32-21.3")
   end
 
-  it 'returns nil as its localization' do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
 
-describe 'UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)' do
+describe "UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)" do
   before do
-    @useragent = UserAgent.parse('Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)')
+    @useragent = UserAgent.parse("Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)")
   end
 
-  it_behaves_like 'Podcast Addict'
+  it_behaves_like "Podcast Addict"
 
   it "returns 'Android' as its operating system" do
-    expect(@useragent.os).to eq('Android')
+    expect(@useragent.os).to eq("Android")
   end
 
   it "returns 'Android M' as its device" do
-    expect(@useragent.device).to eq('Android M')
+    expect(@useragent.device).to eq("Android M")
   end
 
   it "returns 'MPZ79M' as its device build" do
-    expect(@useragent.device_build).to eq('MPZ79M')
+    expect(@useragent.device_build).to eq("MPZ79M")
   end
 
-  it 'returns nil as its localization' do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 end
 
-describe 'UserAgent: Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30' do
+describe "UserAgent: Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30" do
   before do
-    @useragent = UserAgent.parse('Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30')
+    @useragent = UserAgent.parse("Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30")
   end
 
-  it_behaves_like 'Podcast Addict'
+  it_behaves_like "Podcast Addict"
 
   it "returns 'Android' as its operating system" do
-    expect(@useragent.os).to eq('Android 4.2.2')
+    expect(@useragent.os).to eq("Android 4.2.2")
   end
 
   it "returns 'ALCATEL ONE TOUCH 6040A' as its device" do
-    expect(@useragent.device).to eq('ALCATEL ONE TOUCH 6040A')
+    expect(@useragent.device).to eq("ALCATEL ONE TOUCH 6040A")
   end
 
   it "returns 'JDQ39' as its device build" do
-    expect(@useragent.device_build).to eq('JDQ39')
+    expect(@useragent.device_build).to eq("JDQ39")
   end
 
   it "returns 'en-ca' as its localization" do
-    expect(@useragent.localization).to eq('en-ca')
+    expect(@useragent.localization).to eq("en-ca")
   end
 end

--- a/spec/browsers/podcast_addict_user_agent_spec.rb
+++ b/spec/browsers/podcast_addict_user_agent_spec.rb
@@ -3,118 +3,112 @@ require "user_agent"
 
 shared_examples "Podcast Addict" do
   it "returns 'Podcast Addict' as its browser" do
-    expect(@useragent.browser).to eq("Podcast Addict")
+    expect(useragent.browser).to eq("Podcast Addict")
   end
 
   it "returns nil as its version" do
-    expect(@useragent.version).to be_nil
+    expect(useragent.version).to be_nil
   end
 
   it "returns 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
+    expect(useragent.platform).to eq("Android")
   end
 
   it "returns ':strong' as its security" do
-    expect(@useragent.security).to eq(:strong)
+    expect(useragent.security).to eq(:strong)
   end
 
   it "is a mobile user agent" do
-    expect(@useragent.mobile?).to be true
+    expect(useragent.mobile?).to be true
   end
 end
 
-describe "UserAgent: Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)" do
-  before do
-    @useragent = UserAgent.parse("Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)")
+describe UserAgent do
+  context "when Podcast Addict LG-D631 Android 4.4.2" do
+    let(:useragent) { described_class.parse("Podcast Addict - Dalvik/1.6.0 (Linux; U; Android 4.4.2; LG-D631 Build/KOT49I.D63110b)") }
+
+    it_behaves_like "Podcast Addict"
+
+    it "returns 'Android 4.4.2' as its operating system" do
+      expect(useragent.os).to eq("Android 4.4.2")
+    end
+
+    it "returns 'LG-D631' as its device" do
+      expect(useragent.device).to eq("LG-D631")
+    end
+
+    it "returns 'KOT49I.D63110b' as its device build" do
+      expect(useragent.device_build).to eq("KOT49I.D63110b")
+    end
+
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
   end
 
-  it_behaves_like "Podcast Addict"
+  context "when Podcast Addict XT1093 Android 5.1" do
+    let(:useragent) { described_class.parse("Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)") }
 
-  it "returns 'Android 4.4.2' as its operating system" do
-    expect(@useragent.os).to eq("Android 4.4.2")
+    it_behaves_like "Podcast Addict"
+
+    it "returns 'Android 5.1' as its operating system" do
+      expect(useragent.os).to eq("Android 5.1")
+    end
+
+    it "returns 'XT1093' as its device" do
+      expect(useragent.device).to eq("XT1093")
+    end
+
+    it "returns 'LPE23.32-21.3' as its device build" do
+      expect(useragent.device_build).to eq("LPE23.32-21.3")
+    end
+
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
   end
 
-  it "returns 'LG-D631' as its device" do
-    expect(@useragent.device).to eq("LG-D631")
+  context "when Podcast Addict MPZ79M Adnroid M" do
+    let(:useragent) { described_class.parse("Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)") }
+
+    it_behaves_like "Podcast Addict"
+
+    it "returns 'Android' as its operating system" do
+      expect(useragent.os).to eq("Android")
+    end
+
+    it "returns 'Android M' as its device" do
+      expect(useragent.device).to eq("Android M")
+    end
+
+    it "returns 'MPZ79M' as its device build" do
+      expect(useragent.device_build).to eq("MPZ79M")
+    end
+
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
   end
 
-  it "returns 'KOT49I.D63110b' as its device build" do
-    expect(@useragent.device_build).to eq("KOT49I.D63110b")
-  end
+  context "when Podcast Addict Alcatel One Touch 6040A Android 4.2.2" do
+    let(:useragent) { described_class.parse("Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30") }
 
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
-  end
-end
+    it_behaves_like "Podcast Addict"
 
-describe "UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)" do
-  before do
-    @useragent = UserAgent.parse("Podcast Addict - Dalvik/2.1.0 (Linux; U; Android 5.1; XT1093 Build/LPE23.32-21.3)")
-  end
+    it "returns 'Android' as its operating system" do
+      expect(useragent.os).to eq("Android 4.2.2")
+    end
 
-  it_behaves_like "Podcast Addict"
+    it "returns 'ALCATEL ONE TOUCH 6040A' as its device" do
+      expect(useragent.device).to eq("ALCATEL ONE TOUCH 6040A")
+    end
 
-  it "returns 'Android 5.1' as its operating system" do
-    expect(@useragent.os).to eq("Android 5.1")
-  end
+    it "returns 'JDQ39' as its device build" do
+      expect(useragent.device_build).to eq("JDQ39")
+    end
 
-  it "returns 'XT1093' as its device" do
-    expect(@useragent.device).to eq("XT1093")
-  end
-
-  it "returns 'LPE23.32-21.3' as its device build" do
-    expect(@useragent.device_build).to eq("LPE23.32-21.3")
-  end
-
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
-  end
-end
-
-describe "UserAgent: Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)" do
-  before do
-    @useragent = UserAgent.parse("Podcast Addict - Dalvik/2.1.0 (Linux; U; Android M Build/MPZ79M)")
-  end
-
-  it_behaves_like "Podcast Addict"
-
-  it "returns 'Android' as its operating system" do
-    expect(@useragent.os).to eq("Android")
-  end
-
-  it "returns 'Android M' as its device" do
-    expect(@useragent.device).to eq("Android M")
-  end
-
-  it "returns 'MPZ79M' as its device build" do
-    expect(@useragent.device_build).to eq("MPZ79M")
-  end
-
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
-  end
-end
-
-describe "UserAgent: Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30" do
-  before do
-    @useragent = UserAgent.parse("Podcast Addict - Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; ALCATEL ONE TOUCH 6040A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30")
-  end
-
-  it_behaves_like "Podcast Addict"
-
-  it "returns 'Android' as its operating system" do
-    expect(@useragent.os).to eq("Android 4.2.2")
-  end
-
-  it "returns 'ALCATEL ONE TOUCH 6040A' as its device" do
-    expect(@useragent.device).to eq("ALCATEL ONE TOUCH 6040A")
-  end
-
-  it "returns 'JDQ39' as its device build" do
-    expect(@useragent.device_build).to eq("JDQ39")
-  end
-
-  it "returns 'en-ca' as its localization" do
-    expect(@useragent.localization).to eq("en-ca")
+    it "returns 'en-ca' as its localization" do
+      expect(useragent.localization).to eq("en-ca")
+    end
   end
 end

--- a/spec/browsers/vivaldi_user_agent_spec.rb
+++ b/spec/browsers/vivaldi_user_agent_spec.rb
@@ -1,47 +1,48 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples_for "Vivaldi browser" do
+shared_examples_for 'Vivaldi browser' do
   it "should return 'Vivaldi' as its browser" do
-    expect(@useragent.browser).to eq("Vivaldi")
+    expect(@useragent.browser).to eq('Vivaldi')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43')
   end
 
-  it_should_behave_like "Vivaldi browser"
+  it_should_behave_like 'Vivaldi browser'
 
   it "should return '1.2.490.43' as its version" do
-    expect(@useragent.version).to eq("1.2.490.43")
+    expect(@useragent.version).to eq('1.2.490.43')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
+    expect(@useragent.os).to eq('Windows 7')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43')
   end
 
-  it_should_behave_like "Vivaldi browser"
+  it_should_behave_like 'Vivaldi browser'
 
   it "should return '1.2.490.43' as its version" do
-    expect(@useragent.version).to eq("1.2.490.43")
+    expect(@useragent.version).to eq('1.2.490.43')
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
+    expect(@useragent.platform).to eq('X11')
   end
 
   it "should return 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq("Linux x86_64")
+    expect(@useragent.os).to eq('Linux x86_64')
   end
 end

--- a/spec/browsers/vivaldi_user_agent_spec.rb
+++ b/spec/browsers/vivaldi_user_agent_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples_for "Vivaldi browser" do
-  it "should return 'Vivaldi' as its browser" do
+  it "returns 'Vivaldi' as its browser" do
     expect(@useragent.browser).to eq("Vivaldi")
   end
 end
@@ -12,21 +12,21 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KH
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43")
   end
 
-  it_should_behave_like "Vivaldi browser"
+  it_behaves_like "Vivaldi browser"
 
-  it "should return '1.2.490.43' as its version" do
+  it "returns '1.2.490.43' as its version" do
     expect(@useragent.version).to eq("1.2.490.43")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows 7' as its os" do
+  it "returns 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
 
-  it "should return '537.36' as its build" do
+  it "returns '537.36' as its build" do
     expect(@useragent.build).to eq("537.36")
   end
 end
@@ -36,17 +36,33 @@ describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML,
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43")
   end
 
-  it_should_behave_like "Vivaldi browser"
+  it_behaves_like "Vivaldi browser"
 
-  it "should return '1.2.490.43' as its version" do
+  it "returns '1.2.490.43' as its version" do
     expect(@useragent.version).to eq("1.2.490.43")
   end
 
-  it "should return 'X11' as its platform" do
+  it "returns 'X11' as its platform" do
     expect(@useragent.platform).to eq("X11")
   end
 
-  it "should return 'Linux x86_64' as its os" do
+  it "returns 'Linux x86_64' as its os" do
     expect(@useragent.os).to eq("Linux x86_64")
+  end
+end
+
+describe "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.148 Mobile Safari/537.36 Vivaldi/1.4.589.38" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.148 Mobile Safari/537.36 Vivaldi/1.4.589.38")
+  end
+
+  it_behaves_like "Vivaldi browser"
+
+  it "returns 'Android 6.0.1' as its os" do
+    expect(@useragent.os).to eq("Android 6.0.1")
+  end
+
+  it "returns 'Android' as its platform" do
+    expect(@useragent.platform).to eq("Android")
   end
 end

--- a/spec/browsers/vivaldi_user_agent_spec.rb
+++ b/spec/browsers/vivaldi_user_agent_spec.rb
@@ -3,66 +3,62 @@ require "user_agent"
 
 shared_examples_for "Vivaldi browser" do
   it "returns 'Vivaldi' as its browser" do
-    expect(@useragent.browser).to eq("Vivaldi")
+    expect(useragent.browser).to eq("Vivaldi")
   end
 end
 
-describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43")
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43") }
+
+    it_behaves_like "Vivaldi browser"
+
+    it "returns '1.2.490.43' as its version" do
+      expect(useragent.version).to eq("1.2.490.43")
+    end
+
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
+
+    it "returns 'Windows 7' as its os" do
+      expect(useragent.os).to eq("Windows 7")
+    end
+
+    it "returns '537.36' as its build" do
+      expect(useragent.build).to eq("537.36")
+    end
   end
 
-  it_behaves_like "Vivaldi browser"
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43") }
 
-  it "returns '1.2.490.43' as its version" do
-    expect(@useragent.version).to eq("1.2.490.43")
+    it_behaves_like "Vivaldi browser"
+
+    it "returns '1.2.490.43' as its version" do
+      expect(useragent.version).to eq("1.2.490.43")
+    end
+
+    it "returns 'X11' as its platform" do
+      expect(useragent.platform).to eq("X11")
+    end
+
+    it "returns 'Linux x86_64' as its os" do
+      expect(useragent.os).to eq("Linux x86_64")
+    end
   end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.148 Mobile Safari/537.36 Vivaldi/1.4.589.38") }
 
-  it "returns 'Windows 7' as its os" do
-    expect(@useragent.os).to eq("Windows 7")
-  end
+    it_behaves_like "Vivaldi browser"
 
-  it "returns '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
-  end
-end
+    it "returns 'Android 6.0.1' as its os" do
+      expect(useragent.os).to eq("Android 6.0.1")
+    end
 
-describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43")
-  end
-
-  it_behaves_like "Vivaldi browser"
-
-  it "returns '1.2.490.43' as its version" do
-    expect(@useragent.version).to eq("1.2.490.43")
-  end
-
-  it "returns 'X11' as its platform" do
-    expect(@useragent.platform).to eq("X11")
-  end
-
-  it "returns 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq("Linux x86_64")
-  end
-end
-
-describe "Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.148 Mobile Safari/537.36 Vivaldi/1.4.589.38" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.148 Mobile Safari/537.36 Vivaldi/1.4.589.38")
-  end
-
-  it_behaves_like "Vivaldi browser"
-
-  it "returns 'Android 6.0.1' as its os" do
-    expect(@useragent.os).to eq("Android 6.0.1")
-  end
-
-  it "returns 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
+    it "returns 'Android' as its platform" do
+      expect(useragent.platform).to eq("Android")
+    end
   end
 end

--- a/spec/browsers/vivaldi_user_agent_spec.rb
+++ b/spec/browsers/vivaldi_user_agent_spec.rb
@@ -25,6 +25,10 @@ describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KH
   it "should return 'Windows 7' as its os" do
     expect(@useragent.os).to eq("Windows 7")
   end
+
+  it "should return '537.36' as its build" do
+    expect(@useragent.build).to eq("537.36")
+  end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do

--- a/spec/browsers/vivaldi_user_agent_spec.rb
+++ b/spec/browsers/vivaldi_user_agent_spec.rb
@@ -1,48 +1,48 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples_for 'Vivaldi browser' do
+shared_examples_for "Vivaldi browser" do
   it "should return 'Vivaldi' as its browser" do
-    expect(@useragent.browser).to eq('Vivaldi')
+    expect(@useragent.browser).to eq("Vivaldi")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43")
   end
 
-  it_should_behave_like 'Vivaldi browser'
+  it_should_behave_like "Vivaldi browser"
 
   it "should return '1.2.490.43' as its version" do
-    expect(@useragent.version).to eq('1.2.490.43')
+    expect(@useragent.version).to eq("1.2.490.43")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows 7' as its os" do
-    expect(@useragent.os).to eq('Windows 7')
+    expect(@useragent.os).to eq("Windows 7")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43")
   end
 
-  it_should_behave_like 'Vivaldi browser'
+  it_should_behave_like "Vivaldi browser"
 
   it "should return '1.2.490.43' as its version" do
-    expect(@useragent.version).to eq('1.2.490.43')
+    expect(@useragent.version).to eq("1.2.490.43")
   end
 
   it "should return 'X11' as its platform" do
-    expect(@useragent.platform).to eq('X11')
+    expect(@useragent.platform).to eq("X11")
   end
 
   it "should return 'Linux x86_64' as its os" do
-    expect(@useragent.os).to eq('Linux x86_64')
+    expect(@useragent.os).to eq("Linux x86_64")
   end
 end

--- a/spec/browsers/webkit_user_agent_spec.rb
+++ b/spec/browsers/webkit_user_agent_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples_for "Safari browser" do
-  it "should return 'Safari' as its browser" do
+  it "returns 'Safari' as its browser" do
     expect(@useragent.browser).to eq("Safari")
   end
 
-  it "should return :strong as its security" do
+  it "returns :strong as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 end
@@ -16,29 +16,29 @@ describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) Ap
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '533.16' as its build" do
+  it "returns '533.16' as its build" do
     expect(@useragent.build).to eq("533.16")
   end
 
-  it "should return '5.0' as its version" do
+  it "returns '5.0' as its version" do
     expect(@useragent.version).to eq("5.0")
   end
 
-  it "should return '533.16' as its webkit version" do
+  it "returns '533.16' as its webkit version" do
     expect(@useragent.webkit.version).to eq("533.16")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.6.3' as its os" do
+  it "returns 'OS X 10.6.3' as its os" do
     expect(@useragent.os).to eq("OS X 10.6.3")
   end
 
-  it "should return 'en-us' as its localization" do
+  it "returns 'en-us' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
@@ -50,29 +50,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) A
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '526.8' as its build" do
+  it "returns '526.8' as its build" do
     expect(@useragent.build).to eq("526.9")
   end
 
-  it "should return '4.0dp1' as its version" do
+  it "returns '4.0dp1' as its version" do
     expect(@useragent.version).to eq("4.0dp1")
   end
 
-  it "should return '526.9' as its webkit version" do
+  it "returns '526.9' as its webkit version" do
     expect(@useragent.webkit.version).to eq("526.9")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.5.3' as its os" do
+  it "returns 'OS X 10.5.3' as its os" do
     expect(@useragent.os).to eq("OS X 10.5.3")
   end
 
-  it "should return 'en-us' as its localization" do
+  it "returns 'en-us' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
@@ -84,29 +84,29 @@ describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/5
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '526.8' as its build" do
+  it "returns '526.8' as its build" do
     expect(@useragent.build).to eq("526.9")
   end
 
-  it "should return '4.0dp1' as its version" do
+  it "returns '4.0dp1' as its version" do
     expect(@useragent.version).to eq("4.0dp1")
   end
 
-  it "should return '526.9' as its webkit version" do
+  it "returns '526.9' as its webkit version" do
     expect(@useragent.webkit.version).to eq("526.9")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 
@@ -118,69 +118,69 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) A
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '525.18' as its build" do
+  it "returns '525.18' as its build" do
     expect(@useragent.build).to eq("525.18")
   end
 
-  it "should return '3.1.1' as its version" do
+  it "returns '3.1.1' as its version" do
     expect(@useragent.version).to eq("3.1.1")
   end
 
-  it "should return '525.18' as its webkit version" do
+  it "returns '525.18' as its webkit version" do
     expect(@useragent.webkit.version).to eq("525.18")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.5.3' as its os" do
+  it "returns 'OS X 10.5.3' as its os" do
     expect(@useragent.os).to eq("OS X 10.5.3")
   end
 
-  it "should return 'en-us' as its localization" do
+  it "returns 'en-us' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
-  it "should be == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
+  it "is == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
     expect(@useragent).to eq(@useragent)
   end
 
-  it "should not be == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
+  it "is not == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
     expect(@useragent).not_to eq(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3"))
   end
 
-  it "should be > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
+  it "is > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
     expect(@useragent).to be > UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
   end
 
-  it "should not be > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
+  it "is not > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
     expect(@useragent).not_to be > UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
-  it "should be < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
+  it "is < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
     expect(@useragent).to be < UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
-  it "should not be < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
+  it "is not < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
     expect(@useragent).not_to be < @useragent
   end
 
-  it "should be >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
+  it "is >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
     expect(@useragent).to be >= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
   end
 
-  it "should not be >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
+  it "is not >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
     expect(@useragent).not_to be >= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
-  it "should be <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
+  it "is <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
     expect(@useragent).to be <= @useragent
   end
 
-  it "should not be <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
+  it "is not <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
     expect(@useragent).not_to be <= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
   end
 end
@@ -190,29 +190,29 @@ describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/5
     @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '525.18' as its build" do
+  it "returns '525.18' as its build" do
     expect(@useragent.build).to eq("525.18")
   end
 
-  it "should return '3.1.1' as its version" do
+  it "returns '3.1.1' as its version" do
     expect(@useragent.version).to eq("3.1.1")
   end
 
-  it "should return '525.18' as its webkit version" do
+  it "returns '525.18' as its webkit version" do
     expect(@useragent.webkit.version).to eq("525.18")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should return 'Windows XP' as its os" do
+  it "returns 'Windows XP' as its os" do
     expect(@useragent.os).to eq("Windows XP")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -222,29 +222,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '419.3' as its build" do
+  it "returns '419.3' as its build" do
     expect(@useragent.build).to eq("419")
   end
 
-  it "should return '2.0.4' as its version" do
+  it "returns '2.0.4' as its version" do
     expect(@useragent.version).to eq("2.0.4")
   end
 
-  it "should return '419' as its webkit version" do
+  it "returns '419' as its webkit version" do
     expect(@useragent.webkit.version).to eq("419")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -254,29 +254,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKi
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '412.2' as its build" do
+  it "returns '412.2' as its build" do
     expect(@useragent.build).to eq("412.6")
   end
 
-  it "should return '2.0' as its version" do
+  it "returns '2.0' as its version" do
     expect(@useragent.version).to eq("2.0")
   end
 
-  it "should return '412.6' as its webkit version" do
+  it "returns '412.6' as its webkit version" do
     expect(@useragent.webkit.version).to eq("412.6")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 end
@@ -286,29 +286,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/4
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '412.2.2' as its build" do
+  it "returns '412.2.2' as its build" do
     expect(@useragent.build).to eq("412.6.2")
   end
 
-  it "should return '2.0' as its version" do
+  it "returns '2.0' as its version" do
     expect(@useragent.version).to eq("2.0")
   end
 
-  it "should return '412.6.2' as its webkit version" do
+  it "returns '412.6.2' as its webkit version" do
     expect(@useragent.webkit.version).to eq("412.6.2")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -318,29 +318,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/3
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '312.6' as its build" do
+  it "returns '312.6' as its build" do
     expect(@useragent.build).to eq("312.8")
   end
 
-  it "should return '1.3.2' as its version" do
+  it "returns '1.3.2' as its version" do
     expect(@useragent.version).to eq("1.3.2")
   end
 
-  it "should return '312.8' as its webkit version" do
+  it "returns '312.8' as its webkit version" do
     expect(@useragent.webkit.version).to eq("312.8")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -350,29 +350,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKi
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '312' as its build" do
+  it "returns '312' as its build" do
     expect(@useragent.build).to eq("312.1.1")
   end
 
-  it "should return '1.3' as its version" do
+  it "returns '1.3' as its version" do
     expect(@useragent.version).to eq("1.3")
   end
 
-  it "should return '312.1.1' as its webkit version" do
+  it "returns '312.1.1' as its webkit version" do
     expect(@useragent.webkit.version).to eq("312.1.1")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("fr-ch")
   end
 end
@@ -382,29 +382,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKi
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '312.3.3' as its build" do
+  it "returns '312.3.3' as its build" do
     expect(@useragent.build).to eq("312.5.2")
   end
 
-  it "should return '1.3.1' as its version" do
+  it "returns '1.3.1' as its version" do
     expect(@useragent.version).to eq("1.3.1")
   end
 
-  it "should return '312.5.2' as its webkit version" do
+  it "returns '312.5.2' as its webkit version" do
     expect(@useragent.webkit.version).to eq("312.5.2")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("es-es")
   end
 end
@@ -414,29 +414,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/3
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '312.3.1' as its build" do
+  it "returns '312.3.1' as its build" do
     expect(@useragent.build).to eq("312.5.1")
   end
 
-  it "should return '1.3.1' as its version" do
+  it "returns '1.3.1' as its version" do
     expect(@useragent.version).to eq("1.3.1")
   end
 
-  it "should return '312.5.1' as its webkit version" do
+  it "returns '312.5.1' as its webkit version" do
     expect(@useragent.webkit.version).to eq("312.5.1")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("fr")
   end
 end
@@ -446,29 +446,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKi
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '312.3' as its build" do
+  it "returns '312.3' as its build" do
     expect(@useragent.build).to eq("312.5")
   end
 
-  it "should return '1.3.1' as its version" do
+  it "returns '1.3.1' as its version" do
     expect(@useragent.version).to eq("1.3.1")
   end
 
-  it "should return '312.5' as its webkit version" do
+  it "returns '312.5' as its webkit version" do
     expect(@useragent.webkit.version).to eq("312.5")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 end
@@ -478,29 +478,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKi
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '125' as its build" do
+  it "returns '125' as its build" do
     expect(@useragent.build).to eq("124")
   end
 
-  it "should return '1.2' as its version" do
+  it "returns '1.2' as its version" do
     expect(@useragent.version).to eq("1.2")
   end
 
-  it "should return '124' as its webkit version" do
+  it "returns '124' as its webkit version" do
     expect(@useragent.webkit.version).to eq("124")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 end
@@ -510,29 +510,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/1
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '125.12' as its build" do
+  it "returns '125.12' as its build" do
     expect(@useragent.build).to eq("125.5.7")
   end
 
-  it "should return '1.2.4' as its version" do
+  it "returns '1.2.4' as its version" do
     expect(@useragent.version).to eq("1.2.4")
   end
 
-  it "should return '125.5.7' as its webkit version" do
+  it "returns '125.5.7' as its webkit version" do
     expect(@useragent.webkit.version).to eq("125.5.7")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 end
@@ -542,29 +542,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKi
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '85.5' as its build" do
+  it "returns '85.5' as its build" do
     expect(@useragent.build).to eq("85.7")
   end
 
-  it "should return '1.0' as its version" do
+  it "returns '1.0' as its version" do
     expect(@useragent.version).to eq("1.0")
   end
 
-  it "should return '85.7' as its webkit version" do
+  it "returns '85.7' as its webkit version" do
     expect(@useragent.webkit.version).to eq("85.7")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X' as its os" do
+  it "returns 'OS X' as its os" do
     expect(@useragent.os).to eq("OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("fr-fr")
   end
 end
@@ -574,29 +574,29 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit
     @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '419' as its build" do
+  it "returns '419' as its build" do
     expect(@useragent.build).to eq("420.1")
   end
 
-  it "should return '3.0' as its version" do
+  it "returns '3.0' as its version" do
     expect(@useragent.version).to eq("3.0")
   end
 
-  it "should return '420.1' as its webkit version" do
+  it "returns '420.1' as its webkit version" do
     expect(@useragent.webkit.version).to eq("420.1")
   end
 
-  it "should return 'iPhone' as its platform" do
+  it "returns 'iPhone' as its platform" do
     expect(@useragent.platform).to eq("iPhone")
   end
 
-  it "should return 'CPU like Mac OS X' as its os" do
+  it "returns 'CPU like Mac OS X' as its os" do
     expect(@useragent.os).to eq("CPU like Mac OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 
@@ -608,29 +608,29 @@ describe "UserAgent: 'Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/4
     @useragent = UserAgent.parse("Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '419' as its build" do
+  it "returns '419' as its build" do
     expect(@useragent.build).to eq("420.1")
   end
 
-  it "should return '3.0' as its version" do
+  it "returns '3.0' as its version" do
     expect(@useragent.version).to eq("3.0")
   end
 
-  it "should return '420.1' as its webkit version" do
+  it "returns '420.1' as its webkit version" do
     expect(@useragent.webkit.version).to eq("420.1")
   end
 
-  it "should return 'iPod' as its platform" do
+  it "returns 'iPod' as its platform" do
     expect(@useragent.platform).to eq("iPod")
   end
 
-  it "should return 'CPU like Mac OS X' as its os" do
+  it "returns 'CPU like Mac OS X' as its os" do
     expect(@useragent.os).to eq("CPU like Mac OS X")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en")
   end
 
@@ -642,29 +642,29 @@ describe "UserAgent: Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) Appl
     @useragent = UserAgent.parse("Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '531.21.10' as its build" do
+  it "returns '531.21.10' as its build" do
     expect(@useragent.build).to eq("531.21.10")
   end
 
-  it "should return '4.0.4' as its version" do
+  it "returns '4.0.4' as its version" do
     expect(@useragent.version).to eq("4.0.4")
   end
 
-  it "should return '531.21.10' as its webkit version" do
+  it "returns '531.21.10' as its webkit version" do
     expect(@useragent.webkit.version).to eq("531.21.10")
   end
 
-  it "should return 'iPad' as its platform" do
+  it "returns 'iPad' as its platform" do
     expect(@useragent.platform).to eq("iPad")
   end
 
-  it "should return 'iOS 3.2' as its os" do
+  it "returns 'iOS 3.2' as its os" do
     expect(@useragent.os).to eq("iOS 3.2")
   end
 
-  it "should return 'en-us' as its localization" do
+  it "returns 'en-us' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
@@ -676,29 +676,29 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X;
     @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '528.18' as its build" do
+  it "returns '528.18' as its build" do
     expect(@useragent.build).to eq("528.18")
   end
 
-  it "should return '4.0' as its version" do
+  it "returns '4.0' as its version" do
     expect(@useragent.version).to eq("4.0")
   end
 
-  it "should return '528.18' as its webkit version" do
+  it "returns '528.18' as its webkit version" do
     expect(@useragent.webkit.version).to eq("528.18")
   end
 
-  it "should return 'iPhone' as its platform" do
+  it "returns 'iPhone' as its platform" do
     expect(@useragent.platform).to eq("iPhone")
   end
 
-  it "should return 'iOS 3.1.3' as its os" do
+  it "returns 'iOS 3.1.3' as its os" do
     expect(@useragent.os).to eq("iOS 3.1.3")
   end
 
-  it "should return 'en-us' as its localization" do
+  it "returns 'en-us' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 end
@@ -708,29 +708,29 @@ describe "UserAgent: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; e
     @useragent = UserAgent.parse("Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '528.18' as its build" do
+  it "returns '528.18' as its build" do
     expect(@useragent.build).to eq("528.18")
   end
 
-  it "should return '4.0' as its version" do
+  it "returns '4.0' as its version" do
     expect(@useragent.version).to eq("4.0")
   end
 
-  it "should return '528.18' as its webkit version" do
+  it "returns '528.18' as its webkit version" do
     expect(@useragent.webkit.version).to eq("528.18")
   end
 
-  it "should return 'iPod' as its platform" do
+  it "returns 'iPod' as its platform" do
     expect(@useragent.platform).to eq("iPod")
   end
 
-  it "should return 'iOS 3.1.3' as its os" do
+  it "returns 'iOS 3.1.3' as its os" do
     expect(@useragent.os).to eq("iOS 3.1.3")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
@@ -742,29 +742,29 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) A
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '533.19.4' as its build" do
+  it "returns '533.19.4' as its build" do
     expect(@useragent.build).to eq("533.19.4")
   end
 
-  it "should return '5.0.3' as its version" do
+  it "returns '5.0.3' as its version" do
     expect(@useragent.version).to eq("5.0.3")
   end
 
-  it "should return '533.19.4' as its webkit version" do
+  it "returns '533.19.4' as its webkit version" do
     expect(@useragent.webkit.version).to eq("533.19.4")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.6.5' as its os" do
+  it "returns 'OS X 10.6.5' as its os" do
     expect(@useragent.os).to eq("OS X 10.6.5")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
@@ -776,29 +776,29 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; e
     @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '532.9' as its build" do
+  it "returns '532.9' as its build" do
     expect(@useragent.build).to eq("532.9")
   end
 
-  it "should return '4.0.5' as its version" do
+  it "returns '4.0.5' as its version" do
     expect(@useragent.version).to eq("4.0.5")
   end
 
-  it "should return '532.9' as its webkit version" do
+  it "returns '532.9' as its webkit version" do
     expect(@useragent.webkit.version).to eq("532.9")
   end
 
-  it "should return 'iPhone' as its platform" do
+  it "returns 'iPhone' as its platform" do
     expect(@useragent.platform).to eq("iPhone")
   end
 
-  it "should return 'iOS 4.1'" do
+  it "returns 'iOS 4.1'" do
     expect(@useragent.os).to eq("iOS 4.1")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
@@ -810,29 +810,29 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X;
     @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '532.9' as its build" do
+  it "returns '532.9' as its build" do
     expect(@useragent.build).to eq("532.9")
   end
 
-  it "should return '4.0.1' as its version" do
+  it "returns '4.0.1' as its version" do
     expect(@useragent.version).to eq("4.0.1")
   end
 
-  it "should return '532.9' as its webkit version" do
+  it "returns '532.9' as its webkit version" do
     expect(@useragent.webkit.version).to eq("532.9")
   end
 
-  it "should return 'iPhone' as its platform" do
+  it "returns 'iPhone' as its platform" do
     expect(@useragent.platform).to eq("iPhone")
   end
 
-  it "should return 'iOS 4.0.1'" do
+  it "returns 'iOS 4.0.1'" do
     expect(@useragent.os).to eq("iOS 4.0.1")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
@@ -844,29 +844,29 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like
     @useragent = UserAgent.parse("Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7")
   end
 
-  it_should_behave_like "Safari browser"
+  it_behaves_like "Safari browser"
 
-  it "should return '532.9' as its build" do
+  it "returns '532.9' as its build" do
     expect(@useragent.build).to eq("532.9")
   end
 
-  it "should return '4.0.5' as its version" do
+  it "returns '4.0.5' as its version" do
     expect(@useragent.version).to eq("4.0.5")
   end
 
-  it "should return '532.9' as its webkit version" do
+  it "returns '532.9' as its webkit version" do
     expect(@useragent.webkit.version).to eq("532.9")
   end
 
-  it "should return 'iPhone' as its platform" do
+  it "returns 'iPhone' as its platform" do
     expect(@useragent.platform).to eq("iPhone Simulator")
   end
 
-  it "should return 'iOS 4.0.1'" do
+  it "returns 'iOS 4.0.1'" do
     expect(@useragent.os).to eq("iOS 4.0.1")
   end
 
-  it "should return 'en' as its localization" do
+  it "returns 'en' as its localization" do
     expect(@useragent.localization).to eq("en-us")
   end
 
@@ -878,27 +878,27 @@ describe "UserAgent: 'Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/P
     @useragent = UserAgent.parse("Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1")
   end
 
-  it "should return 'Android' as its browser" do
+  it "returns 'Android' as its browser" do
     expect(@useragent.browser).to eq("Android")
   end
 
-  it "should return '528.5+' as its build" do
+  it "returns '528.5+' as its build" do
     expect(@useragent.build).to eq("528.5+")
   end
 
-  it "should return '3.1.2' as its version" do
+  it "returns '3.1.2' as its version" do
     expect(@useragent.version).to eq("3.1.2")
   end
 
-  it "should return '528.5+' as its webkit version" do
+  it "returns '528.5+' as its webkit version" do
     expect(@useragent.webkit.version).to eq("528.5+")
   end
 
-  it "should return 'Android' as its platform" do
+  it "returns 'Android' as its platform" do
     expect(@useragent.platform).to eq("Android")
   end
 
-  it "should return 'Android 1.5' as its os" do
+  it "returns 'Android 1.5' as its os" do
     expect(@useragent.os).to eq("Android 1.5")
   end
 
@@ -910,27 +910,27 @@ describe "UserAgent: 'Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebK
     @useragent = UserAgent.parse("Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+")
   end
 
-  it "should return 'BlackBerry' as its browser" do
+  it "returns 'BlackBerry' as its browser" do
     expect(@useragent.browser).to eq("BlackBerry")
   end
 
-  it "should return '534.1+' as its build" do
+  it "returns '534.1+' as its build" do
     expect(@useragent.build).to eq("534.1+")
   end
 
-  it "should return '6.0.0.141' as its version" do
+  it "returns '6.0.0.141' as its version" do
     expect(@useragent.version).to eq("6.0.0.141")
   end
 
-  it "should return '534.1+' as its webkit version" do
+  it "returns '534.1+' as its webkit version" do
     expect(@useragent.webkit.version).to eq("534.1+")
   end
 
-  it "should return 'BlackBerry' as its platform" do
+  it "returns 'BlackBerry' as its platform" do
     expect(@useragent.platform).to eq("BlackBerry")
   end
 
-  it "should return 'BlackBerry 9800' as its os" do
+  it "returns 'BlackBerry 9800' as its os" do
     expect(@useragent.os).to eq("BlackBerry 9800")
   end
 
@@ -942,27 +942,27 @@ describe "UserAgent: 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like 
     @useragent = UserAgent.parse("Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+")
   end
 
-  it "should return 'BlackBerry' as its browser" do
+  it "returns 'BlackBerry' as its browser" do
     expect(@useragent.browser).to eq("BlackBerry")
   end
 
-  it "should return '537.3+' as its build" do
+  it "returns '537.3+' as its build" do
     expect(@useragent.build).to eq("537.3+")
   end
 
-  it "should return '10.0.9.388' as its version" do
+  it "returns '10.0.9.388' as its version" do
     expect(@useragent.version).to eq("10.0.9.388")
   end
 
-  it "should return '537.3+' as its webkit version" do
+  it "returns '537.3+' as its webkit version" do
     expect(@useragent.webkit.version).to eq("537.3+")
   end
 
-  it "should return 'BlackBerry' as its platform" do
+  it "returns 'BlackBerry' as its platform" do
     expect(@useragent.platform).to eq("BlackBerry")
   end
 
-  it "should return 'Touch' as its os" do
+  it "returns 'Touch' as its os" do
     expect(@useragent.os).to eq("Touch")
   end
 
@@ -974,35 +974,35 @@ describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22")
   end
 
-  it "should return 'Safari' as its browser" do
+  it "returns 'Safari' as its browser" do
     expect(@useragent.browser).to eq("Safari")
   end
 
-  it "should return nil as its security" do
+  it "returns nil as its security" do
     expect(@useragent.security).to be_nil
   end
 
-  it "should return '534.51.22' as its build" do
+  it "returns '534.51.22' as its build" do
     expect(@useragent.build).to eq("534.51.22")
   end
 
-  it "should return '5.1.1' as its version" do
+  it "returns '5.1.1' as its version" do
     expect(@useragent.version).to eq("5.1.1")
   end
 
-  it "should return '534.51.22' as its webkit version" do
+  it "returns '534.51.22' as its webkit version" do
     expect(@useragent.webkit.version).to eq("534.51.22")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.7.2' as its os" do
+  it "returns 'OS X 10.7.2' as its os" do
     expect(@useragent.os).to eq("OS X 10.7.2")
   end
 
-  it "should return nil as its localization" do
+  it "returns nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 
@@ -1014,11 +1014,11 @@ describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (K
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)")
   end
 
-  it "should return 'Safari' as its browser" do
+  it "returns 'Safari' as its browser" do
     expect(@useragent.browser).to eq("Safari")
   end
 
-  it "should return '5.1.2' as its version" do
+  it "returns '5.1.2' as its version" do
     expect(@useragent.version).to eq("5.1.2")
   end
 end
@@ -1028,23 +1028,23 @@ describe "UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/
     @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36")
   end
 
-  it "should return '537.36' as its build" do
+  it "returns '537.36' as its build" do
     expect(@useragent.build).to eq("537.36")
   end
 
-  it "should return null as its version" do
+  it "returns null as its version" do
     expect(@useragent.version).to eq("")
   end
 
-  it "should return '537.36' as its webkit version" do
+  it "returns '537.36' as its webkit version" do
     expect(@useragent.webkit.version).to eq("537.36")
   end
 
-  it "should return 'Macintosh' as its platform" do
+  it "returns 'Macintosh' as its platform" do
     expect(@useragent.platform).to eq("Macintosh")
   end
 
-  it "should return 'OS X 10.9.5' as its os" do
+  it "returns 'OS X 10.9.5' as its os" do
     expect(@useragent.os).to eq("OS X 10.9.5")
   end
 
@@ -1056,23 +1056,23 @@ describe "UserAgent: Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36")
   end
 
-  it "should return '537.36' as its build" do
+  it "returns '537.36' as its build" do
     expect(@useragent.build).to eq("537.36")
   end
 
-  it "should return '30.0.1599.38' as its version" do
+  it "returns '30.0.1599.38' as its version" do
     expect(@useragent.version).to eq("30.0.1599.38")
   end
 
-  it "should return '537.36' as its webkit version" do
+  it "returns '537.36' as its webkit version" do
     expect(@useragent.webkit.version).to eq("537.36")
   end
 
-  it "should return 'ChromeOS' as its platform" do
+  it "returns 'ChromeOS' as its platform" do
     expect(@useragent.platform).to eq("ChromeOS")
   end
 
-  it "should return 'ChromeOS 4537.56.0' as its os" do
+  it "returns 'ChromeOS 4537.56.0' as its os" do
     expect(@useragent.os).to eq("ChromeOS 4537.56.0")
   end
 
@@ -1084,23 +1084,23 @@ describe "UserAgent: Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36")
   end
 
-  it "should return '537.36' as its build" do
+  it "returns '537.36' as its build" do
     expect(@useragent.build).to eq("537.36")
   end
 
-  it "should return '32.0.1700.95' as its version" do
+  it "returns '32.0.1700.95' as its version" do
     expect(@useragent.version).to eq("32.0.1700.95")
   end
 
-  it "should return '537.36' as its webkit version" do
+  it "returns '537.36' as its webkit version" do
     expect(@useragent.webkit.version).to eq("537.36")
   end
 
-  it "should return 'ChromeOS' as its platform" do
+  it "returns 'ChromeOS' as its platform" do
     expect(@useragent.platform).to eq("ChromeOS")
   end
 
-  it "should return 'ChromeOS 4920.71.0' as its os" do
+  it "returns 'ChromeOS 4920.71.0' as its os" do
     expect(@useragent.os).to eq("ChromeOS 4920.71.0")
   end
 
@@ -1112,23 +1112,23 @@ describe "UserAgent: Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/5
     @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5")
   end
 
-  it "should return '532.5' as its build" do
+  it "returns '532.5' as its build" do
     expect(@useragent.build).to eq("532.5")
   end
 
-  it "should return '4.0.253.0' as its version" do
+  it "returns '4.0.253.0' as its version" do
     expect(@useragent.version).to eq("4.0.253.0")
   end
 
-  it "should return '532.5' as its webkit version" do
+  it "returns '532.5' as its webkit version" do
     expect(@useragent.webkit.version).to eq("532.5")
   end
 
-  it "should return 'ChromeOS' as its platform" do
+  it "returns 'ChromeOS' as its platform" do
     expect(@useragent.platform).to eq("ChromeOS")
   end
 
-  it "should return 'ChromeOS 9.10.0' as its os" do
+  it "returns 'ChromeOS 9.10.0' as its os" do
     expect(@useragent.os).to eq("ChromeOS 9.10.0")
   end
 
@@ -1140,23 +1140,23 @@ describe "UserAgent: Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS
     @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5")
   end
 
-  it "should return '533.17.9' as its build" do
+  it "returns '533.17.9' as its build" do
     expect(@useragent.build).to eq("533.17.9")
   end
 
-  it "should return '5.0.2' as its version" do
+  it "returns '5.0.2' as its version" do
     expect(@useragent.version).to eq("5.0.2")
   end
 
-  it "should return '533.17.9' as its webkit version" do
+  it "returns '533.17.9' as its webkit version" do
     expect(@useragent.webkit.version).to eq("533.17.9")
   end
 
-  it "should return 'iPhone' as its platform" do
+  it "returns 'iPhone' as its platform" do
     expect(@useragent.platform).to eq("iPhone")
   end
 
-  it "should return 'iOS 4.2.1' as its os" do
+  it "returns 'iOS 4.2.1' as its os" do
     expect(@useragent.os).to eq("iOS 4.2.1")
   end
 
@@ -1168,35 +1168,35 @@ describe "UserAgent: Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build
     @useragent = UserAgent.parse("Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30")
   end
 
-  it "should return 'Android' as its browser" do
+  it "returns 'Android' as its browser" do
     expect(@useragent.browser).to eq("Android")
   end
 
-  it "should return :strong as its security" do
+  it "returns :strong as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 
-  it "should return '534.30' as its build" do
+  it "returns '534.30' as its build" do
     expect(@useragent.build).to eq("534.30")
   end
 
-  it "should return '4.0' as its version" do
+  it "returns '4.0' as its version" do
     expect(@useragent.version).to eq("4.0")
   end
 
-  it "should return '534.30' as its webkit version" do
+  it "returns '534.30' as its webkit version" do
     expect(@useragent.webkit.version).to eq("534.30")
   end
 
-  it "should return 'Android' as its platform" do
+  it "returns 'Android' as its platform" do
     expect(@useragent.platform).to eq("Android")
   end
 
-  it "should return 'Android 4.0.3' as its os" do
+  it "returns 'Android 4.0.3' as its os" do
     expect(@useragent.os).to eq("Android 4.0.3")
   end
 
-  it "should return 'ko-kr' as its localization" do
+  it "returns 'ko-kr' as its localization" do
     expect(@useragent.localization).to eq("ko-kr")
   end
 
@@ -1208,35 +1208,35 @@ describe "UserAgent: HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4
     @useragent = UserAgent.parse("HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36")
   end
 
-  it "should return 'Android' as its browser" do
+  it "returns 'Android' as its browser" do
     expect(@useragent.browser).to eq("Android")
   end
 
-  it "should return :strong as its security" do
+  it "returns :strong as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 
-  it "should return '537.36' as its build" do
+  it "returns '537.36' as its build" do
     expect(@useragent.build).to eq("537.36")
   end
 
-  it "should return nil as its version" do
+  it "returns nil as its version" do
     expect(@useragent.version).to be_nil
   end
 
-  it "should return '537.36' as its webkit version" do
+  it "returns '537.36' as its webkit version" do
     expect(@useragent.webkit.version).to eq("537.36")
   end
 
-  it "should return 'Android' as its platform" do
+  it "returns 'Android' as its platform" do
     expect(@useragent.platform).to eq("Android")
   end
 
-  it "should return 'Android 4.4.2' as its os" do
+  it "returns 'Android 4.4.2' as its os" do
     expect(@useragent.os).to eq("Android 4.4.2")
   end
 
-  it "should return 'zh-cn' as its localization" do
+  it "returns 'zh-cn' as its localization" do
     expect(@useragent.localization).to eq("zh-cn")
   end
 

--- a/spec/browsers/webkit_user_agent_spec.rb
+++ b/spec/browsers/webkit_user_agent_spec.rb
@@ -1,44 +1,45 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples_for "Safari browser" do
+shared_examples_for 'Safari browser' do
   it "should return 'Safari' as its browser" do
-    expect(@useragent.browser).to eq("Safari")
+    expect(@useragent.browser).to eq('Safari')
   end
 
-  it "should return :strong as its security" do
+  it 'should return :strong as its security' do
     expect(@useragent.security).to eq(:strong)
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16" do
+describe 'UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '533.16' as its build" do
-    expect(@useragent.build).to eq("533.16")
+    expect(@useragent.build).to eq('533.16')
   end
 
   it "should return '5.0' as its version" do
-    expect(@useragent.version).to eq("5.0")
+    expect(@useragent.version).to eq('5.0')
   end
 
   it "should return '533.16' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("533.16")
+    expect(@useragent.webkit.version).to eq('533.16')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.6.3' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6.3")
+    expect(@useragent.os).to eq('OS X 10.6.3')
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -46,33 +47,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '526.8' as its build" do
-    expect(@useragent.build).to eq("526.9")
+    expect(@useragent.build).to eq('526.9')
   end
 
   it "should return '4.0dp1' as its version" do
-    expect(@useragent.version).to eq("4.0dp1")
+    expect(@useragent.version).to eq('4.0dp1')
   end
 
   it "should return '526.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("526.9")
+    expect(@useragent.webkit.version).to eq('526.9')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.5.3' as its os" do
-    expect(@useragent.os).to eq("OS X 10.5.3")
+    expect(@useragent.os).to eq('OS X 10.5.3')
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -80,33 +81,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '526.8' as its build" do
-    expect(@useragent.build).to eq("526.9")
+    expect(@useragent.build).to eq('526.9')
   end
 
   it "should return '4.0dp1' as its version" do
-    expect(@useragent.version).to eq("4.0dp1")
+    expect(@useragent.version).to eq('4.0dp1')
   end
 
   it "should return '526.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("526.9")
+    expect(@useragent.webkit.version).to eq('526.9')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -114,33 +115,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '525.18' as its build" do
-    expect(@useragent.build).to eq("525.18")
+    expect(@useragent.build).to eq('525.18')
   end
 
   it "should return '3.1.1' as its version" do
-    expect(@useragent.version).to eq("3.1.1")
+    expect(@useragent.version).to eq('3.1.1')
   end
 
   it "should return '525.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("525.18")
+    expect(@useragent.webkit.version).to eq('525.18')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.5.3' as its os" do
-    expect(@useragent.os).to eq("OS X 10.5.3")
+    expect(@useragent.os).to eq('OS X 10.5.3')
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it "should be == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
@@ -148,19 +149,19 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) A
   end
 
   it "should not be == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).not_to eq(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3"))
+    expect(@useragent).not_to eq(UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'))
   end
 
   it "should be > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).to be > UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
+    expect(@useragent).to be > UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3')
   end
 
   it "should not be > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).not_to be > UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
+    expect(@useragent).not_to be > UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
   end
 
   it "should be < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).to be < UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
+    expect(@useragent).to be < UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
   end
 
   it "should not be < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
@@ -168,11 +169,11 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) A
   end
 
   it "should be >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).to be >= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
+    expect(@useragent).to be >= UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3')
   end
 
   it "should not be >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).not_to be >= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
+    expect(@useragent).not_to be >= UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
   end
 
   it "should be <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
@@ -180,423 +181,423 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) A
   end
 
   it "should not be <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).not_to be <= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
+    expect(@useragent).not_to be <= UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '525.18' as its build" do
-    expect(@useragent.build).to eq("525.18")
+    expect(@useragent.build).to eq('525.18')
   end
 
   it "should return '3.1.1' as its version" do
-    expect(@useragent.version).to eq("3.1.1")
+    expect(@useragent.version).to eq('3.1.1')
   end
 
   it "should return '525.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("525.18")
+    expect(@useragent.webkit.version).to eq('525.18')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    expect(@useragent.os).to eq('Windows XP')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '419.3' as its build" do
-    expect(@useragent.build).to eq("419")
+    expect(@useragent.build).to eq('419')
   end
 
   it "should return '2.0.4' as its version" do
-    expect(@useragent.version).to eq("2.0.4")
+    expect(@useragent.version).to eq('2.0.4')
   end
 
   it "should return '419' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("419")
+    expect(@useragent.webkit.version).to eq('419')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '412.2' as its build" do
-    expect(@useragent.build).to eq("412.6")
+    expect(@useragent.build).to eq('412.6')
   end
 
   it "should return '2.0' as its version" do
-    expect(@useragent.version).to eq("2.0")
+    expect(@useragent.version).to eq('2.0')
   end
 
   it "should return '412.6' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("412.6")
+    expect(@useragent.webkit.version).to eq('412.6')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '412.2.2' as its build" do
-    expect(@useragent.build).to eq("412.6.2")
+    expect(@useragent.build).to eq('412.6.2')
   end
 
   it "should return '2.0' as its version" do
-    expect(@useragent.version).to eq("2.0")
+    expect(@useragent.version).to eq('2.0')
   end
 
   it "should return '412.6.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("412.6.2")
+    expect(@useragent.webkit.version).to eq('412.6.2')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '312.6' as its build" do
-    expect(@useragent.build).to eq("312.8")
+    expect(@useragent.build).to eq('312.8')
   end
 
   it "should return '1.3.2' as its version" do
-    expect(@useragent.version).to eq("1.3.2")
+    expect(@useragent.version).to eq('1.3.2')
   end
 
   it "should return '312.8' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.8")
+    expect(@useragent.webkit.version).to eq('312.8')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '312' as its build" do
-    expect(@useragent.build).to eq("312.1.1")
+    expect(@useragent.build).to eq('312.1.1')
   end
 
   it "should return '1.3' as its version" do
-    expect(@useragent.version).to eq("1.3")
+    expect(@useragent.version).to eq('1.3')
   end
 
   it "should return '312.1.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.1.1")
+    expect(@useragent.webkit.version).to eq('312.1.1')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("fr-ch")
+    expect(@useragent.localization).to eq('fr-ch')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '312.3.3' as its build" do
-    expect(@useragent.build).to eq("312.5.2")
+    expect(@useragent.build).to eq('312.5.2')
   end
 
   it "should return '1.3.1' as its version" do
-    expect(@useragent.version).to eq("1.3.1")
+    expect(@useragent.version).to eq('1.3.1')
   end
 
   it "should return '312.5.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.5.2")
+    expect(@useragent.webkit.version).to eq('312.5.2')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("es-es")
+    expect(@useragent.localization).to eq('es-es')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '312.3.1' as its build" do
-    expect(@useragent.build).to eq("312.5.1")
+    expect(@useragent.build).to eq('312.5.1')
   end
 
   it "should return '1.3.1' as its version" do
-    expect(@useragent.version).to eq("1.3.1")
+    expect(@useragent.version).to eq('1.3.1')
   end
 
   it "should return '312.5.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.5.1")
+    expect(@useragent.webkit.version).to eq('312.5.1')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("fr")
+    expect(@useragent.localization).to eq('fr')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '312.3' as its build" do
-    expect(@useragent.build).to eq("312.5")
+    expect(@useragent.build).to eq('312.5')
   end
 
   it "should return '1.3.1' as its version" do
-    expect(@useragent.version).to eq("1.3.1")
+    expect(@useragent.version).to eq('1.3.1')
   end
 
   it "should return '312.5' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.5")
+    expect(@useragent.webkit.version).to eq('312.5')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '125' as its build" do
-    expect(@useragent.build).to eq("124")
+    expect(@useragent.build).to eq('124')
   end
 
   it "should return '1.2' as its version" do
-    expect(@useragent.version).to eq("1.2")
+    expect(@useragent.version).to eq('1.2')
   end
 
   it "should return '124' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("124")
+    expect(@useragent.webkit.version).to eq('124')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '125.12' as its build" do
-    expect(@useragent.build).to eq("125.5.7")
+    expect(@useragent.build).to eq('125.5.7')
   end
 
   it "should return '1.2.4' as its version" do
-    expect(@useragent.version).to eq("1.2.4")
+    expect(@useragent.version).to eq('1.2.4')
   end
 
   it "should return '125.5.7' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("125.5.7")
+    expect(@useragent.webkit.version).to eq('125.5.7')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '85.5' as its build" do
-    expect(@useragent.build).to eq("85.7")
+    expect(@useragent.build).to eq('85.7')
   end
 
   it "should return '1.0' as its version" do
-    expect(@useragent.version).to eq("1.0")
+    expect(@useragent.version).to eq('1.0')
   end
 
   it "should return '85.7' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("85.7")
+    expect(@useragent.webkit.version).to eq('85.7')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    expect(@useragent.os).to eq('OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("fr-fr")
+    expect(@useragent.localization).to eq('fr-fr')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '419' as its build" do
-    expect(@useragent.build).to eq("420.1")
+    expect(@useragent.build).to eq('420.1')
   end
 
   it "should return '3.0' as its version" do
-    expect(@useragent.version).to eq("3.0")
+    expect(@useragent.version).to eq('3.0')
   end
 
   it "should return '420.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("420.1")
+    expect(@useragent.webkit.version).to eq('420.1')
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
+    expect(@useragent.platform).to eq('iPhone')
   end
 
   it "should return 'CPU like Mac OS X' as its os" do
-    expect(@useragent.os).to eq("CPU like Mac OS X")
+    expect(@useragent.os).to eq('CPU like Mac OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -604,67 +605,67 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '419' as its build" do
-    expect(@useragent.build).to eq("420.1")
+    expect(@useragent.build).to eq('420.1')
   end
 
   it "should return '3.0' as its version" do
-    expect(@useragent.version).to eq("3.0")
+    expect(@useragent.version).to eq('3.0')
   end
 
   it "should return '420.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("420.1")
+    expect(@useragent.webkit.version).to eq('420.1')
   end
 
   it "should return 'iPod' as its platform" do
-    expect(@useragent.platform).to eq("iPod")
+    expect(@useragent.platform).to eq('iPod')
   end
 
   it "should return 'CPU like Mac OS X' as its os" do
-    expect(@useragent.os).to eq("CPU like Mac OS X")
+    expect(@useragent.os).to eq('CPU like Mac OS X')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    expect(@useragent.localization).to eq('en')
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe "UserAgent: Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10" do
+describe 'UserAgent: Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '531.21.10' as its build" do
-    expect(@useragent.build).to eq("531.21.10")
+    expect(@useragent.build).to eq('531.21.10')
   end
 
   it "should return '4.0.4' as its version" do
-    expect(@useragent.version).to eq("4.0.4")
+    expect(@useragent.version).to eq('4.0.4')
   end
 
   it "should return '531.21.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("531.21.10")
+    expect(@useragent.webkit.version).to eq('531.21.10')
   end
 
   it "should return 'iPad' as its platform" do
-    expect(@useragent.platform).to eq("iPad")
+    expect(@useragent.platform).to eq('iPad')
   end
 
   it "should return 'iOS 3.2' as its os" do
-    expect(@useragent.os).to eq("iOS 3.2")
+    expect(@useragent.os).to eq('iOS 3.2')
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -672,65 +673,65 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '528.18' as its build" do
-    expect(@useragent.build).to eq("528.18")
+    expect(@useragent.build).to eq('528.18')
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
+    expect(@useragent.version).to eq('4.0')
   end
 
   it "should return '528.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("528.18")
+    expect(@useragent.webkit.version).to eq('528.18')
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
+    expect(@useragent.platform).to eq('iPhone')
   end
 
   it "should return 'iOS 3.1.3' as its os" do
-    expect(@useragent.os).to eq("iOS 3.1.3")
+    expect(@useragent.os).to eq('iOS 3.1.3')
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '528.18' as its build" do
-    expect(@useragent.build).to eq("528.18")
+    expect(@useragent.build).to eq('528.18')
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
+    expect(@useragent.version).to eq('4.0')
   end
 
   it "should return '528.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("528.18")
+    expect(@useragent.webkit.version).to eq('528.18')
   end
 
   it "should return 'iPod' as its platform" do
-    expect(@useragent.platform).to eq("iPod")
+    expect(@useragent.platform).to eq('iPod')
   end
 
   it "should return 'iOS 3.1.3' as its os" do
-    expect(@useragent.os).to eq("iOS 3.1.3")
+    expect(@useragent.os).to eq('iOS 3.1.3')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -738,33 +739,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '533.19.4' as its build" do
-    expect(@useragent.build).to eq("533.19.4")
+    expect(@useragent.build).to eq('533.19.4')
   end
 
   it "should return '5.0.3' as its version" do
-    expect(@useragent.version).to eq("5.0.3")
+    expect(@useragent.version).to eq('5.0.3')
   end
 
   it "should return '533.19.4' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("533.19.4")
+    expect(@useragent.webkit.version).to eq('533.19.4')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6.5")
+    expect(@useragent.os).to eq('OS X 10.6.5')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -772,33 +773,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '532.9' as its build" do
-    expect(@useragent.build).to eq("532.9")
+    expect(@useragent.build).to eq('532.9')
   end
 
   it "should return '4.0.5' as its version" do
-    expect(@useragent.version).to eq("4.0.5")
+    expect(@useragent.version).to eq('4.0.5')
   end
 
   it "should return '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("532.9")
+    expect(@useragent.webkit.version).to eq('532.9')
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
+    expect(@useragent.platform).to eq('iPhone')
   end
 
   it "should return 'iOS 4.1'" do
-    expect(@useragent.os).to eq("iOS 4.1")
+    expect(@useragent.os).to eq('iOS 4.1')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -806,33 +807,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '532.9' as its build" do
-    expect(@useragent.build).to eq("532.9")
+    expect(@useragent.build).to eq('532.9')
   end
 
   it "should return '4.0.1' as its version" do
-    expect(@useragent.version).to eq("4.0.1")
+    expect(@useragent.version).to eq('4.0.1')
   end
 
   it "should return '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("532.9")
+    expect(@useragent.webkit.version).to eq('532.9')
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
+    expect(@useragent.platform).to eq('iPhone')
   end
 
   it "should return 'iOS 4.0.1'" do
-    expect(@useragent.os).to eq("iOS 4.0.1")
+    expect(@useragent.os).to eq('iOS 4.0.1')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -840,33 +841,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7')
   end
 
-  it_should_behave_like "Safari browser"
+  it_should_behave_like 'Safari browser'
 
   it "should return '532.9' as its build" do
-    expect(@useragent.build).to eq("532.9")
+    expect(@useragent.build).to eq('532.9')
   end
 
   it "should return '4.0.5' as its version" do
-    expect(@useragent.version).to eq("4.0.5")
+    expect(@useragent.version).to eq('4.0.5')
   end
 
   it "should return '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("532.9")
+    expect(@useragent.webkit.version).to eq('532.9')
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone Simulator")
+    expect(@useragent.platform).to eq('iPhone Simulator')
   end
 
   it "should return 'iOS 4.0.1'" do
-    expect(@useragent.os).to eq("iOS 4.0.1")
+    expect(@useragent.os).to eq('iOS 4.0.1')
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    expect(@useragent.localization).to eq('en-us')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -874,31 +875,31 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1')
   end
 
   it "should return 'Android' as its browser" do
-    expect(@useragent.browser).to eq("Android")
+    expect(@useragent.browser).to eq('Android')
   end
 
   it "should return '528.5+' as its build" do
-    expect(@useragent.build).to eq("528.5+")
+    expect(@useragent.build).to eq('528.5+')
   end
 
   it "should return '3.1.2' as its version" do
-    expect(@useragent.version).to eq("3.1.2")
+    expect(@useragent.version).to eq('3.1.2')
   end
 
   it "should return '528.5+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("528.5+")
+    expect(@useragent.webkit.version).to eq('528.5+')
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
+    expect(@useragent.platform).to eq('Android')
   end
 
   it "should return 'Android 1.5' as its os" do
-    expect(@useragent.os).to eq("Android 1.5")
+    expect(@useragent.os).to eq('Android 1.5')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -906,31 +907,31 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+")
+    @useragent = UserAgent.parse('Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+')
   end
 
   it "should return 'BlackBerry' as its browser" do
-    expect(@useragent.browser).to eq("BlackBerry")
+    expect(@useragent.browser).to eq('BlackBerry')
   end
 
   it "should return '534.1+' as its build" do
-    expect(@useragent.build).to eq("534.1+")
+    expect(@useragent.build).to eq('534.1+')
   end
 
   it "should return '6.0.0.141' as its version" do
-    expect(@useragent.version).to eq("6.0.0.141")
+    expect(@useragent.version).to eq('6.0.0.141')
   end
 
   it "should return '534.1+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.1+")
+    expect(@useragent.webkit.version).to eq('534.1+')
   end
 
   it "should return 'BlackBerry' as its platform" do
-    expect(@useragent.platform).to eq("BlackBerry")
+    expect(@useragent.platform).to eq('BlackBerry')
   end
 
   it "should return 'BlackBerry 9800' as its os" do
-    expect(@useragent.os).to eq("BlackBerry 9800")
+    expect(@useragent.os).to eq('BlackBerry 9800')
   end
 
   it { expect(@useragent).to be_mobile }
@@ -938,305 +939,305 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+")
+    @useragent = UserAgent.parse('Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+')
   end
 
   it "should return 'BlackBerry' as its browser" do
-    expect(@useragent.browser).to eq("BlackBerry")
+    expect(@useragent.browser).to eq('BlackBerry')
   end
 
   it "should return '537.3+' as its build" do
-    expect(@useragent.build).to eq("537.3+")
+    expect(@useragent.build).to eq('537.3+')
   end
 
   it "should return '10.0.9.388' as its version" do
-    expect(@useragent.version).to eq("10.0.9.388")
+    expect(@useragent.version).to eq('10.0.9.388')
   end
 
   it "should return '537.3+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.3+")
+    expect(@useragent.webkit.version).to eq('537.3+')
   end
 
   it "should return 'BlackBerry' as its platform" do
-    expect(@useragent.platform).to eq("BlackBerry")
+    expect(@useragent.platform).to eq('BlackBerry')
   end
 
   it "should return 'Touch' as its os" do
-    expect(@useragent.os).to eq("Touch")
+    expect(@useragent.os).to eq('Touch')
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22" do
+describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22')
   end
 
   it "should return 'Safari' as its browser" do
-    expect(@useragent.browser).to eq("Safari")
+    expect(@useragent.browser).to eq('Safari')
   end
 
-  it "should return nil as its security" do
+  it 'should return nil as its security' do
     expect(@useragent.security).to be_nil
   end
 
   it "should return '534.51.22' as its build" do
-    expect(@useragent.build).to eq("534.51.22")
+    expect(@useragent.build).to eq('534.51.22')
   end
 
   it "should return '5.1.1' as its version" do
-    expect(@useragent.version).to eq("5.1.1")
+    expect(@useragent.version).to eq('5.1.1')
   end
 
   it "should return '534.51.22' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.51.22")
+    expect(@useragent.webkit.version).to eq('534.51.22')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.7.2' as its os" do
-    expect(@useragent.os).to eq("OS X 10.7.2")
+    expect(@useragent.os).to eq('OS X 10.7.2')
   end
 
-  it "should return nil as its localization" do
+  it 'should return nil as its localization' do
     expect(@useragent.localization).to be_nil
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)" do
+describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)')
   end
 
   it "should return 'Safari' as its browser" do
-    expect(@useragent.browser).to eq("Safari")
+    expect(@useragent.browser).to eq('Safari')
   end
 
   it "should return '5.1.2' as its version" do
-    expect(@useragent.version).to eq("5.1.2")
+    expect(@useragent.version).to eq('5.1.2')
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36" do
+describe 'UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36')
   end
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
+    expect(@useragent.build).to eq('537.36')
   end
 
-  it "should return null as its version" do
-    expect(@useragent.version).to eq("")
+  it 'should return null as its version' do
+    expect(@useragent.version).to eq('')
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
+    expect(@useragent.webkit.version).to eq('537.36')
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
+    expect(@useragent.platform).to eq('Macintosh')
   end
 
   it "should return 'OS X 10.9.5' as its os" do
-    expect(@useragent.os).to eq("OS X 10.9.5")
+    expect(@useragent.os).to eq('OS X 10.9.5')
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe "UserAgent: Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36" do
+describe 'UserAgent: Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36')
   end
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
+    expect(@useragent.build).to eq('537.36')
   end
 
   it "should return '30.0.1599.38' as its version" do
-    expect(@useragent.version).to eq("30.0.1599.38")
+    expect(@useragent.version).to eq('30.0.1599.38')
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
+    expect(@useragent.webkit.version).to eq('537.36')
   end
 
   it "should return 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq("ChromeOS")
+    expect(@useragent.platform).to eq('ChromeOS')
   end
 
   it "should return 'ChromeOS 4537.56.0' as its os" do
-    expect(@useragent.os).to eq("ChromeOS 4537.56.0")
+    expect(@useragent.os).to eq('ChromeOS 4537.56.0')
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe "UserAgent: Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36" do
+describe 'UserAgent: Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36')
   end
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
+    expect(@useragent.build).to eq('537.36')
   end
 
   it "should return '32.0.1700.95' as its version" do
-    expect(@useragent.version).to eq("32.0.1700.95")
+    expect(@useragent.version).to eq('32.0.1700.95')
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
+    expect(@useragent.webkit.version).to eq('537.36')
   end
 
   it "should return 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq("ChromeOS")
+    expect(@useragent.platform).to eq('ChromeOS')
   end
 
   it "should return 'ChromeOS 4920.71.0' as its os" do
-    expect(@useragent.os).to eq("ChromeOS 4920.71.0")
+    expect(@useragent.os).to eq('ChromeOS 4920.71.0')
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe "UserAgent: Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5" do
+describe 'UserAgent: Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5")
+    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5')
   end
 
   it "should return '532.5' as its build" do
-    expect(@useragent.build).to eq("532.5")
+    expect(@useragent.build).to eq('532.5')
   end
 
   it "should return '4.0.253.0' as its version" do
-    expect(@useragent.version).to eq("4.0.253.0")
+    expect(@useragent.version).to eq('4.0.253.0')
   end
 
   it "should return '532.5' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("532.5")
+    expect(@useragent.webkit.version).to eq('532.5')
   end
 
   it "should return 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq("ChromeOS")
+    expect(@useragent.platform).to eq('ChromeOS')
   end
 
   it "should return 'ChromeOS 9.10.0' as its os" do
-    expect(@useragent.os).to eq("ChromeOS 9.10.0")
+    expect(@useragent.os).to eq('ChromeOS 9.10.0')
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe "UserAgent: Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5" do
+describe 'UserAgent: Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5')
   end
 
   it "should return '533.17.9' as its build" do
-    expect(@useragent.build).to eq("533.17.9")
+    expect(@useragent.build).to eq('533.17.9')
   end
 
   it "should return '5.0.2' as its version" do
-    expect(@useragent.version).to eq("5.0.2")
+    expect(@useragent.version).to eq('5.0.2')
   end
 
   it "should return '533.17.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("533.17.9")
+    expect(@useragent.webkit.version).to eq('533.17.9')
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
+    expect(@useragent.platform).to eq('iPhone')
   end
 
   it "should return 'iOS 4.2.1' as its os" do
-    expect(@useragent.os).to eq("iOS 4.2.1")
+    expect(@useragent.os).to eq('iOS 4.2.1')
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe "UserAgent: Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30" do
+describe 'UserAgent: Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30' do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30')
   end
 
   it "should return 'Android' as its browser" do
-    expect(@useragent.browser).to eq("Android")
+    expect(@useragent.browser).to eq('Android')
   end
 
-  it "should return :strong as its security" do
+  it 'should return :strong as its security' do
     expect(@useragent.security).to eq(:strong)
   end
 
   it "should return '534.30' as its build" do
-    expect(@useragent.build).to eq("534.30")
+    expect(@useragent.build).to eq('534.30')
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
+    expect(@useragent.version).to eq('4.0')
   end
 
   it "should return '534.30' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.30")
+    expect(@useragent.webkit.version).to eq('534.30')
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
+    expect(@useragent.platform).to eq('Android')
   end
 
   it "should return 'Android 4.0.3' as its os" do
-    expect(@useragent.os).to eq("Android 4.0.3")
+    expect(@useragent.os).to eq('Android 4.0.3')
   end
 
   it "should return 'ko-kr' as its localization" do
-    expect(@useragent.localization).to eq("ko-kr")
+    expect(@useragent.localization).to eq('ko-kr')
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe "UserAgent: HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36" do
+describe 'UserAgent: HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36' do
   before do
-    @useragent = UserAgent.parse("HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36")
+    @useragent = UserAgent.parse('HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36')
   end
 
   it "should return 'Android' as its browser" do
-    expect(@useragent.browser).to eq("Android")
+    expect(@useragent.browser).to eq('Android')
   end
 
-  it "should return :strong as its security" do
+  it 'should return :strong as its security' do
     expect(@useragent.security).to eq(:strong)
   end
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
+    expect(@useragent.build).to eq('537.36')
   end
 
-  it "should return nil as its version" do
+  it 'should return nil as its version' do
     expect(@useragent.version).to be_nil
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
+    expect(@useragent.webkit.version).to eq('537.36')
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
+    expect(@useragent.platform).to eq('Android')
   end
 
   it "should return 'Android 4.4.2' as its os" do
-    expect(@useragent.os).to eq("Android 4.4.2")
+    expect(@useragent.os).to eq('Android 4.4.2')
   end
 
   it "should return 'zh-cn' as its localization" do
-    expect(@useragent.localization).to eq("zh-cn")
+    expect(@useragent.localization).to eq('zh-cn')
   end
 
   it { expect(@useragent).to be_mobile }

--- a/spec/browsers/webkit_user_agent_spec.rb
+++ b/spec/browsers/webkit_user_agent_spec.rb
@@ -3,1242 +3,1170 @@ require "user_agent"
 
 shared_examples_for "Safari browser" do
   it "returns 'Safari' as its browser" do
-    expect(@useragent.browser).to eq("Safari")
+    expect(useragent.browser).to eq("Safari")
   end
 
   it "returns :strong as its security" do
-    expect(@useragent.security).to eq(:strong)
+    expect(useragent.security).to eq(:strong)
   end
 end
 
-describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16")
-  end
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16") }
 
-  it_behaves_like "Safari browser"
+    it_behaves_like "Safari browser"
 
-  it "returns '533.16' as its build" do
-    expect(@useragent.build).to eq("533.16")
-  end
+    it "returns '533.16' as its build" do
+      expect(useragent.build).to eq("533.16")
+    end
 
-  it "returns '5.0' as its version" do
-    expect(@useragent.version).to eq("5.0")
-  end
+    it "returns '5.0' as its version" do
+      expect(useragent.version).to eq("5.0")
+    end
 
-  it "returns '533.16' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("533.16")
-  end
+    it "returns '533.16' as its webkit version" do
+      expect(useragent.webkit.version).to eq("533.16")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'OS X 10.6.3' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6.3")
-  end
+    it "returns 'OS X 10.6.3' as its os" do
+      expect(useragent.os).to eq("OS X 10.6.3")
+    end
+
+    it "returns 'en-us' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '526.8' as its build" do
+      expect(useragent.build).to eq("526.9")
+    end
 
-  it "returns '526.8' as its build" do
-    expect(@useragent.build).to eq("526.9")
-  end
+    it "returns '4.0dp1' as its version" do
+      expect(useragent.version).to eq("4.0dp1")
+    end
 
-  it "returns '4.0dp1' as its version" do
-    expect(@useragent.version).to eq("4.0dp1")
-  end
+    it "returns '526.9' as its webkit version" do
+      expect(useragent.webkit.version).to eq("526.9")
+    end
 
-  it "returns '526.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("526.9")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X 10.5.3' as its os" do
+      expect(useragent.os).to eq("OS X 10.5.3")
+    end
 
-  it "returns 'OS X 10.5.3' as its os" do
-    expect(@useragent.os).to eq("OS X 10.5.3")
-  end
+    it "returns 'en-us' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8") }
 
-describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '526.8' as its build" do
+      expect(useragent.build).to eq("526.9")
+    end
 
-  it "returns '526.8' as its build" do
-    expect(@useragent.build).to eq("526.9")
-  end
+    it "returns '4.0dp1' as its version" do
+      expect(useragent.version).to eq("4.0dp1")
+    end
 
-  it "returns '4.0dp1' as its version" do
-    expect(@useragent.version).to eq("4.0dp1")
-  end
+    it "returns '526.9' as its webkit version" do
+      expect(useragent.webkit.version).to eq("526.9")
+    end
 
-  it "returns '526.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("526.9")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
 
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
-  end
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '525.18' as its build" do
+      expect(useragent.build).to eq("525.18")
+    end
 
-  it "returns '525.18' as its build" do
-    expect(@useragent.build).to eq("525.18")
-  end
+    it "returns '3.1.1' as its version" do
+      expect(useragent.version).to eq("3.1.1")
+    end
 
-  it "returns '3.1.1' as its version" do
-    expect(@useragent.version).to eq("3.1.1")
-  end
+    it "returns '525.18' as its webkit version" do
+      expect(useragent.webkit.version).to eq("525.18")
+    end
 
-  it "returns '525.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("525.18")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X 10.5.3' as its os" do
+      expect(useragent.os).to eq("OS X 10.5.3")
+    end
 
-  it "returns 'OS X 10.5.3' as its os" do
-    expect(@useragent.os).to eq("OS X 10.5.3")
-  end
+    it "returns 'en-us' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
-  end
+    it "is == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
+      expect(useragent).to eq(useragent)
+    end
 
-  it "is == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
-    expect(@useragent).to eq(@useragent)
-  end
+    it "is not == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
+      expect(useragent).not_to eq(described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3"))
+    end
 
-  it "is not == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).not_to eq(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3"))
-  end
+    it "is > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
+      expect(useragent).to be > described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
+    end
 
-  it "is > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).to be > UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
-  end
+    it "is not > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
+      expect(useragent).not_to be > described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
+    end
 
-  it "is not > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).not_to be > UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
-  end
+    it "is < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
+      expect(useragent).to be < described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
+    end
 
-  it "is < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).to be < UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
-  end
+    it "is not < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
+      expect(useragent).not_to be < useragent
+    end
 
-  it "is not < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
-    expect(@useragent).not_to be < @useragent
-  end
+    it "is >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
+      expect(useragent).to be >= described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
+    end
 
-  it "is >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).to be >= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
-  end
+    it "is not >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
+      expect(useragent).not_to be >= described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
+    end
 
-  it "is not >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).not_to be >= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
-  end
+    it "is <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
+      expect(useragent).to be <= useragent
+    end
 
-  it "is <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
-    expect(@useragent).to be <= @useragent
+    it "is not <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
+      expect(useragent).not_to be <= described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
+    end
   end
 
-  it "is not <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).not_to be <= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18") }
 
-describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '525.18' as its build" do
+      expect(useragent.build).to eq("525.18")
+    end
 
-  it "returns '525.18' as its build" do
-    expect(@useragent.build).to eq("525.18")
-  end
+    it "returns '3.1.1' as its version" do
+      expect(useragent.version).to eq("3.1.1")
+    end
 
-  it "returns '3.1.1' as its version" do
-    expect(@useragent.version).to eq("3.1.1")
-  end
+    it "returns '525.18' as its webkit version" do
+      expect(useragent.webkit.version).to eq("525.18")
+    end
 
-  it "returns '525.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("525.18")
-  end
+    it "returns 'Windows' as its platform" do
+      expect(useragent.platform).to eq("Windows")
+    end
 
-  it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
-  end
+    it "returns 'Windows XP' as its os" do
+      expect(useragent.os).to eq("Windows XP")
+    end
 
-  it "returns 'Windows XP' as its os" do
-    expect(@useragent.os).to eq("Windows XP")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '419.3' as its build" do
+      expect(useragent.build).to eq("419")
+    end
 
-  it "returns '419.3' as its build" do
-    expect(@useragent.build).to eq("419")
-  end
+    it "returns '2.0.4' as its version" do
+      expect(useragent.version).to eq("2.0.4")
+    end
 
-  it "returns '2.0.4' as its version" do
-    expect(@useragent.version).to eq("2.0.4")
-  end
+    it "returns '419' as its webkit version" do
+      expect(useragent.webkit.version).to eq("419")
+    end
 
-  it "returns '419' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("419")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '412.2' as its build" do
+      expect(useragent.build).to eq("412.6")
+    end
 
-  it "returns '412.2' as its build" do
-    expect(@useragent.build).to eq("412.6")
-  end
+    it "returns '2.0' as its version" do
+      expect(useragent.version).to eq("2.0")
+    end
 
-  it "returns '2.0' as its version" do
-    expect(@useragent.version).to eq("2.0")
-  end
+    it "returns '412.6' as its webkit version" do
+      expect(useragent.webkit.version).to eq("412.6")
+    end
 
-  it "returns '412.6' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("412.6")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '412.2.2' as its build" do
+      expect(useragent.build).to eq("412.6.2")
+    end
 
-  it "returns '412.2.2' as its build" do
-    expect(@useragent.build).to eq("412.6.2")
-  end
+    it "returns '2.0' as its version" do
+      expect(useragent.version).to eq("2.0")
+    end
 
-  it "returns '2.0' as its version" do
-    expect(@useragent.version).to eq("2.0")
-  end
+    it "returns '412.6.2' as its webkit version" do
+      expect(useragent.webkit.version).to eq("412.6.2")
+    end
 
-  it "returns '412.6.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("412.6.2")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '312.6' as its build" do
+      expect(useragent.build).to eq("312.8")
+    end
 
-  it "returns '312.6' as its build" do
-    expect(@useragent.build).to eq("312.8")
-  end
+    it "returns '1.3.2' as its version" do
+      expect(useragent.version).to eq("1.3.2")
+    end
 
-  it "returns '1.3.2' as its version" do
-    expect(@useragent.version).to eq("1.3.2")
-  end
+    it "returns '312.8' as its webkit version" do
+      expect(useragent.webkit.version).to eq("312.8")
+    end
 
-  it "returns '312.8' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.8")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '312' as its build" do
+      expect(useragent.build).to eq("312.1.1")
+    end
 
-  it "returns '312' as its build" do
-    expect(@useragent.build).to eq("312.1.1")
-  end
+    it "returns '1.3' as its version" do
+      expect(useragent.version).to eq("1.3")
+    end
 
-  it "returns '1.3' as its version" do
-    expect(@useragent.version).to eq("1.3")
-  end
+    it "returns '312.1.1' as its webkit version" do
+      expect(useragent.webkit.version).to eq("312.1.1")
+    end
 
-  it "returns '312.1.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.1.1")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("fr-ch")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("fr-ch")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '312.3.3' as its build" do
+      expect(useragent.build).to eq("312.5.2")
+    end
 
-  it "returns '312.3.3' as its build" do
-    expect(@useragent.build).to eq("312.5.2")
-  end
+    it "returns '1.3.1' as its version" do
+      expect(useragent.version).to eq("1.3.1")
+    end
 
-  it "returns '1.3.1' as its version" do
-    expect(@useragent.version).to eq("1.3.1")
-  end
+    it "returns '312.5.2' as its webkit version" do
+      expect(useragent.webkit.version).to eq("312.5.2")
+    end
 
-  it "returns '312.5.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.5.2")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("es-es")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("es-es")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '312.3.1' as its build" do
+      expect(useragent.build).to eq("312.5.1")
+    end
 
-  it "returns '312.3.1' as its build" do
-    expect(@useragent.build).to eq("312.5.1")
-  end
+    it "returns '1.3.1' as its version" do
+      expect(useragent.version).to eq("1.3.1")
+    end
 
-  it "returns '1.3.1' as its version" do
-    expect(@useragent.version).to eq("1.3.1")
-  end
+    it "returns '312.5.1' as its webkit version" do
+      expect(useragent.webkit.version).to eq("312.5.1")
+    end
 
-  it "returns '312.5.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.5.1")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("fr")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("fr")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '312.3' as its build" do
+      expect(useragent.build).to eq("312.5")
+    end
 
-  it "returns '312.3' as its build" do
-    expect(@useragent.build).to eq("312.5")
-  end
+    it "returns '1.3.1' as its version" do
+      expect(useragent.version).to eq("1.3.1")
+    end
 
-  it "returns '1.3.1' as its version" do
-    expect(@useragent.version).to eq("1.3.1")
-  end
+    it "returns '312.5' as its webkit version" do
+      expect(useragent.webkit.version).to eq("312.5")
+    end
 
-  it "returns '312.5' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("312.5")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '125' as its build" do
+      expect(useragent.build).to eq("124")
+    end
 
-  it "returns '125' as its build" do
-    expect(@useragent.build).to eq("124")
-  end
+    it "returns '1.2' as its version" do
+      expect(useragent.version).to eq("1.2")
+    end
 
-  it "returns '1.2' as its version" do
-    expect(@useragent.version).to eq("1.2")
-  end
+    it "returns '124' as its webkit version" do
+      expect(useragent.webkit.version).to eq("124")
+    end
 
-  it "returns '124' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("124")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '125.12' as its build" do
+      expect(useragent.build).to eq("125.5.7")
+    end
 
-  it "returns '125.12' as its build" do
-    expect(@useragent.build).to eq("125.5.7")
-  end
+    it "returns '1.2.4' as its version" do
+      expect(useragent.version).to eq("1.2.4")
+    end
 
-  it "returns '1.2.4' as its version" do
-    expect(@useragent.version).to eq("1.2.4")
-  end
+    it "returns '125.5.7' as its webkit version" do
+      expect(useragent.webkit.version).to eq("125.5.7")
+    end
 
-  it "returns '125.5.7' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("125.5.7")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '85.5' as its build" do
+      expect(useragent.build).to eq("85.7")
+    end
 
-  it "returns '85.5' as its build" do
-    expect(@useragent.build).to eq("85.7")
-  end
+    it "returns '1.0' as its version" do
+      expect(useragent.version).to eq("1.0")
+    end
 
-  it "returns '1.0' as its version" do
-    expect(@useragent.version).to eq("1.0")
-  end
+    it "returns '85.7' as its webkit version" do
+      expect(useragent.webkit.version).to eq("85.7")
+    end
 
-  it "returns '85.7' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("85.7")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X' as its os" do
+      expect(useragent.os).to eq("OS X")
+    end
 
-  it "returns 'OS X' as its os" do
-    expect(@useragent.os).to eq("OS X")
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("fr-fr")
+    end
   end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("fr-fr")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419") }
 
-describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '419' as its build" do
+      expect(useragent.build).to eq("420.1")
+    end
 
-  it "returns '419' as its build" do
-    expect(@useragent.build).to eq("420.1")
-  end
+    it "returns '3.0' as its version" do
+      expect(useragent.version).to eq("3.0")
+    end
 
-  it "returns '3.0' as its version" do
-    expect(@useragent.version).to eq("3.0")
-  end
+    it "returns '420.1' as its webkit version" do
+      expect(useragent.webkit.version).to eq("420.1")
+    end
 
-  it "returns '420.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("420.1")
-  end
+    it "returns 'iPhone' as its platform" do
+      expect(useragent.platform).to eq("iPhone")
+    end
 
-  it "returns 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
-  end
+    it "returns 'CPU like Mac OS X' as its os" do
+      expect(useragent.os).to eq("CPU like Mac OS X")
+    end
 
-  it "returns 'CPU like Mac OS X' as its os" do
-    expect(@useragent.os).to eq("CPU like Mac OS X")
-  end
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419") }
 
-describe "UserAgent: 'Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '419' as its build" do
+      expect(useragent.build).to eq("420.1")
+    end
 
-  it "returns '419' as its build" do
-    expect(@useragent.build).to eq("420.1")
-  end
+    it "returns '3.0' as its version" do
+      expect(useragent.version).to eq("3.0")
+    end
 
-  it "returns '3.0' as its version" do
-    expect(@useragent.version).to eq("3.0")
-  end
+    it "returns '420.1' as its webkit version" do
+      expect(useragent.webkit.version).to eq("420.1")
+    end
 
-  it "returns '420.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("420.1")
-  end
+    it "returns 'iPod' as its platform" do
+      expect(useragent.platform).to eq("iPod")
+    end
 
-  it "returns 'iPod' as its platform" do
-    expect(@useragent.platform).to eq("iPod")
-  end
+    it "returns 'CPU like Mac OS X' as its os" do
+      expect(useragent.os).to eq("CPU like Mac OS X")
+    end
 
-  it "returns 'CPU like Mac OS X' as its os" do
-    expect(@useragent.os).to eq("CPU like Mac OS X")
-  end
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10") }
 
-describe "UserAgent: Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '531.21.10' as its build" do
+      expect(useragent.build).to eq("531.21.10")
+    end
 
-  it "returns '531.21.10' as its build" do
-    expect(@useragent.build).to eq("531.21.10")
-  end
+    it "returns '4.0.4' as its version" do
+      expect(useragent.version).to eq("4.0.4")
+    end
 
-  it "returns '4.0.4' as its version" do
-    expect(@useragent.version).to eq("4.0.4")
-  end
+    it "returns '531.21.10' as its webkit version" do
+      expect(useragent.webkit.version).to eq("531.21.10")
+    end
 
-  it "returns '531.21.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("531.21.10")
-  end
+    it "returns 'iPad' as its platform" do
+      expect(useragent.platform).to eq("iPad")
+    end
 
-  it "returns 'iPad' as its platform" do
-    expect(@useragent.platform).to eq("iPad")
-  end
+    it "returns 'iOS 3.2' as its os" do
+      expect(useragent.os).to eq("iOS 3.2")
+    end
 
-  it "returns 'iOS 3.2' as its os" do
-    expect(@useragent.os).to eq("iOS 3.2")
-  end
+    it "returns 'en-us' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16") }
 
-describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '528.18' as its build" do
+      expect(useragent.build).to eq("528.18")
+    end
 
-  it "returns '528.18' as its build" do
-    expect(@useragent.build).to eq("528.18")
-  end
+    it "returns '4.0' as its version" do
+      expect(useragent.version).to eq("4.0")
+    end
 
-  it "returns '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
-  end
+    it "returns '528.18' as its webkit version" do
+      expect(useragent.webkit.version).to eq("528.18")
+    end
 
-  it "returns '528.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("528.18")
-  end
+    it "returns 'iPhone' as its platform" do
+      expect(useragent.platform).to eq("iPhone")
+    end
 
-  it "returns 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
-  end
+    it "returns 'iOS 3.1.3' as its os" do
+      expect(useragent.os).to eq("iOS 3.1.3")
+    end
 
-  it "returns 'iOS 3.1.3' as its os" do
-    expect(@useragent.os).to eq("iOS 3.1.3")
+    it "returns 'en-us' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
   end
 
-  it "returns 'en-us' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16") }
 
-describe "UserAgent: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '528.18' as its build" do
+      expect(useragent.build).to eq("528.18")
+    end
 
-  it "returns '528.18' as its build" do
-    expect(@useragent.build).to eq("528.18")
-  end
+    it "returns '4.0' as its version" do
+      expect(useragent.version).to eq("4.0")
+    end
 
-  it "returns '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
-  end
+    it "returns '528.18' as its webkit version" do
+      expect(useragent.webkit.version).to eq("528.18")
+    end
 
-  it "returns '528.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("528.18")
-  end
+    it "returns 'iPod' as its platform" do
+      expect(useragent.platform).to eq("iPod")
+    end
 
-  it "returns 'iPod' as its platform" do
-    expect(@useragent.platform).to eq("iPod")
-  end
+    it "returns 'iOS 3.1.3' as its os" do
+      expect(useragent.os).to eq("iOS 3.1.3")
+    end
 
-  it "returns 'iOS 3.1.3' as its os" do
-    expect(@useragent.os).to eq("iOS 3.1.3")
-  end
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4") }
 
-describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '533.19.4' as its build" do
+      expect(useragent.build).to eq("533.19.4")
+    end
 
-  it "returns '533.19.4' as its build" do
-    expect(@useragent.build).to eq("533.19.4")
-  end
+    it "returns '5.0.3' as its version" do
+      expect(useragent.version).to eq("5.0.3")
+    end
 
-  it "returns '5.0.3' as its version" do
-    expect(@useragent.version).to eq("5.0.3")
-  end
+    it "returns '533.19.4' as its webkit version" do
+      expect(useragent.webkit.version).to eq("533.19.4")
+    end
 
-  it "returns '533.19.4' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("533.19.4")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X 10.6.5' as its os" do
+      expect(useragent.os).to eq("OS X 10.6.5")
+    end
 
-  it "returns 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq("OS X 10.6.5")
-  end
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7") }
 
-describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '532.9' as its build" do
+      expect(useragent.build).to eq("532.9")
+    end
 
-  it "returns '532.9' as its build" do
-    expect(@useragent.build).to eq("532.9")
-  end
+    it "returns '4.0.5' as its version" do
+      expect(useragent.version).to eq("4.0.5")
+    end
 
-  it "returns '4.0.5' as its version" do
-    expect(@useragent.version).to eq("4.0.5")
-  end
+    it "returns '532.9' as its webkit version" do
+      expect(useragent.webkit.version).to eq("532.9")
+    end
 
-  it "returns '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("532.9")
-  end
+    it "returns 'iPhone' as its platform" do
+      expect(useragent.platform).to eq("iPhone")
+    end
 
-  it "returns 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
-  end
+    it "returns 'iOS 4.1'" do
+      expect(useragent.os).to eq("iOS 4.1")
+    end
 
-  it "returns 'iOS 4.1'" do
-    expect(@useragent.os).to eq("iOS 4.1")
-  end
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306") }
 
-describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '532.9' as its build" do
+      expect(useragent.build).to eq("532.9")
+    end
 
-  it "returns '532.9' as its build" do
-    expect(@useragent.build).to eq("532.9")
-  end
+    it "returns '4.0.1' as its version" do
+      expect(useragent.version).to eq("4.0.1")
+    end
 
-  it "returns '4.0.1' as its version" do
-    expect(@useragent.version).to eq("4.0.1")
-  end
+    it "returns '532.9' as its webkit version" do
+      expect(useragent.webkit.version).to eq("532.9")
+    end
 
-  it "returns '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("532.9")
-  end
+    it "returns 'iPhone' as its platform" do
+      expect(useragent.platform).to eq("iPhone")
+    end
 
-  it "returns 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
-  end
+    it "returns 'iOS 4.0.1'" do
+      expect(useragent.os).to eq("iOS 4.0.1")
+    end
 
-  it "returns 'iOS 4.0.1'" do
-    expect(@useragent.os).to eq("iOS 4.0.1")
-  end
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7") }
 
-describe "UserAgent: 'Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7")
-  end
+    it_behaves_like "Safari browser"
 
-  it_behaves_like "Safari browser"
+    it "returns '532.9' as its build" do
+      expect(useragent.build).to eq("532.9")
+    end
 
-  it "returns '532.9' as its build" do
-    expect(@useragent.build).to eq("532.9")
-  end
+    it "returns '4.0.5' as its version" do
+      expect(useragent.version).to eq("4.0.5")
+    end
 
-  it "returns '4.0.5' as its version" do
-    expect(@useragent.version).to eq("4.0.5")
-  end
+    it "returns '532.9' as its webkit version" do
+      expect(useragent.webkit.version).to eq("532.9")
+    end
 
-  it "returns '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("532.9")
-  end
+    it "returns 'iPhone' as its platform" do
+      expect(useragent.platform).to eq("iPhone Simulator")
+    end
 
-  it "returns 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone Simulator")
-  end
+    it "returns 'iOS 4.0.1'" do
+      expect(useragent.os).to eq("iOS 4.0.1")
+    end
 
-  it "returns 'iOS 4.0.1'" do
-    expect(@useragent.os).to eq("iOS 4.0.1")
-  end
+    it "returns 'en' as its localization" do
+      expect(useragent.localization).to eq("en-us")
+    end
 
-  it "returns 'en' as its localization" do
-    expect(@useragent.localization).to eq("en-us")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1") }
 
-describe "UserAgent: 'Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1")
-  end
+    it "returns 'Android' as its browser" do
+      expect(useragent.browser).to eq("Android")
+    end
 
-  it "returns 'Android' as its browser" do
-    expect(@useragent.browser).to eq("Android")
-  end
+    it "returns '528.5+' as its build" do
+      expect(useragent.build).to eq("528.5+")
+    end
 
-  it "returns '528.5+' as its build" do
-    expect(@useragent.build).to eq("528.5+")
-  end
+    it "returns '3.1.2' as its version" do
+      expect(useragent.version).to eq("3.1.2")
+    end
 
-  it "returns '3.1.2' as its version" do
-    expect(@useragent.version).to eq("3.1.2")
-  end
+    it "returns '528.5+' as its webkit version" do
+      expect(useragent.webkit.version).to eq("528.5+")
+    end
 
-  it "returns '528.5+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("528.5+")
-  end
+    it "returns 'Android' as its platform" do
+      expect(useragent.platform).to eq("Android")
+    end
 
-  it "returns 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
-  end
+    it "returns 'Android 1.5' as its os" do
+      expect(useragent.os).to eq("Android 1.5")
+    end
 
-  it "returns 'Android 1.5' as its os" do
-    expect(@useragent.os).to eq("Android 1.5")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+") }
 
-describe "UserAgent: 'Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+")
-  end
+    it "returns 'BlackBerry' as its browser" do
+      expect(useragent.browser).to eq("BlackBerry")
+    end
 
-  it "returns 'BlackBerry' as its browser" do
-    expect(@useragent.browser).to eq("BlackBerry")
-  end
+    it "returns '534.1+' as its build" do
+      expect(useragent.build).to eq("534.1+")
+    end
 
-  it "returns '534.1+' as its build" do
-    expect(@useragent.build).to eq("534.1+")
-  end
+    it "returns '6.0.0.141' as its version" do
+      expect(useragent.version).to eq("6.0.0.141")
+    end
 
-  it "returns '6.0.0.141' as its version" do
-    expect(@useragent.version).to eq("6.0.0.141")
-  end
+    it "returns '534.1+' as its webkit version" do
+      expect(useragent.webkit.version).to eq("534.1+")
+    end
 
-  it "returns '534.1+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.1+")
-  end
+    it "returns 'BlackBerry' as its platform" do
+      expect(useragent.platform).to eq("BlackBerry")
+    end
 
-  it "returns 'BlackBerry' as its platform" do
-    expect(@useragent.platform).to eq("BlackBerry")
-  end
+    it "returns 'BlackBerry 9800' as its os" do
+      expect(useragent.os).to eq("BlackBerry 9800")
+    end
 
-  it "returns 'BlackBerry 9800' as its os" do
-    expect(@useragent.os).to eq("BlackBerry 9800")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+") }
 
-describe "UserAgent: 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+")
-  end
+    it "returns 'BlackBerry' as its browser" do
+      expect(useragent.browser).to eq("BlackBerry")
+    end
 
-  it "returns 'BlackBerry' as its browser" do
-    expect(@useragent.browser).to eq("BlackBerry")
-  end
+    it "returns '537.3+' as its build" do
+      expect(useragent.build).to eq("537.3+")
+    end
 
-  it "returns '537.3+' as its build" do
-    expect(@useragent.build).to eq("537.3+")
-  end
+    it "returns '10.0.9.388' as its version" do
+      expect(useragent.version).to eq("10.0.9.388")
+    end
 
-  it "returns '10.0.9.388' as its version" do
-    expect(@useragent.version).to eq("10.0.9.388")
-  end
+    it "returns '537.3+' as its webkit version" do
+      expect(useragent.webkit.version).to eq("537.3+")
+    end
 
-  it "returns '537.3+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.3+")
-  end
+    it "returns 'BlackBerry' as its platform" do
+      expect(useragent.platform).to eq("BlackBerry")
+    end
 
-  it "returns 'BlackBerry' as its platform" do
-    expect(@useragent.platform).to eq("BlackBerry")
-  end
+    it "returns 'Touch' as its os" do
+      expect(useragent.os).to eq("Touch")
+    end
 
-  it "returns 'Touch' as its os" do
-    expect(@useragent.os).to eq("Touch")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22") }
 
-describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22")
-  end
+    it "returns 'Safari' as its browser" do
+      expect(useragent.browser).to eq("Safari")
+    end
 
-  it "returns 'Safari' as its browser" do
-    expect(@useragent.browser).to eq("Safari")
-  end
+    it "returns nil as its security" do
+      expect(useragent.security).to be_nil
+    end
 
-  it "returns nil as its security" do
-    expect(@useragent.security).to be_nil
-  end
+    it "returns '534.51.22' as its build" do
+      expect(useragent.build).to eq("534.51.22")
+    end
 
-  it "returns '534.51.22' as its build" do
-    expect(@useragent.build).to eq("534.51.22")
-  end
+    it "returns '5.1.1' as its version" do
+      expect(useragent.version).to eq("5.1.1")
+    end
 
-  it "returns '5.1.1' as its version" do
-    expect(@useragent.version).to eq("5.1.1")
-  end
+    it "returns '534.51.22' as its webkit version" do
+      expect(useragent.webkit.version).to eq("534.51.22")
+    end
 
-  it "returns '534.51.22' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.51.22")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X 10.7.2' as its os" do
+      expect(useragent.os).to eq("OS X 10.7.2")
+    end
 
-  it "returns 'OS X 10.7.2' as its os" do
-    expect(@useragent.os).to eq("OS X 10.7.2")
-  end
+    it "returns nil as its localization" do
+      expect(useragent.localization).to be_nil
+    end
 
-  it "returns nil as its localization" do
-    expect(@useragent.localization).to be_nil
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)") }
 
-describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)")
-  end
+    it "returns 'Safari' as its browser" do
+      expect(useragent.browser).to eq("Safari")
+    end
 
-  it "returns 'Safari' as its browser" do
-    expect(@useragent.browser).to eq("Safari")
+    it "returns '5.1.2' as its version" do
+      expect(useragent.version).to eq("5.1.2")
+    end
   end
 
-  it "returns '5.1.2' as its version" do
-    expect(@useragent.version).to eq("5.1.2")
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36") }
 
-describe "UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36")
-  end
+    it "returns '537.36' as its build" do
+      expect(useragent.build).to eq("537.36")
+    end
 
-  it "returns '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
-  end
+    it "returns null as its version" do
+      expect(useragent.version).to eq("")
+    end
 
-  it "returns null as its version" do
-    expect(@useragent.version).to eq("")
-  end
+    it "returns '537.36' as its webkit version" do
+      expect(useragent.webkit.version).to eq("537.36")
+    end
 
-  it "returns '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
-  end
+    it "returns 'Macintosh' as its platform" do
+      expect(useragent.platform).to eq("Macintosh")
+    end
 
-  it "returns 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq("Macintosh")
-  end
+    it "returns 'OS X 10.9.5' as its os" do
+      expect(useragent.os).to eq("OS X 10.9.5")
+    end
 
-  it "returns 'OS X 10.9.5' as its os" do
-    expect(@useragent.os).to eq("OS X 10.9.5")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36") }
 
-describe "UserAgent: Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36")
-  end
+    it "returns '537.36' as its build" do
+      expect(useragent.build).to eq("537.36")
+    end
 
-  it "returns '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
-  end
+    it "returns '30.0.1599.38' as its version" do
+      expect(useragent.version).to eq("30.0.1599.38")
+    end
 
-  it "returns '30.0.1599.38' as its version" do
-    expect(@useragent.version).to eq("30.0.1599.38")
-  end
+    it "returns '537.36' as its webkit version" do
+      expect(useragent.webkit.version).to eq("537.36")
+    end
 
-  it "returns '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
-  end
+    it "returns 'ChromeOS' as its platform" do
+      expect(useragent.platform).to eq("ChromeOS")
+    end
 
-  it "returns 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq("ChromeOS")
-  end
+    it "returns 'ChromeOS 4537.56.0' as its os" do
+      expect(useragent.os).to eq("ChromeOS 4537.56.0")
+    end
 
-  it "returns 'ChromeOS 4537.56.0' as its os" do
-    expect(@useragent.os).to eq("ChromeOS 4537.56.0")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36") }
 
-describe "UserAgent: Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36")
-  end
+    it "returns '537.36' as its build" do
+      expect(useragent.build).to eq("537.36")
+    end
 
-  it "returns '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
-  end
+    it "returns '32.0.1700.95' as its version" do
+      expect(useragent.version).to eq("32.0.1700.95")
+    end
 
-  it "returns '32.0.1700.95' as its version" do
-    expect(@useragent.version).to eq("32.0.1700.95")
-  end
+    it "returns '537.36' as its webkit version" do
+      expect(useragent.webkit.version).to eq("537.36")
+    end
 
-  it "returns '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
-  end
+    it "returns 'ChromeOS' as its platform" do
+      expect(useragent.platform).to eq("ChromeOS")
+    end
 
-  it "returns 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq("ChromeOS")
-  end
+    it "returns 'ChromeOS 4920.71.0' as its os" do
+      expect(useragent.os).to eq("ChromeOS 4920.71.0")
+    end
 
-  it "returns 'ChromeOS 4920.71.0' as its os" do
-    expect(@useragent.os).to eq("ChromeOS 4920.71.0")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5") }
 
-describe "UserAgent: Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5")
-  end
+    it "returns '532.5' as its build" do
+      expect(useragent.build).to eq("532.5")
+    end
 
-  it "returns '532.5' as its build" do
-    expect(@useragent.build).to eq("532.5")
-  end
+    it "returns '4.0.253.0' as its version" do
+      expect(useragent.version).to eq("4.0.253.0")
+    end
 
-  it "returns '4.0.253.0' as its version" do
-    expect(@useragent.version).to eq("4.0.253.0")
-  end
+    it "returns '532.5' as its webkit version" do
+      expect(useragent.webkit.version).to eq("532.5")
+    end
 
-  it "returns '532.5' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("532.5")
-  end
+    it "returns 'ChromeOS' as its platform" do
+      expect(useragent.platform).to eq("ChromeOS")
+    end
 
-  it "returns 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq("ChromeOS")
-  end
+    it "returns 'ChromeOS 9.10.0' as its os" do
+      expect(useragent.os).to eq("ChromeOS 9.10.0")
+    end
 
-  it "returns 'ChromeOS 9.10.0' as its os" do
-    expect(@useragent.os).to eq("ChromeOS 9.10.0")
+    it { expect(useragent).not_to be_mobile }
   end
 
-  it { expect(@useragent).not_to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5") }
 
-describe "UserAgent: Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5")
-  end
+    it "returns '533.17.9' as its build" do
+      expect(useragent.build).to eq("533.17.9")
+    end
 
-  it "returns '533.17.9' as its build" do
-    expect(@useragent.build).to eq("533.17.9")
-  end
+    it "returns '5.0.2' as its version" do
+      expect(useragent.version).to eq("5.0.2")
+    end
 
-  it "returns '5.0.2' as its version" do
-    expect(@useragent.version).to eq("5.0.2")
-  end
+    it "returns '533.17.9' as its webkit version" do
+      expect(useragent.webkit.version).to eq("533.17.9")
+    end
 
-  it "returns '533.17.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("533.17.9")
-  end
+    it "returns 'iPhone' as its platform" do
+      expect(useragent.platform).to eq("iPhone")
+    end
 
-  it "returns 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
-  end
+    it "returns 'iOS 4.2.1' as its os" do
+      expect(useragent.os).to eq("iOS 4.2.1")
+    end
 
-  it "returns 'iOS 4.2.1' as its os" do
-    expect(@useragent.os).to eq("iOS 4.2.1")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30") }
 
-describe "UserAgent: Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30")
-  end
+    it "returns 'Android' as its browser" do
+      expect(useragent.browser).to eq("Android")
+    end
 
-  it "returns 'Android' as its browser" do
-    expect(@useragent.browser).to eq("Android")
-  end
+    it "returns :strong as its security" do
+      expect(useragent.security).to eq(:strong)
+    end
 
-  it "returns :strong as its security" do
-    expect(@useragent.security).to eq(:strong)
-  end
+    it "returns '534.30' as its build" do
+      expect(useragent.build).to eq("534.30")
+    end
 
-  it "returns '534.30' as its build" do
-    expect(@useragent.build).to eq("534.30")
-  end
+    it "returns '4.0' as its version" do
+      expect(useragent.version).to eq("4.0")
+    end
 
-  it "returns '4.0' as its version" do
-    expect(@useragent.version).to eq("4.0")
-  end
+    it "returns '534.30' as its webkit version" do
+      expect(useragent.webkit.version).to eq("534.30")
+    end
 
-  it "returns '534.30' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("534.30")
-  end
+    it "returns 'Android' as its platform" do
+      expect(useragent.platform).to eq("Android")
+    end
 
-  it "returns 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
-  end
+    it "returns 'Android 4.0.3' as its os" do
+      expect(useragent.os).to eq("Android 4.0.3")
+    end
 
-  it "returns 'Android 4.0.3' as its os" do
-    expect(@useragent.os).to eq("Android 4.0.3")
-  end
+    it "returns 'ko-kr' as its localization" do
+      expect(useragent.localization).to eq("ko-kr")
+    end
 
-  it "returns 'ko-kr' as its localization" do
-    expect(@useragent.localization).to eq("ko-kr")
+    it { expect(useragent).to be_mobile }
   end
 
-  it { expect(@useragent).to be_mobile }
-end
+  context do
+    let(:useragent) { described_class.parse("HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36") }
 
-describe "UserAgent: HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36" do
-  before do
-    @useragent = UserAgent.parse("HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36")
-  end
+    it "returns 'Android' as its browser" do
+      expect(useragent.browser).to eq("Android")
+    end
 
-  it "returns 'Android' as its browser" do
-    expect(@useragent.browser).to eq("Android")
-  end
+    it "returns :strong as its security" do
+      expect(useragent.security).to eq(:strong)
+    end
 
-  it "returns :strong as its security" do
-    expect(@useragent.security).to eq(:strong)
-  end
+    it "returns '537.36' as its build" do
+      expect(useragent.build).to eq("537.36")
+    end
 
-  it "returns '537.36' as its build" do
-    expect(@useragent.build).to eq("537.36")
-  end
+    it "returns nil as its version" do
+      expect(useragent.version).to be_nil
+    end
 
-  it "returns nil as its version" do
-    expect(@useragent.version).to be_nil
-  end
+    it "returns '537.36' as its webkit version" do
+      expect(useragent.webkit.version).to eq("537.36")
+    end
 
-  it "returns '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq("537.36")
-  end
+    it "returns 'Android' as its platform" do
+      expect(useragent.platform).to eq("Android")
+    end
 
-  it "returns 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
-  end
+    it "returns 'Android 4.4.2' as its os" do
+      expect(useragent.os).to eq("Android 4.4.2")
+    end
 
-  it "returns 'Android 4.4.2' as its os" do
-    expect(@useragent.os).to eq("Android 4.4.2")
-  end
+    it "returns 'zh-cn' as its localization" do
+      expect(useragent.localization).to eq("zh-cn")
+    end
 
-  it "returns 'zh-cn' as its localization" do
-    expect(@useragent.localization).to eq("zh-cn")
+    it { expect(useragent).to be_mobile }
   end
-
-  it { expect(@useragent).to be_mobile }
 end

--- a/spec/browsers/webkit_user_agent_spec.rb
+++ b/spec/browsers/webkit_user_agent_spec.rb
@@ -1,45 +1,45 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples_for 'Safari browser' do
+shared_examples_for "Safari browser" do
   it "should return 'Safari' as its browser" do
-    expect(@useragent.browser).to eq('Safari')
+    expect(@useragent.browser).to eq("Safari")
   end
 
-  it 'should return :strong as its security' do
+  it "should return :strong as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16' do
+describe "UserAgent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '533.16' as its build" do
-    expect(@useragent.build).to eq('533.16')
+    expect(@useragent.build).to eq("533.16")
   end
 
   it "should return '5.0' as its version" do
-    expect(@useragent.version).to eq('5.0')
+    expect(@useragent.version).to eq("5.0")
   end
 
   it "should return '533.16' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('533.16')
+    expect(@useragent.webkit.version).to eq("533.16")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.6.3' as its os" do
-    expect(@useragent.os).to eq('OS X 10.6.3')
+    expect(@useragent.os).to eq("OS X 10.6.3")
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -47,33 +47,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '526.8' as its build" do
-    expect(@useragent.build).to eq('526.9')
+    expect(@useragent.build).to eq("526.9")
   end
 
   it "should return '4.0dp1' as its version" do
-    expect(@useragent.version).to eq('4.0dp1')
+    expect(@useragent.version).to eq("4.0dp1")
   end
 
   it "should return '526.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('526.9')
+    expect(@useragent.webkit.version).to eq("526.9")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.5.3' as its os" do
-    expect(@useragent.os).to eq('OS X 10.5.3')
+    expect(@useragent.os).to eq("OS X 10.5.3")
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -81,33 +81,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '526.8' as its build" do
-    expect(@useragent.build).to eq('526.9')
+    expect(@useragent.build).to eq("526.9")
   end
 
   it "should return '4.0dp1' as its version" do
-    expect(@useragent.version).to eq('4.0dp1')
+    expect(@useragent.version).to eq("4.0dp1")
   end
 
   it "should return '526.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('526.9')
+    expect(@useragent.webkit.version).to eq("526.9")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -115,33 +115,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '525.18' as its build" do
-    expect(@useragent.build).to eq('525.18')
+    expect(@useragent.build).to eq("525.18")
   end
 
   it "should return '3.1.1' as its version" do
-    expect(@useragent.version).to eq('3.1.1')
+    expect(@useragent.version).to eq("3.1.1")
   end
 
   it "should return '525.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('525.18')
+    expect(@useragent.webkit.version).to eq("525.18")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.5.3' as its os" do
-    expect(@useragent.os).to eq('OS X 10.5.3')
+    expect(@useragent.os).to eq("OS X 10.5.3")
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it "should be == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
@@ -149,19 +149,19 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) A
   end
 
   it "should not be == 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).not_to eq(UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'))
+    expect(@useragent).not_to eq(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3"))
   end
 
   it "should be > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).to be > UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3')
+    expect(@useragent).to be > UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
   end
 
   it "should not be > 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).not_to be > UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
+    expect(@useragent).not_to be > UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
   it "should be < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).to be < UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
+    expect(@useragent).to be < UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
   it "should not be < 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
@@ -169,11 +169,11 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) A
   end
 
   it "should be >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).to be >= UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3')
+    expect(@useragent).to be >= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
   end
 
   it "should not be >= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8'" do
-    expect(@useragent).not_to be >= UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8')
+    expect(@useragent).not_to be >= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/526.9 (KHTML, like Gecko) Version/4.0dp1 Safari/526.8")
   end
 
   it "should be <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
@@ -181,423 +181,423 @@ describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) A
   end
 
   it "should not be <= 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
-    expect(@useragent).not_to be <= UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3')
+    expect(@useragent).not_to be <= UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '525.18' as its build" do
-    expect(@useragent.build).to eq('525.18')
+    expect(@useragent.build).to eq("525.18")
   end
 
   it "should return '3.1.1' as its version" do
-    expect(@useragent.version).to eq('3.1.1')
+    expect(@useragent.version).to eq("3.1.1")
   end
 
   it "should return '525.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('525.18')
+    expect(@useragent.webkit.version).to eq("525.18")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
   it "should return 'Windows XP' as its os" do
-    expect(@useragent.os).to eq('Windows XP')
+    expect(@useragent.os).to eq("Windows XP")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Safari/419.3")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '419.3' as its build" do
-    expect(@useragent.build).to eq('419')
+    expect(@useragent.build).to eq("419")
   end
 
   it "should return '2.0.4' as its version" do
-    expect(@useragent.version).to eq('2.0.4')
+    expect(@useragent.version).to eq("2.0.4")
   end
 
   it "should return '419' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('419')
+    expect(@useragent.webkit.version).to eq("419")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/412.6 (KHTML, like Gecko) Safari/412.2")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '412.2' as its build" do
-    expect(@useragent.build).to eq('412.6')
+    expect(@useragent.build).to eq("412.6")
   end
 
   it "should return '2.0' as its version" do
-    expect(@useragent.version).to eq('2.0')
+    expect(@useragent.version).to eq("2.0")
   end
 
   it "should return '412.6' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('412.6')
+    expect(@useragent.webkit.version).to eq("412.6")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/412.6.2 (KHTML, like Gecko) Safari/412.2.2")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '412.2.2' as its build" do
-    expect(@useragent.build).to eq('412.6.2')
+    expect(@useragent.build).to eq("412.6.2")
   end
 
   it "should return '2.0' as its version" do
-    expect(@useragent.version).to eq('2.0')
+    expect(@useragent.version).to eq("2.0")
   end
 
   it "should return '412.6.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('412.6.2')
+    expect(@useragent.webkit.version).to eq("412.6.2")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/312.8 (KHTML, like Gecko) Safari/312.6")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '312.6' as its build" do
-    expect(@useragent.build).to eq('312.8')
+    expect(@useragent.build).to eq("312.8")
   end
 
   it "should return '1.3.2' as its version" do
-    expect(@useragent.version).to eq('1.3.2')
+    expect(@useragent.version).to eq("1.3.2")
   end
 
   it "should return '312.8' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('312.8')
+    expect(@useragent.webkit.version).to eq("312.8")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-ch) AppleWebKit/312.1.1 (KHTML, like Gecko) Safari/312")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '312' as its build" do
-    expect(@useragent.build).to eq('312.1.1')
+    expect(@useragent.build).to eq("312.1.1")
   end
 
   it "should return '1.3' as its version" do
-    expect(@useragent.version).to eq('1.3')
+    expect(@useragent.version).to eq("1.3")
   end
 
   it "should return '312.1.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('312.1.1')
+    expect(@useragent.webkit.version).to eq("312.1.1")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('fr-ch')
+    expect(@useragent.localization).to eq("fr-ch")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; es-es) AppleWebKit/312.5.2 (KHTML, like Gecko) Safari/312.3.3")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '312.3.3' as its build" do
-    expect(@useragent.build).to eq('312.5.2')
+    expect(@useragent.build).to eq("312.5.2")
   end
 
   it "should return '1.3.1' as its version" do
-    expect(@useragent.version).to eq('1.3.1')
+    expect(@useragent.version).to eq("1.3.1")
   end
 
   it "should return '312.5.2' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('312.5.2')
+    expect(@useragent.webkit.version).to eq("312.5.2")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('es-es')
+    expect(@useragent.localization).to eq("es-es")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr) AppleWebKit/312.5.1 (KHTML, like Gecko) Safari/312.3.1")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '312.3.1' as its build" do
-    expect(@useragent.build).to eq('312.5.1')
+    expect(@useragent.build).to eq("312.5.1")
   end
 
   it "should return '1.3.1' as its version" do
-    expect(@useragent.version).to eq('1.3.1')
+    expect(@useragent.version).to eq("1.3.1")
   end
 
   it "should return '312.5.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('312.5.1')
+    expect(@useragent.webkit.version).to eq("312.5.1")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('fr')
+    expect(@useragent.localization).to eq("fr")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/312.5 (KHTML, like Gecko) Safari/312.3")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '312.3' as its build" do
-    expect(@useragent.build).to eq('312.5')
+    expect(@useragent.build).to eq("312.5")
   end
 
   it "should return '1.3.1' as its version" do
-    expect(@useragent.version).to eq('1.3.1')
+    expect(@useragent.version).to eq("1.3.1")
   end
 
   it "should return '312.5' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('312.5')
+    expect(@useragent.webkit.version).to eq("312.5")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/124 (KHTML, like Gecko) Safari/125")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '125' as its build" do
-    expect(@useragent.build).to eq('124')
+    expect(@useragent.build).to eq("124")
   end
 
   it "should return '1.2' as its version" do
-    expect(@useragent.version).to eq('1.2')
+    expect(@useragent.version).to eq("1.2")
   end
 
   it "should return '124' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('124')
+    expect(@useragent.webkit.version).to eq("124")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/125.5.7 (KHTML, like Gecko) Safari/125.12")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '125.12' as its build" do
-    expect(@useragent.build).to eq('125.5.7')
+    expect(@useragent.build).to eq("125.5.7")
   end
 
   it "should return '1.2.4' as its version" do
-    expect(@useragent.version).to eq('1.2.4')
+    expect(@useragent.version).to eq("1.2.4")
   end
 
   it "should return '125.5.7' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('125.5.7')
+    expect(@useragent.webkit.version).to eq("125.5.7")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; PPC Mac OS X; fr-fr) AppleWebKit/85.7 (KHTML, like Gecko) Safari/85.5")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '85.5' as its build" do
-    expect(@useragent.build).to eq('85.7')
+    expect(@useragent.build).to eq("85.7")
   end
 
   it "should return '1.0' as its version" do
-    expect(@useragent.version).to eq('1.0')
+    expect(@useragent.version).to eq("1.0")
   end
 
   it "should return '85.7' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('85.7')
+    expect(@useragent.webkit.version).to eq("85.7")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X' as its os" do
-    expect(@useragent.os).to eq('OS X')
+    expect(@useragent.os).to eq("OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('fr-fr')
+    expect(@useragent.localization).to eq("fr-fr")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '419' as its build" do
-    expect(@useragent.build).to eq('420.1')
+    expect(@useragent.build).to eq("420.1")
   end
 
   it "should return '3.0' as its version" do
-    expect(@useragent.version).to eq('3.0')
+    expect(@useragent.version).to eq("3.0")
   end
 
   it "should return '420.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('420.1')
+    expect(@useragent.webkit.version).to eq("420.1")
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq('iPhone')
+    expect(@useragent.platform).to eq("iPhone")
   end
 
   it "should return 'CPU like Mac OS X' as its os" do
-    expect(@useragent.os).to eq('CPU like Mac OS X')
+    expect(@useragent.os).to eq("CPU like Mac OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -605,67 +605,67 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/4A102 Safari/419")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '419' as its build" do
-    expect(@useragent.build).to eq('420.1')
+    expect(@useragent.build).to eq("420.1")
   end
 
   it "should return '3.0' as its version" do
-    expect(@useragent.version).to eq('3.0')
+    expect(@useragent.version).to eq("3.0")
   end
 
   it "should return '420.1' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('420.1')
+    expect(@useragent.webkit.version).to eq("420.1")
   end
 
   it "should return 'iPod' as its platform" do
-    expect(@useragent.platform).to eq('iPod')
+    expect(@useragent.platform).to eq("iPod")
   end
 
   it "should return 'CPU like Mac OS X' as its os" do
-    expect(@useragent.os).to eq('CPU like Mac OS X')
+    expect(@useragent.os).to eq("CPU like Mac OS X")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en')
+    expect(@useragent.localization).to eq("en")
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe 'UserAgent: Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10' do
+describe "UserAgent: Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '531.21.10' as its build" do
-    expect(@useragent.build).to eq('531.21.10')
+    expect(@useragent.build).to eq("531.21.10")
   end
 
   it "should return '4.0.4' as its version" do
-    expect(@useragent.version).to eq('4.0.4')
+    expect(@useragent.version).to eq("4.0.4")
   end
 
   it "should return '531.21.10' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('531.21.10')
+    expect(@useragent.webkit.version).to eq("531.21.10")
   end
 
   it "should return 'iPad' as its platform" do
-    expect(@useragent.platform).to eq('iPad')
+    expect(@useragent.platform).to eq("iPad")
   end
 
   it "should return 'iOS 3.2' as its os" do
-    expect(@useragent.os).to eq('iOS 3.2')
+    expect(@useragent.os).to eq("iOS 3.2")
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -673,65 +673,65 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '528.18' as its build" do
-    expect(@useragent.build).to eq('528.18')
+    expect(@useragent.build).to eq("528.18")
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq('4.0')
+    expect(@useragent.version).to eq("4.0")
   end
 
   it "should return '528.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('528.18')
+    expect(@useragent.webkit.version).to eq("528.18")
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq('iPhone')
+    expect(@useragent.platform).to eq("iPhone")
   end
 
   it "should return 'iOS 3.1.3' as its os" do
-    expect(@useragent.os).to eq('iOS 3.1.3')
+    expect(@useragent.os).to eq("iOS 3.1.3")
   end
 
   it "should return 'en-us' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1_3 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7E18 Safari/528.16")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '528.18' as its build" do
-    expect(@useragent.build).to eq('528.18')
+    expect(@useragent.build).to eq("528.18")
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq('4.0')
+    expect(@useragent.version).to eq("4.0")
   end
 
   it "should return '528.18' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('528.18')
+    expect(@useragent.webkit.version).to eq("528.18")
   end
 
   it "should return 'iPod' as its platform" do
-    expect(@useragent.platform).to eq('iPod')
+    expect(@useragent.platform).to eq("iPod")
   end
 
   it "should return 'iOS 3.1.3' as its os" do
-    expect(@useragent.os).to eq('iOS 3.1.3')
+    expect(@useragent.os).to eq("iOS 3.1.3")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -739,33 +739,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_5; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '533.19.4' as its build" do
-    expect(@useragent.build).to eq('533.19.4')
+    expect(@useragent.build).to eq("533.19.4")
   end
 
   it "should return '5.0.3' as its version" do
-    expect(@useragent.version).to eq('5.0.3')
+    expect(@useragent.version).to eq("5.0.3")
   end
 
   it "should return '533.19.4' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('533.19.4')
+    expect(@useragent.webkit.version).to eq("533.19.4")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.6.5' as its os" do
-    expect(@useragent.os).to eq('OS X 10.6.5')
+    expect(@useragent.os).to eq("OS X 10.6.5")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it { expect(@useragent).not_to be_mobile }
@@ -773,33 +773,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '532.9' as its build" do
-    expect(@useragent.build).to eq('532.9')
+    expect(@useragent.build).to eq("532.9")
   end
 
   it "should return '4.0.5' as its version" do
-    expect(@useragent.version).to eq('4.0.5')
+    expect(@useragent.version).to eq("4.0.5")
   end
 
   it "should return '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('532.9')
+    expect(@useragent.webkit.version).to eq("532.9")
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq('iPhone')
+    expect(@useragent.platform).to eq("iPhone")
   end
 
   it "should return 'iOS 4.1'" do
-    expect(@useragent.os).to eq('iOS 4.1')
+    expect(@useragent.os).to eq("iOS 4.1")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -807,33 +807,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8A306")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '532.9' as its build" do
-    expect(@useragent.build).to eq('532.9')
+    expect(@useragent.build).to eq("532.9")
   end
 
   it "should return '4.0.1' as its version" do
-    expect(@useragent.version).to eq('4.0.1')
+    expect(@useragent.version).to eq("4.0.1")
   end
 
   it "should return '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('532.9')
+    expect(@useragent.webkit.version).to eq("532.9")
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq('iPhone')
+    expect(@useragent.platform).to eq("iPhone")
   end
 
   it "should return 'iOS 4.0.1'" do
-    expect(@useragent.os).to eq('iOS 4.0.1')
+    expect(@useragent.os).to eq("iOS 4.0.1")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -841,33 +841,33 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone Simulator; U; CPU iPhone OS 4_0_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A306 Safari/6531.22.7")
   end
 
-  it_should_behave_like 'Safari browser'
+  it_should_behave_like "Safari browser"
 
   it "should return '532.9' as its build" do
-    expect(@useragent.build).to eq('532.9')
+    expect(@useragent.build).to eq("532.9")
   end
 
   it "should return '4.0.5' as its version" do
-    expect(@useragent.version).to eq('4.0.5')
+    expect(@useragent.version).to eq("4.0.5")
   end
 
   it "should return '532.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('532.9')
+    expect(@useragent.webkit.version).to eq("532.9")
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq('iPhone Simulator')
+    expect(@useragent.platform).to eq("iPhone Simulator")
   end
 
   it "should return 'iOS 4.0.1'" do
-    expect(@useragent.os).to eq('iOS 4.0.1')
+    expect(@useragent.os).to eq("iOS 4.0.1")
   end
 
   it "should return 'en' as its localization" do
-    expect(@useragent.localization).to eq('en-us')
+    expect(@useragent.localization).to eq("en-us")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -875,31 +875,31 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; U; Android 1.5; de-; HTC Magic Build/PLAT-RC33) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1")
   end
 
   it "should return 'Android' as its browser" do
-    expect(@useragent.browser).to eq('Android')
+    expect(@useragent.browser).to eq("Android")
   end
 
   it "should return '528.5+' as its build" do
-    expect(@useragent.build).to eq('528.5+')
+    expect(@useragent.build).to eq("528.5+")
   end
 
   it "should return '3.1.2' as its version" do
-    expect(@useragent.version).to eq('3.1.2')
+    expect(@useragent.version).to eq("3.1.2")
   end
 
   it "should return '528.5+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('528.5+')
+    expect(@useragent.webkit.version).to eq("528.5+")
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq('Android')
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "should return 'Android 1.5' as its os" do
-    expect(@useragent.os).to eq('Android 1.5')
+    expect(@useragent.os).to eq("Android 1.5")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -907,31 +907,31 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+')
+    @useragent = UserAgent.parse("Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, Like Gecko) Version/6.0.0.141 Mobile Safari/534.1+")
   end
 
   it "should return 'BlackBerry' as its browser" do
-    expect(@useragent.browser).to eq('BlackBerry')
+    expect(@useragent.browser).to eq("BlackBerry")
   end
 
   it "should return '534.1+' as its build" do
-    expect(@useragent.build).to eq('534.1+')
+    expect(@useragent.build).to eq("534.1+")
   end
 
   it "should return '6.0.0.141' as its version" do
-    expect(@useragent.version).to eq('6.0.0.141')
+    expect(@useragent.version).to eq("6.0.0.141")
   end
 
   it "should return '534.1+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('534.1+')
+    expect(@useragent.webkit.version).to eq("534.1+")
   end
 
   it "should return 'BlackBerry' as its platform" do
-    expect(@useragent.platform).to eq('BlackBerry')
+    expect(@useragent.platform).to eq("BlackBerry")
   end
 
   it "should return 'BlackBerry 9800' as its os" do
-    expect(@useragent.os).to eq('BlackBerry 9800')
+    expect(@useragent.os).to eq("BlackBerry 9800")
   end
 
   it { expect(@useragent).to be_mobile }
@@ -939,305 +939,305 @@ end
 
 describe "UserAgent: 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+')
+    @useragent = UserAgent.parse("Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+")
   end
 
   it "should return 'BlackBerry' as its browser" do
-    expect(@useragent.browser).to eq('BlackBerry')
+    expect(@useragent.browser).to eq("BlackBerry")
   end
 
   it "should return '537.3+' as its build" do
-    expect(@useragent.build).to eq('537.3+')
+    expect(@useragent.build).to eq("537.3+")
   end
 
   it "should return '10.0.9.388' as its version" do
-    expect(@useragent.version).to eq('10.0.9.388')
+    expect(@useragent.version).to eq("10.0.9.388")
   end
 
   it "should return '537.3+' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('537.3+')
+    expect(@useragent.webkit.version).to eq("537.3+")
   end
 
   it "should return 'BlackBerry' as its platform" do
-    expect(@useragent.platform).to eq('BlackBerry')
+    expect(@useragent.platform).to eq("BlackBerry")
   end
 
   it "should return 'Touch' as its os" do
-    expect(@useragent.os).to eq('Touch')
+    expect(@useragent.os).to eq("Touch")
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22' do
+describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.51.22 (KHTML, like Gecko) Version/5.1.1 Safari/534.51.22")
   end
 
   it "should return 'Safari' as its browser" do
-    expect(@useragent.browser).to eq('Safari')
+    expect(@useragent.browser).to eq("Safari")
   end
 
-  it 'should return nil as its security' do
+  it "should return nil as its security" do
     expect(@useragent.security).to be_nil
   end
 
   it "should return '534.51.22' as its build" do
-    expect(@useragent.build).to eq('534.51.22')
+    expect(@useragent.build).to eq("534.51.22")
   end
 
   it "should return '5.1.1' as its version" do
-    expect(@useragent.version).to eq('5.1.1')
+    expect(@useragent.version).to eq("5.1.1")
   end
 
   it "should return '534.51.22' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('534.51.22')
+    expect(@useragent.webkit.version).to eq("534.51.22")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.7.2' as its os" do
-    expect(@useragent.os).to eq('OS X 10.7.2')
+    expect(@useragent.os).to eq("OS X 10.7.2")
   end
 
-  it 'should return nil as its localization' do
+  it "should return nil as its localization" do
     expect(@useragent.localization).to be_nil
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)' do
+describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko)")
   end
 
   it "should return 'Safari' as its browser" do
-    expect(@useragent.browser).to eq('Safari')
+    expect(@useragent.browser).to eq("Safari")
   end
 
   it "should return '5.1.2' as its version" do
-    expect(@useragent.version).to eq('5.1.2')
+    expect(@useragent.version).to eq("5.1.2")
   end
 end
 
-describe 'UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36' do
+describe "UserAgent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Salamander/44.0 Safari/537.36")
   end
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq('537.36')
+    expect(@useragent.build).to eq("537.36")
   end
 
-  it 'should return null as its version' do
-    expect(@useragent.version).to eq('')
+  it "should return null as its version" do
+    expect(@useragent.version).to eq("")
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('537.36')
+    expect(@useragent.webkit.version).to eq("537.36")
   end
 
   it "should return 'Macintosh' as its platform" do
-    expect(@useragent.platform).to eq('Macintosh')
+    expect(@useragent.platform).to eq("Macintosh")
   end
 
   it "should return 'OS X 10.9.5' as its os" do
-    expect(@useragent.os).to eq('OS X 10.9.5')
+    expect(@useragent.os).to eq("OS X 10.9.5")
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe 'UserAgent: Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36' do
+describe "UserAgent: Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36")
   end
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq('537.36')
+    expect(@useragent.build).to eq("537.36")
   end
 
   it "should return '30.0.1599.38' as its version" do
-    expect(@useragent.version).to eq('30.0.1599.38')
+    expect(@useragent.version).to eq("30.0.1599.38")
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('537.36')
+    expect(@useragent.webkit.version).to eq("537.36")
   end
 
   it "should return 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq('ChromeOS')
+    expect(@useragent.platform).to eq("ChromeOS")
   end
 
   it "should return 'ChromeOS 4537.56.0' as its os" do
-    expect(@useragent.os).to eq('ChromeOS 4537.56.0')
+    expect(@useragent.os).to eq("ChromeOS 4537.56.0")
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe 'UserAgent: Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36' do
+describe "UserAgent: Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; CrOS x86_64 4920.71.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.95 Safari/537.36")
   end
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq('537.36')
+    expect(@useragent.build).to eq("537.36")
   end
 
   it "should return '32.0.1700.95' as its version" do
-    expect(@useragent.version).to eq('32.0.1700.95')
+    expect(@useragent.version).to eq("32.0.1700.95")
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('537.36')
+    expect(@useragent.webkit.version).to eq("537.36")
   end
 
   it "should return 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq('ChromeOS')
+    expect(@useragent.platform).to eq("ChromeOS")
   end
 
   it "should return 'ChromeOS 4920.71.0' as its os" do
-    expect(@useragent.os).to eq('ChromeOS 4920.71.0')
+    expect(@useragent.os).to eq("ChromeOS 4920.71.0")
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe 'UserAgent: Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5' do
+describe "UserAgent: Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5')
+    @useragent = UserAgent.parse("Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5")
   end
 
   it "should return '532.5' as its build" do
-    expect(@useragent.build).to eq('532.5')
+    expect(@useragent.build).to eq("532.5")
   end
 
   it "should return '4.0.253.0' as its version" do
-    expect(@useragent.version).to eq('4.0.253.0')
+    expect(@useragent.version).to eq("4.0.253.0")
   end
 
   it "should return '532.5' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('532.5')
+    expect(@useragent.webkit.version).to eq("532.5")
   end
 
   it "should return 'ChromeOS' as its platform" do
-    expect(@useragent.platform).to eq('ChromeOS')
+    expect(@useragent.platform).to eq("ChromeOS")
   end
 
   it "should return 'ChromeOS 9.10.0' as its os" do
-    expect(@useragent.os).to eq('ChromeOS 9.10.0')
+    expect(@useragent.os).to eq("ChromeOS 9.10.0")
   end
 
   it { expect(@useragent).not_to be_mobile }
 end
 
-describe 'UserAgent: Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5' do
+describe "UserAgent: Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; U; fr; CPU iPhone OS 4_2_1 like Mac OS X; fr) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148a Safari/6533.18.5")
   end
 
   it "should return '533.17.9' as its build" do
-    expect(@useragent.build).to eq('533.17.9')
+    expect(@useragent.build).to eq("533.17.9")
   end
 
   it "should return '5.0.2' as its version" do
-    expect(@useragent.version).to eq('5.0.2')
+    expect(@useragent.version).to eq("5.0.2")
   end
 
   it "should return '533.17.9' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('533.17.9')
+    expect(@useragent.webkit.version).to eq("533.17.9")
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq('iPhone')
+    expect(@useragent.platform).to eq("iPhone")
   end
 
   it "should return 'iOS 4.2.1' as its os" do
-    expect(@useragent.os).to eq('iOS 4.2.1')
+    expect(@useragent.os).to eq("iOS 4.2.1")
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe 'UserAgent: Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30' do
+describe "UserAgent: Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30")
   end
 
   it "should return 'Android' as its browser" do
-    expect(@useragent.browser).to eq('Android')
+    expect(@useragent.browser).to eq("Android")
   end
 
-  it 'should return :strong as its security' do
+  it "should return :strong as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 
   it "should return '534.30' as its build" do
-    expect(@useragent.build).to eq('534.30')
+    expect(@useragent.build).to eq("534.30")
   end
 
   it "should return '4.0' as its version" do
-    expect(@useragent.version).to eq('4.0')
+    expect(@useragent.version).to eq("4.0")
   end
 
   it "should return '534.30' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('534.30')
+    expect(@useragent.webkit.version).to eq("534.30")
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq('Android')
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "should return 'Android 4.0.3' as its os" do
-    expect(@useragent.os).to eq('Android 4.0.3')
+    expect(@useragent.os).to eq("Android 4.0.3")
   end
 
   it "should return 'ko-kr' as its localization" do
-    expect(@useragent.localization).to eq('ko-kr')
+    expect(@useragent.localization).to eq("ko-kr")
   end
 
   it { expect(@useragent).to be_mobile }
 end
 
-describe 'UserAgent: HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36' do
+describe "UserAgent: HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36" do
   before do
-    @useragent = UserAgent.parse('HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36')
+    @useragent = UserAgent.parse("HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/01.18.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36")
   end
 
   it "should return 'Android' as its browser" do
-    expect(@useragent.browser).to eq('Android')
+    expect(@useragent.browser).to eq("Android")
   end
 
-  it 'should return :strong as its security' do
+  it "should return :strong as its security" do
     expect(@useragent.security).to eq(:strong)
   end
 
   it "should return '537.36' as its build" do
-    expect(@useragent.build).to eq('537.36')
+    expect(@useragent.build).to eq("537.36")
   end
 
-  it 'should return nil as its version' do
+  it "should return nil as its version" do
     expect(@useragent.version).to be_nil
   end
 
   it "should return '537.36' as its webkit version" do
-    expect(@useragent.webkit.version).to eq('537.36')
+    expect(@useragent.webkit.version).to eq("537.36")
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq('Android')
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "should return 'Android 4.4.2' as its os" do
-    expect(@useragent.os).to eq('Android 4.4.2')
+    expect(@useragent.os).to eq("Android 4.4.2")
   end
 
   it "should return 'zh-cn' as its localization" do
-    expect(@useragent.localization).to eq('zh-cn')
+    expect(@useragent.localization).to eq("zh-cn")
   end
 
   it { expect(@useragent).to be_mobile }

--- a/spec/browsers/wechat_browser_user_agent_spec.rb
+++ b/spec/browsers/wechat_browser_user_agent_spec.rb
@@ -1,69 +1,68 @@
+require 'spec_helper'
 require 'user_agent'
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN")
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN')
   end
 
-  it "should return WechatBrowser" do
-    expect(@useragent.browser).to eq("Wechat Browser")
+  it 'should return WechatBrowser' do
+    expect(@useragent.browser).to eq('Wechat Browser')
   end
 
   it "should return '6.3.16' as its version" do
-    expect(@useragent.version).to eq("6.3.16")
+    expect(@useragent.version).to eq('6.3.16')
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
+    expect(@useragent.platform).to eq('iPhone')
   end
 
   it "should return 'iOS 9.3.1' as its os" do
-    expect(@useragent.os).to eq("iOS 9.3.1")
+    expect(@useragent.os).to eq('iOS 9.3.1')
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN'" do
   before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN")
+    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN')
   end
 
-  it "should return WechatBrowser" do
-    expect(@useragent.browser).to eq("Wechat Browser")
+  it 'should return WechatBrowser' do
+    expect(@useragent.browser).to eq('Wechat Browser')
   end
 
   it "should return '6.3.16.49_r03ae324.780' as its version" do
-    expect(@useragent.version).to eq("6.3.16.49_r03ae324.780")
+    expect(@useragent.version).to eq('6.3.16.49_r03ae324.780')
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
+    expect(@useragent.platform).to eq('Android')
   end
 
   it "should return 'Android 4.4.4' as its os" do
-    expect(@useragent.os).to eq("Android 4.4.4")
+    expect(@useragent.os).to eq('Android 4.4.4')
   end
 end
 
-describe "Not well-formed UserAgent: LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN" do
+describe 'Not well-formed UserAgent: LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN' do
   before do
-    @useragent = UserAgent.parse("LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN")
+    @useragent = UserAgent.parse('LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN')
   end
 
-  it "should return WechatBrowser" do
-    expect(@useragent.browser).to eq("Wechat Browser")
+  it 'should return WechatBrowser' do
+    expect(@useragent.browser).to eq('Wechat Browser')
   end
 
   it "should return '6.2.4.54_r266a9ba.601' as its version" do
-    expect(@useragent.version).to eq("6.2.4.54_r266a9ba.601")
+    expect(@useragent.version).to eq('6.2.4.54_r266a9ba.601')
   end
 
-  it "should return nil as its platform" do
+  it 'should return nil as its platform' do
     expect(@useragent.platform).to be_nil
   end
 
-  it "should return nil as its os" do
+  it 'should return nil as its os' do
     expect(@useragent.os).to be_nil
   end
-
 end
-

--- a/spec/browsers/wechat_browser_user_agent_spec.rb
+++ b/spec/browsers/wechat_browser_user_agent_spec.rb
@@ -6,19 +6,19 @@ describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) Ap
     @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN")
   end
 
-  it "should return WechatBrowser" do
+  it "returns WechatBrowser" do
     expect(@useragent.browser).to eq("Wechat Browser")
   end
 
-  it "should return '6.3.16' as its version" do
+  it "returns '6.3.16' as its version" do
     expect(@useragent.version).to eq("6.3.16")
   end
 
-  it "should return 'iPhone' as its platform" do
+  it "returns 'iPhone' as its platform" do
     expect(@useragent.platform).to eq("iPhone")
   end
 
-  it "should return 'iOS 9.3.1' as its os" do
+  it "returns 'iOS 9.3.1' as its os" do
     expect(@useragent.os).to eq("iOS 9.3.1")
   end
 end
@@ -28,19 +28,19 @@ describe "UserAgent: 'Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) A
     @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN")
   end
 
-  it "should return WechatBrowser" do
+  it "returns WechatBrowser" do
     expect(@useragent.browser).to eq("Wechat Browser")
   end
 
-  it "should return '6.3.16.49_r03ae324.780' as its version" do
+  it "returns '6.3.16.49_r03ae324.780' as its version" do
     expect(@useragent.version).to eq("6.3.16.49_r03ae324.780")
   end
 
-  it "should return 'Android' as its platform" do
+  it "returns 'Android' as its platform" do
     expect(@useragent.platform).to eq("Android")
   end
 
-  it "should return 'Android 4.4.4' as its os" do
+  it "returns 'Android 4.4.4' as its os" do
     expect(@useragent.os).to eq("Android 4.4.4")
   end
 end
@@ -50,19 +50,19 @@ describe "Not well-formed UserAgent: LenovoA658t_TD/1.0 Android 4.0.3 Release/10
     @useragent = UserAgent.parse("LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN")
   end
 
-  it "should return WechatBrowser" do
+  it "returns WechatBrowser" do
     expect(@useragent.browser).to eq("Wechat Browser")
   end
 
-  it "should return '6.2.4.54_r266a9ba.601' as its version" do
+  it "returns '6.2.4.54_r266a9ba.601' as its version" do
     expect(@useragent.version).to eq("6.2.4.54_r266a9ba.601")
   end
 
-  it "should return nil as its platform" do
+  it "returns nil as its platform" do
     expect(@useragent.platform).to be_nil
   end
 
-  it "should return nil as its os" do
+  it "returns nil as its os" do
     expect(@useragent.os).to be_nil
   end
 end

--- a/spec/browsers/wechat_browser_user_agent_spec.rb
+++ b/spec/browsers/wechat_browser_user_agent_spec.rb
@@ -1,68 +1,68 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
 describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN')
+    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN")
   end
 
-  it 'should return WechatBrowser' do
-    expect(@useragent.browser).to eq('Wechat Browser')
+  it "should return WechatBrowser" do
+    expect(@useragent.browser).to eq("Wechat Browser")
   end
 
   it "should return '6.3.16' as its version" do
-    expect(@useragent.version).to eq('6.3.16')
+    expect(@useragent.version).to eq("6.3.16")
   end
 
   it "should return 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq('iPhone')
+    expect(@useragent.platform).to eq("iPhone")
   end
 
   it "should return 'iOS 9.3.1' as its os" do
-    expect(@useragent.os).to eq('iOS 9.3.1')
+    expect(@useragent.os).to eq("iOS 9.3.1")
   end
 end
 
 describe "UserAgent: 'Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN'" do
   before do
-    @useragent = UserAgent.parse('Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN')
+    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN")
   end
 
-  it 'should return WechatBrowser' do
-    expect(@useragent.browser).to eq('Wechat Browser')
+  it "should return WechatBrowser" do
+    expect(@useragent.browser).to eq("Wechat Browser")
   end
 
   it "should return '6.3.16.49_r03ae324.780' as its version" do
-    expect(@useragent.version).to eq('6.3.16.49_r03ae324.780')
+    expect(@useragent.version).to eq("6.3.16.49_r03ae324.780")
   end
 
   it "should return 'Android' as its platform" do
-    expect(@useragent.platform).to eq('Android')
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "should return 'Android 4.4.4' as its os" do
-    expect(@useragent.os).to eq('Android 4.4.4')
+    expect(@useragent.os).to eq("Android 4.4.4")
   end
 end
 
-describe 'Not well-formed UserAgent: LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN' do
+describe "Not well-formed UserAgent: LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN" do
   before do
-    @useragent = UserAgent.parse('LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN')
+    @useragent = UserAgent.parse("LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN")
   end
 
-  it 'should return WechatBrowser' do
-    expect(@useragent.browser).to eq('Wechat Browser')
+  it "should return WechatBrowser" do
+    expect(@useragent.browser).to eq("Wechat Browser")
   end
 
   it "should return '6.2.4.54_r266a9ba.601' as its version" do
-    expect(@useragent.version).to eq('6.2.4.54_r266a9ba.601')
+    expect(@useragent.version).to eq("6.2.4.54_r266a9ba.601")
   end
 
-  it 'should return nil as its platform' do
+  it "should return nil as its platform" do
     expect(@useragent.platform).to be_nil
   end
 
-  it 'should return nil as its os' do
+  it "should return nil as its os" do
     expect(@useragent.os).to be_nil
   end
 end

--- a/spec/browsers/wechat_browser_user_agent_spec.rb
+++ b/spec/browsers/wechat_browser_user_agent_spec.rb
@@ -1,68 +1,65 @@
 require "spec_helper"
 require "user_agent"
 
-describe "UserAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN")
+describe UserAgent do
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 MicroMessenger/6.3.16 NetType/WIFI Language/zh_CN") }
+
+    it "returns WechatBrowser" do
+      expect(useragent.browser).to eq("Wechat Browser")
+    end
+
+    it "returns '6.3.16' as its version" do
+      expect(useragent.version).to eq("6.3.16")
+    end
+
+    it "returns 'iPhone' as its platform" do
+      expect(useragent.platform).to eq("iPhone")
+    end
+
+    it "returns 'iOS 9.3.1' as its os" do
+      expect(useragent.os).to eq("iOS 9.3.1")
+    end
   end
 
-  it "returns WechatBrowser" do
-    expect(@useragent.browser).to eq("Wechat Browser")
+  context do
+    let(:useragent) { described_class.parse("Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN") }
+
+    it "returns WechatBrowser" do
+      expect(useragent.browser).to eq("Wechat Browser")
+    end
+
+    it "returns '6.3.16.49_r03ae324.780' as its version" do
+      expect(useragent.version).to eq("6.3.16.49_r03ae324.780")
+    end
+
+    it "returns 'Android' as its platform" do
+      expect(useragent.platform).to eq("Android")
+    end
+
+    it "returns 'Android 4.4.4' as its os" do
+      expect(useragent.os).to eq("Android 4.4.4")
+    end
   end
 
-  it "returns '6.3.16' as its version" do
-    expect(@useragent.version).to eq("6.3.16")
-  end
+  # Not well formed
+  context do
+    let(:useragent) { described_class.parse("LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN") }
 
-  it "returns 'iPhone' as its platform" do
-    expect(@useragent.platform).to eq("iPhone")
-  end
+    it "returns WechatBrowser" do
+      expect(useragent.browser).to eq("Wechat Browser")
+    end
 
-  it "returns 'iOS 9.3.1' as its os" do
-    expect(@useragent.os).to eq("iOS 9.3.1")
-  end
-end
+    it "returns '6.2.4.54_r266a9ba.601' as its version" do
+      expect(useragent.version).to eq("6.2.4.54_r266a9ba.601")
+    end
 
-describe "UserAgent: 'Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN'" do
-  before do
-    @useragent = UserAgent.parse("Mozilla/5.0 (Linux; Android 4.4.4; MI 4LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036215 Safari/537.36 MicroMessenger/6.3.16.49_r03ae324.780 NetType/WIFI Language/zh_CN")
-  end
+    it "returns nil as its platform" do
+      expect(useragent.platform).to be_nil
+    end
 
-  it "returns WechatBrowser" do
-    expect(@useragent.browser).to eq("Wechat Browser")
-  end
-
-  it "returns '6.3.16.49_r03ae324.780' as its version" do
-    expect(@useragent.version).to eq("6.3.16.49_r03ae324.780")
-  end
-
-  it "returns 'Android' as its platform" do
-    expect(@useragent.platform).to eq("Android")
-  end
-
-  it "returns 'Android 4.4.4' as its os" do
-    expect(@useragent.os).to eq("Android 4.4.4")
-  end
-end
-
-describe "Not well-formed UserAgent: LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN" do
-  before do
-    @useragent = UserAgent.parse("LenovoA658t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/cmnet Language/zh_CN")
-  end
-
-  it "returns WechatBrowser" do
-    expect(@useragent.browser).to eq("Wechat Browser")
-  end
-
-  it "returns '6.2.4.54_r266a9ba.601' as its version" do
-    expect(@useragent.version).to eq("6.2.4.54_r266a9ba.601")
-  end
-
-  it "returns nil as its platform" do
-    expect(@useragent.platform).to be_nil
-  end
-
-  it "returns nil as its os" do
-    expect(@useragent.os).to be_nil
+    it "returns nil as its os" do
+      expect(useragent.os).to be_nil
+    end
   end
 end

--- a/spec/browsers/windows_media_player_user_agent_spec.rb
+++ b/spec/browsers/windows_media_player_user_agent_spec.rb
@@ -1,85 +1,85 @@
-require 'spec_helper'
-require 'user_agent'
+require "spec_helper"
+require "user_agent"
 
-shared_examples 'Windows Media Player' do
+shared_examples "Windows Media Player" do
   it "should return 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq('Windows Media Player')
+    expect(@useragent.browser).to eq("Windows Media Player")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
-  it 'should not identify as being classic' do
+  it "should not identify as being classic" do
     expect(@useragent.classic?).to eq(false)
   end
 
-  it 'should be the desktop version' do
+  it "should be the desktop version" do
     expect(@useragent.mobile?).to eq(false)
   end
 end
 
-shared_examples 'Windows Media Player Mobile' do
+shared_examples "Windows Media Player Mobile" do
   it "should return 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq('Windows Media Player')
+    expect(@useragent.browser).to eq("Windows Media Player")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
-  it 'should not identify as being classic' do
+  it "should not identify as being classic" do
     expect(@useragent.classic?).to eq(false)
   end
 
-  it 'should be the desktop version' do
+  it "should be the desktop version" do
     expect(@useragent.mobile?).to eq(true)
   end
 end
 
-shared_examples 'Windows Media Player Classic' do
+shared_examples "Windows Media Player Classic" do
   it "should return 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq('Windows Media Player')
+    expect(@useragent.browser).to eq("Windows Media Player")
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq('Windows')
+    expect(@useragent.platform).to eq("Windows")
   end
 
-  it 'should identify as being classic' do
+  it "should identify as being classic" do
     expect(@useragent.classic?).to eq(true)
   end
 end
 
 shared_examples "Windows Media Player isn't using WMFSDK" do
-  it 'should return nil as its WMFSDK version' do
+  it "should return nil as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to be_nil
   end
 
-  it 'should not have WMFSDK9' do
-    expect(@useragent.wmfsdk?('9')).to eq(false)
+  it "should not have WMFSDK9" do
+    expect(@useragent.wmfsdk?("9")).to eq(false)
   end
 
-  it 'should not have WMFSDK10' do
-    expect(@useragent.wmfsdk?('10')).to eq(false)
+  it "should not have WMFSDK10" do
+    expect(@useragent.wmfsdk?("10")).to eq(false)
   end
 
-  it 'should not have WMFSDK11' do
-    expect(@useragent.wmfsdk?('11')).to eq(false)
+  it "should not have WMFSDK11" do
+    expect(@useragent.wmfsdk?("11")).to eq(false)
   end
 
-  it 'should not have WMFSDK12' do
-    expect(@useragent.wmfsdk?('12')).to eq(false)
+  it "should not have WMFSDK12" do
+    expect(@useragent.wmfsdk?("12")).to eq(false)
   end
 end
 
-shared_examples 'Windows Media Player runs on' do |os|
+shared_examples "Windows Media Player runs on" do |os|
   it "should return '#{os}' as its OS" do
     expect(@useragent.os).to eq(os)
   end
 end
 
-shared_examples 'Windows Media Player has version number' do |version|
+shared_examples "Windows Media Player has version number" do |version|
   it "should return '#{version}' as its version" do
     expect(@useragent.version).to eq(version)
   end
@@ -92,11 +92,11 @@ end
     end
 
     it "should not return 'Windows Media Player' as its browser" do
-      expect(@useragent.browser).not_to eq('Windows Media Player')
+      expect(@useragent.browser).not_to eq("Windows Media Player")
     end
 
     it "should not return 'Windows' as its platform" do
-      expect(@useragent.platform).not_to eq('Windows')
+      expect(@useragent.platform).not_to eq("Windows")
     end
   end
 end
@@ -107,10 +107,10 @@ end
       @useragent = UserAgent.parse("NSPlayer/#{win9x_wmp6}")
     end
 
-    it_behaves_like 'Windows Media Player Classic'
+    it_behaves_like "Windows Media Player Classic"
     it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like 'Windows Media Player runs on', 'Windows 9x'
-    it_behaves_like 'Windows Media Player has version number', win9x_wmp6
+    it_behaves_like "Windows Media Player runs on", "Windows 9x"
+    it_behaves_like "Windows Media Player has version number", win9x_wmp6
   end
 end
 
@@ -120,10 +120,10 @@ end
       @useragent = UserAgent.parse("NSPlayer/#{win98_wmp6}")
     end
 
-    it_behaves_like 'Windows Media Player Classic'
+    it_behaves_like "Windows Media Player Classic"
     it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like 'Windows Media Player runs on', 'Windows 98'
-    it_behaves_like 'Windows Media Player has version number', win98_wmp6
+    it_behaves_like "Windows Media Player runs on", "Windows 98"
+    it_behaves_like "Windows Media Player has version number", win98_wmp6
   end
 end
 
@@ -133,362 +133,362 @@ end
       @useragent = UserAgent.parse("NSPlayer/#{win98_wmp71}")
     end
 
-    it_behaves_like 'Windows Media Player'
+    it_behaves_like "Windows Media Player"
     it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like 'Windows Media Player runs on', 'Windows 98'
-    it_behaves_like 'Windows Media Player has version number', win98_wmp71
+    it_behaves_like "Windows Media Player runs on", "Windows 98"
+    it_behaves_like "Windows Media Player has version number", win98_wmp71
   end
 end
 
-describe 'UserAgent: Windows-Media-Player/9.00.00.2980' do
+describe "UserAgent: Windows-Media-Player/9.00.00.2980" do
   before do
-    @useragent = UserAgent.parse('Windows-Media-Player/9.00.00.2980')
+    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.2980")
   end
 
-  it_behaves_like 'Windows Media Player'
+  it_behaves_like "Windows Media Player"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows 98/2000'
-  it_behaves_like 'Windows Media Player has version number', '9.00.00.2980'
+  it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
+  it_behaves_like "Windows Media Player has version number", "9.00.00.2980"
 end
 
-describe 'UserAgent: NSPlayer/9.0.0.2980 WMFSDK/9.0' do
+describe "UserAgent: NSPlayer/9.0.0.2980 WMFSDK/9.0" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/9.0.0.2980 WMFSDK/9.0')
+    @useragent = UserAgent.parse("NSPlayer/9.0.0.2980 WMFSDK/9.0")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows 98/2000'
-  it_behaves_like 'Windows Media Player has version number', '9.0.0.2980'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
+  it_behaves_like "Windows Media Player has version number", "9.0.0.2980"
 
   it "should return '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('9.0')
+    expect(@useragent.wmfsdk_version).to eq("9.0")
   end
 
-  it 'should have WMFSDK9' do
-    expect(@useragent.wmfsdk?('9.0')).to eq(true)
+  it "should have WMFSDK9" do
+    expect(@useragent.wmfsdk?("9.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: NSPlayer/4.1.0.3938' do
+describe "UserAgent: NSPlayer/4.1.0.3938" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/4.1.0.3938')
+    @useragent = UserAgent.parse("NSPlayer/4.1.0.3938")
   end
 
-  it_behaves_like 'Windows Media Player Classic'
+  it_behaves_like "Windows Media Player Classic"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
-  it_behaves_like 'Windows Media Player has version number', '4.1.0.3938'
+  it_behaves_like "Windows Media Player runs on", "Windows 2000"
+  it_behaves_like "Windows Media Player has version number", "4.1.0.3938"
 end
 
-describe 'UserAgent: NSPlayer/9.0.0.3268' do
+describe "UserAgent: NSPlayer/9.0.0.3268" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/9.0.0.3268')
+    @useragent = UserAgent.parse("NSPlayer/9.0.0.3268")
   end
 
-  it_behaves_like 'Windows Media Player'
+  it_behaves_like "Windows Media Player"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
-  it_behaves_like 'Windows Media Player has version number', '9.0.0.3268'
+  it_behaves_like "Windows Media Player runs on", "Windows 2000"
+  it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
 end
 
-describe 'UserAgent: NSPlayer/9.0.0.3268 WMFSDK/9.0' do
+describe "UserAgent: NSPlayer/9.0.0.3268 WMFSDK/9.0" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/9.0.0.3268 WMFSDK/9.0')
+    @useragent = UserAgent.parse("NSPlayer/9.0.0.3268 WMFSDK/9.0")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
-  it_behaves_like 'Windows Media Player has version number', '9.0.0.3268'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows 2000"
+  it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
 
   it "should return '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('9.0')
+    expect(@useragent.wmfsdk_version).to eq("9.0")
   end
 
-  it 'should have WMFSDK9' do
-    expect(@useragent.wmfsdk?('9.0')).to eq(true)
+  it "should have WMFSDK9" do
+    expect(@useragent.wmfsdk?("9.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: NSPlayer/9.0.0.3270 WMFSDK/9.0' do
+describe "UserAgent: NSPlayer/9.0.0.3270 WMFSDK/9.0" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/9.0.0.3270 WMFSDK/9.0')
+    @useragent = UserAgent.parse("NSPlayer/9.0.0.3270 WMFSDK/9.0")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
-  it_behaves_like 'Windows Media Player has version number', '9.0.0.3270'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows 2000"
+  it_behaves_like "Windows Media Player has version number", "9.0.0.3270"
 
   it "should return '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('9.0')
+    expect(@useragent.wmfsdk_version).to eq("9.0")
   end
 
-  it 'should have WMFSDK9' do
-    expect(@useragent.wmfsdk?('9.0')).to eq(true)
+  it "should have WMFSDK9" do
+    expect(@useragent.wmfsdk?("9.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: Windows-Media-Player/9.00.00.3367' do
+describe "UserAgent: Windows-Media-Player/9.00.00.3367" do
   before do
-    @useragent = UserAgent.parse('Windows-Media-Player/9.00.00.3367')
+    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.3367")
   end
 
-  it_behaves_like 'Windows Media Player'
+  it_behaves_like "Windows Media Player"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
-  it_behaves_like 'Windows Media Player has version number', '9.00.00.3367'
+  it_behaves_like "Windows Media Player runs on", "Windows 2000"
+  it_behaves_like "Windows Media Player has version number", "9.00.00.3367"
 end
 
-describe 'UserAgent: NSPlayer/4.1.0.3936' do
+describe "UserAgent: NSPlayer/4.1.0.3936" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/4.1.0.3936')
+    @useragent = UserAgent.parse("NSPlayer/4.1.0.3936")
   end
 
-  it_behaves_like 'Windows Media Player Classic'
+  it_behaves_like "Windows Media Player Classic"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
-  it_behaves_like 'Windows Media Player has version number', '4.1.0.3936'
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like "Windows Media Player has version number", "4.1.0.3936"
 end
 
-describe 'UserAgent: NSPlayer/9.0.0.4503' do
+describe "UserAgent: NSPlayer/9.0.0.4503" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/9.0.0.4503')
+    @useragent = UserAgent.parse("NSPlayer/9.0.0.4503")
   end
 
-  it_behaves_like 'Windows Media Player'
+  it_behaves_like "Windows Media Player"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
-  it_behaves_like 'Windows Media Player has version number', '9.0.0.4503'
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
 end
 
-describe 'UserAgent: NSPlayer/9.0.0.4503 WMFSDK/9.0' do
+describe "UserAgent: NSPlayer/9.0.0.4503 WMFSDK/9.0" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/9.0.0.4503 WMFSDK/9.0')
+    @useragent = UserAgent.parse("NSPlayer/9.0.0.4503 WMFSDK/9.0")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
-  it_behaves_like 'Windows Media Player has version number', '9.0.0.4503'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
 
   it "should return '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('9.0')
+    expect(@useragent.wmfsdk_version).to eq("9.0")
   end
 
-  it 'should have WMFSDK9' do
-    expect(@useragent.wmfsdk?('9.0')).to eq(true)
+  it "should have WMFSDK9" do
+    expect(@useragent.wmfsdk?("9.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: Windows-Media-Player/9.00.00.4503' do
+describe "UserAgent: Windows-Media-Player/9.00.00.4503" do
   before do
-    @useragent = UserAgent.parse('Windows-Media-Player/9.00.00.4503')
+    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.4503")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player has version number', '9.00.00.4503'
+  it_behaves_like "Windows Media Player has version number", "9.00.00.4503"
 end
 
-describe 'UserAgent: NSPlayer/10.0.0.3802' do
+describe "UserAgent: NSPlayer/10.0.0.3802" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/10.0.0.3802')
+    @useragent = UserAgent.parse("NSPlayer/10.0.0.3802")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player has version number', '10.0.0.3802'
+  it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
 end
 
-describe 'UserAgent: NSPlayer/10.0.0.3802 WMFSDK/10.0' do
+describe "UserAgent: NSPlayer/10.0.0.3802 WMFSDK/10.0" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/10.0.0.3802 WMFSDK/10.0')
+    @useragent = UserAgent.parse("NSPlayer/10.0.0.3802 WMFSDK/10.0")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
-  it_behaves_like 'Windows Media Player has version number', '10.0.0.3802'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
 
   it "should return '10.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('10.0')
+    expect(@useragent.wmfsdk_version).to eq("10.0")
   end
 
-  it 'should have WMFSDK10' do
-    expect(@useragent.wmfsdk?('10.0')).to eq(true)
+  it "should have WMFSDK10" do
+    expect(@useragent.wmfsdk?("10.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: Windows-Media-Player/10.00.00.3802' do
+describe "UserAgent: Windows-Media-Player/10.00.00.3802" do
   before do
-    @useragent = UserAgent.parse('Windows-Media-Player/10.00.00.3802')
+    @useragent = UserAgent.parse("Windows-Media-Player/10.00.00.3802")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player has version number', '10.00.00.3802'
+  it_behaves_like "Windows Media Player has version number", "10.00.00.3802"
 end
 
-describe 'UserAgent: NSPlayer/11.0.5721.5262' do
+describe "UserAgent: NSPlayer/11.0.5721.5262" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/11.0.5721.5262')
+    @useragent = UserAgent.parse("NSPlayer/11.0.5721.5262")
   end
 
-  it_behaves_like 'Windows Media Player'
+  it_behaves_like "Windows Media Player"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
-  it_behaves_like 'Windows Media Player has version number', '11.0.5721.5262'
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
 end
 
-describe 'UserAgent: NSPlayer/11.0.5721.5262 WMFSDK/11.0' do
+describe "UserAgent: NSPlayer/11.0.5721.5262 WMFSDK/11.0" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/11.0.5721.5262 WMFSDK/11.0')
+    @useragent = UserAgent.parse("NSPlayer/11.0.5721.5262 WMFSDK/11.0")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
-  it_behaves_like 'Windows Media Player has version number', '11.0.5721.5262'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
 
   it "should return '11.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('11.0')
+    expect(@useragent.wmfsdk_version).to eq("11.0")
   end
 
-  it 'should have WMFSDK11' do
-    expect(@useragent.wmfsdk?('11.0')).to eq(true)
+  it "should have WMFSDK11" do
+    expect(@useragent.wmfsdk?("11.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: Windows-Media-Player/11.0.5721.5262' do
+describe "UserAgent: Windows-Media-Player/11.0.5721.5262" do
   before do
-    @useragent = UserAgent.parse('Windows-Media-Player/11.0.5721.5262')
+    @useragent = UserAgent.parse("Windows-Media-Player/11.0.5721.5262")
   end
 
-  it_behaves_like 'Windows Media Player'
+  it_behaves_like "Windows Media Player"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
-  it_behaves_like 'Windows Media Player has version number', '11.0.5721.5262'
+  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
 end
 
-describe 'UserAgent: NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392' do
+describe "UserAgent: NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392')
+    @useragent = UserAgent.parse("NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows Vista'
-  it_behaves_like 'Windows Media Player has version number', '11.00.6002.18392'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows Vista"
+  it_behaves_like "Windows Media Player has version number", "11.00.6002.18392"
 
   it "should return '11.00.6002.18392' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('11.00.6002.18392')
+    expect(@useragent.wmfsdk_version).to eq("11.00.6002.18392")
   end
 
-  it 'should have WMFSDK11' do
-    expect(@useragent.wmfsdk?('11.0')).to eq(true)
+  it "should have WMFSDK11" do
+    expect(@useragent.wmfsdk?("11.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: NSPlayer/11.0.6002.18005' do
+describe "UserAgent: NSPlayer/11.0.6002.18005" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/11.0.6002.18005')
+    @useragent = UserAgent.parse("NSPlayer/11.0.6002.18005")
   end
 
-  it_behaves_like 'Windows Media Player'
+  it_behaves_like "Windows Media Player"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows Vista'
-  it_behaves_like 'Windows Media Player has version number', '11.0.6002.18005'
+  it_behaves_like "Windows Media Player runs on", "Windows Vista"
+  it_behaves_like "Windows Media Player has version number", "11.0.6002.18005"
 end
 
-describe 'UserAgent: NSPlayer/11.0.6002.18049 WMFSDK/11.0' do
+describe "UserAgent: NSPlayer/11.0.6002.18049 WMFSDK/11.0" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/11.0.6002.18049 WMFSDK/11.0')
+    @useragent = UserAgent.parse("NSPlayer/11.0.6002.18049 WMFSDK/11.0")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows Vista'
-  it_behaves_like 'Windows Media Player has version number', '11.0.6002.18049'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows Vista"
+  it_behaves_like "Windows Media Player has version number", "11.0.6002.18049"
 
   it "should return '11.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('11.0')
+    expect(@useragent.wmfsdk_version).to eq("11.0")
   end
 
-  it 'should have WMFSDK11' do
-    expect(@useragent.wmfsdk?('11.0')).to eq(true)
+  it "should have WMFSDK11" do
+    expect(@useragent.wmfsdk?("11.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: Windows-Media-Player/11.0.6002.18311' do
+describe "UserAgent: Windows-Media-Player/11.0.6002.18311" do
   before do
-    @useragent = UserAgent.parse('Windows-Media-Player/11.0.6002.18311')
+    @useragent = UserAgent.parse("Windows-Media-Player/11.0.6002.18311")
   end
 
-  it_behaves_like 'Windows Media Player'
+  it_behaves_like "Windows Media Player"
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like 'Windows Media Player runs on', 'Windows Vista'
-  it_behaves_like 'Windows Media Player has version number', '11.0.6002.18311'
+  it_behaves_like "Windows Media Player runs on", "Windows Vista"
+  it_behaves_like "Windows Media Player has version number", "11.0.6002.18311"
 end
 
 # FIXME: User agents for Windows 7 and Windows 8
 
-describe 'UserAgent: NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031' do
+describe "UserAgent: NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031')
+    @useragent = UserAgent.parse("NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows 8.1'
-  it_behaves_like 'Windows Media Player has version number', '12.00.9600.17031'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows 8.1"
+  it_behaves_like "Windows Media Player has version number", "12.00.9600.17031"
 
   it "should return '12.00.9600.17031' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('12.00.9600.17031')
+    expect(@useragent.wmfsdk_version).to eq("12.00.9600.17031")
   end
 
-  it 'should have WMFSDK12' do
-    expect(@useragent.wmfsdk?('12.0')).to eq(true)
+  it "should have WMFSDK12" do
+    expect(@useragent.wmfsdk?("12.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: Windows-Media-Player/12.0.9841.0' do
+describe "UserAgent: Windows-Media-Player/12.0.9841.0" do
   before do
-    @useragent = UserAgent.parse('Windows-Media-Player/12.0.9841.0')
+    @useragent = UserAgent.parse("Windows-Media-Player/12.0.9841.0")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows 10'
-  it_behaves_like 'Windows Media Player has version number', '12.0.9841.0'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows 10"
+  it_behaves_like "Windows Media Player has version number", "12.0.9841.0"
 end
 
-describe 'UserAgent: NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000' do
+describe "UserAgent: NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000')
+    @useragent = UserAgent.parse("NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000")
   end
 
-  it_behaves_like 'Windows Media Player'
-  it_behaves_like 'Windows Media Player runs on', 'Windows 10'
-  it_behaves_like 'Windows Media Player has version number', '12.00.9841.0000'
+  it_behaves_like "Windows Media Player"
+  it_behaves_like "Windows Media Player runs on", "Windows 10"
+  it_behaves_like "Windows Media Player has version number", "12.00.9841.0000"
 
   it "should return '12.00.9841.0000' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('12.00.9841.0000')
+    expect(@useragent.wmfsdk_version).to eq("12.00.9841.0000")
   end
 
-  it 'should have WMFSDK12' do
-    expect(@useragent.wmfsdk?('12.0')).to eq(true)
+  it "should have WMFSDK12" do
+    expect(@useragent.wmfsdk?("12.0")).to eq(true)
   end
 end
 
-describe 'UserAgent: NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000' do
+describe "UserAgent: NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000" do
   before do
-    @useragent = UserAgent.parse('NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000')
+    @useragent = UserAgent.parse("NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000")
   end
 
-  it_behaves_like 'Windows Media Player Mobile'
-  it_behaves_like 'Windows Media Player runs on', 'Windows Phone 8.1'
-  it_behaves_like 'Windows Media Player has version number', '12.00.9651.0000'
+  it_behaves_like "Windows Media Player Mobile"
+  it_behaves_like "Windows Media Player runs on", "Windows Phone 8.1"
+  it_behaves_like "Windows Media Player has version number", "12.00.9651.0000"
 
   it "should return '12.00.9651.0000' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq('12.00.9651.0000')
+    expect(@useragent.wmfsdk_version).to eq("12.00.9651.0000")
   end
 
-  it 'should have WMFSDK12' do
-    expect(@useragent.wmfsdk?('12.0')).to eq(true)
+  it "should have WMFSDK12" do
+    expect(@useragent.wmfsdk?("12.0")).to eq(true)
   end
 end

--- a/spec/browsers/windows_media_player_user_agent_spec.rb
+++ b/spec/browsers/windows_media_player_user_agent_spec.rb
@@ -1,493 +1,494 @@
+require 'spec_helper'
 require 'user_agent'
 
-shared_examples "Windows Media Player" do
+shared_examples 'Windows Media Player' do
   it "should return 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq("Windows Media Player")
+    expect(@useragent.browser).to eq('Windows Media Player')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
-  it "should not identify as being classic" do
+  it 'should not identify as being classic' do
     expect(@useragent.classic?).to eq(false)
   end
 
-  it "should be the desktop version" do
+  it 'should be the desktop version' do
     expect(@useragent.mobile?).to eq(false)
   end
 end
 
-shared_examples "Windows Media Player Mobile" do
+shared_examples 'Windows Media Player Mobile' do
   it "should return 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq("Windows Media Player")
+    expect(@useragent.browser).to eq('Windows Media Player')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
-  it "should not identify as being classic" do
+  it 'should not identify as being classic' do
     expect(@useragent.classic?).to eq(false)
   end
 
-  it "should be the desktop version" do
+  it 'should be the desktop version' do
     expect(@useragent.mobile?).to eq(true)
   end
 end
 
-shared_examples "Windows Media Player Classic" do
+shared_examples 'Windows Media Player Classic' do
   it "should return 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq("Windows Media Player")
+    expect(@useragent.browser).to eq('Windows Media Player')
   end
 
   it "should return 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(@useragent.platform).to eq('Windows')
   end
 
-  it "should identify as being classic" do
+  it 'should identify as being classic' do
     expect(@useragent.classic?).to eq(true)
   end
 end
 
 shared_examples "Windows Media Player isn't using WMFSDK" do
-  it "should return nil as its WMFSDK version" do
+  it 'should return nil as its WMFSDK version' do
     expect(@useragent.wmfsdk_version).to be_nil
   end
 
-  it "should not have WMFSDK9" do
-    expect(@useragent.has_wmfsdk?("9")).to eq(false)
+  it 'should not have WMFSDK9' do
+    expect(@useragent.wmfsdk?('9')).to eq(false)
   end
 
-  it "should not have WMFSDK10" do
-    expect(@useragent.has_wmfsdk?("10")).to eq(false)
+  it 'should not have WMFSDK10' do
+    expect(@useragent.wmfsdk?('10')).to eq(false)
   end
 
-  it "should not have WMFSDK11" do
-    expect(@useragent.has_wmfsdk?("11")).to eq(false)
+  it 'should not have WMFSDK11' do
+    expect(@useragent.wmfsdk?('11')).to eq(false)
   end
 
-  it "should not have WMFSDK12" do
-    expect(@useragent.has_wmfsdk?("12")).to eq(false)
+  it 'should not have WMFSDK12' do
+    expect(@useragent.wmfsdk?('12')).to eq(false)
   end
 end
 
-shared_examples "Windows Media Player runs on" do |os|
+shared_examples 'Windows Media Player runs on' do |os|
   it "should return '#{os}' as its OS" do
     expect(@useragent.os).to eq(os)
   end
 end
 
-shared_examples "Windows Media Player has version number" do |version|
+shared_examples 'Windows Media Player has version number' do |version|
   it "should return '#{version}' as its version" do
     expect(@useragent.version).to eq(version)
   end
 end
 
-%w{4.1.0.3856 7.10.0.3059 7.0.0.1956}.each do |not_wmp|
+%w[4.1.0.3856 7.10.0.3059 7.0.0.1956].each do |not_wmp|
   describe "UserAgent: NSPlayer/#{not_wmp}" do
     before do
       @useragent = UserAgent.parse("NSPlayer/#{not_wmp}")
     end
 
     it "should not return 'Windows Media Player' as its browser" do
-      expect(@useragent.browser).not_to eq("Windows Media Player")
+      expect(@useragent.browser).not_to eq('Windows Media Player')
     end
 
     it "should not return 'Windows' as its platform" do
-      expect(@useragent.platform).not_to eq("Windows")
+      expect(@useragent.platform).not_to eq('Windows')
     end
   end
 end
 
-%w{4.1.0.3857}.each do |win9x_wmp6|
+%w[4.1.0.3857].each do |win9x_wmp6|
   describe "UserAgent: NSPlayer/#{win9x_wmp6}" do
     before do
       @useragent = UserAgent.parse("NSPlayer/#{win9x_wmp6}")
     end
 
-    it_behaves_like "Windows Media Player Classic"
+    it_behaves_like 'Windows Media Player Classic'
     it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like "Windows Media Player runs on", "Windows 9x"
-    it_behaves_like "Windows Media Player has version number", win9x_wmp6
+    it_behaves_like 'Windows Media Player runs on', 'Windows 9x'
+    it_behaves_like 'Windows Media Player has version number', win9x_wmp6
   end
 end
 
-%w{3.2.0.3564 4.1.0.3925}.each do |win98_wmp6|
+%w[3.2.0.3564 4.1.0.3925].each do |win98_wmp6|
   describe "UserAgent: NSPlayer/#{win98_wmp6}" do
     before do
       @useragent = UserAgent.parse("NSPlayer/#{win98_wmp6}")
     end
 
-    it_behaves_like "Windows Media Player Classic"
+    it_behaves_like 'Windows Media Player Classic'
     it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like "Windows Media Player runs on", "Windows 98"
-    it_behaves_like "Windows Media Player has version number", win98_wmp6
+    it_behaves_like 'Windows Media Player runs on', 'Windows 98'
+    it_behaves_like 'Windows Media Player has version number', win98_wmp6
   end
 end
 
-%w{7.1.0.3055}.each do |win98_wmp71|
+%w[7.1.0.3055].each do |win98_wmp71|
   describe "UserAgent: NSPlayer/#{win98_wmp71}" do
     before do
       @useragent = UserAgent.parse("NSPlayer/#{win98_wmp71}")
     end
 
-    it_behaves_like "Windows Media Player"
+    it_behaves_like 'Windows Media Player'
     it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like "Windows Media Player runs on", "Windows 98"
-    it_behaves_like "Windows Media Player has version number", win98_wmp71
+    it_behaves_like 'Windows Media Player runs on', 'Windows 98'
+    it_behaves_like 'Windows Media Player has version number', win98_wmp71
   end
 end
 
-describe "UserAgent: Windows-Media-Player/9.00.00.2980" do
+describe 'UserAgent: Windows-Media-Player/9.00.00.2980' do
   before do
-    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.2980")
+    @useragent = UserAgent.parse('Windows-Media-Player/9.00.00.2980')
   end
 
-  it_behaves_like "Windows Media Player"
+  it_behaves_like 'Windows Media Player'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
-  it_behaves_like "Windows Media Player has version number", "9.00.00.2980"
+  it_behaves_like 'Windows Media Player runs on', 'Windows 98/2000'
+  it_behaves_like 'Windows Media Player has version number', '9.00.00.2980'
 end
 
-describe "UserAgent: NSPlayer/9.0.0.2980 WMFSDK/9.0" do
+describe 'UserAgent: NSPlayer/9.0.0.2980 WMFSDK/9.0' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.2980 WMFSDK/9.0")
+    @useragent = UserAgent.parse('NSPlayer/9.0.0.2980 WMFSDK/9.0')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.2980"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows 98/2000'
+  it_behaves_like 'Windows Media Player has version number', '9.0.0.2980'
 
   it "should return '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("9.0")
+    expect(@useragent.wmfsdk_version).to eq('9.0')
   end
 
-  it "should have WMFSDK9" do
-    expect(@useragent.has_wmfsdk?("9.0")).to eq(true)
+  it 'should have WMFSDK9' do
+    expect(@useragent.wmfsdk?('9.0')).to eq(true)
   end
 end
 
-describe "UserAgent: NSPlayer/4.1.0.3938" do
+describe 'UserAgent: NSPlayer/4.1.0.3938' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/4.1.0.3938")
+    @useragent = UserAgent.parse('NSPlayer/4.1.0.3938')
   end
 
-  it_behaves_like "Windows Media Player Classic"
+  it_behaves_like 'Windows Media Player Classic'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "4.1.0.3938"
+  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
+  it_behaves_like 'Windows Media Player has version number', '4.1.0.3938'
 end
 
-describe "UserAgent: NSPlayer/9.0.0.3268" do
+describe 'UserAgent: NSPlayer/9.0.0.3268' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.3268")
+    @useragent = UserAgent.parse('NSPlayer/9.0.0.3268')
   end
 
-  it_behaves_like "Windows Media Player"
+  it_behaves_like 'Windows Media Player'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
+  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
+  it_behaves_like 'Windows Media Player has version number', '9.0.0.3268'
 end
 
-describe "UserAgent: NSPlayer/9.0.0.3268 WMFSDK/9.0" do
+describe 'UserAgent: NSPlayer/9.0.0.3268 WMFSDK/9.0' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.3268 WMFSDK/9.0")
+    @useragent = UserAgent.parse('NSPlayer/9.0.0.3268 WMFSDK/9.0')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
+  it_behaves_like 'Windows Media Player has version number', '9.0.0.3268'
 
   it "should return '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("9.0")
+    expect(@useragent.wmfsdk_version).to eq('9.0')
   end
 
-  it "should have WMFSDK9" do
-    expect(@useragent.has_wmfsdk?("9.0")).to eq(true)
+  it 'should have WMFSDK9' do
+    expect(@useragent.wmfsdk?('9.0')).to eq(true)
   end
 end
 
-describe "UserAgent: NSPlayer/9.0.0.3270 WMFSDK/9.0" do
+describe 'UserAgent: NSPlayer/9.0.0.3270 WMFSDK/9.0' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.3270 WMFSDK/9.0")
+    @useragent = UserAgent.parse('NSPlayer/9.0.0.3270 WMFSDK/9.0')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.3270"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
+  it_behaves_like 'Windows Media Player has version number', '9.0.0.3270'
 
   it "should return '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("9.0")
+    expect(@useragent.wmfsdk_version).to eq('9.0')
   end
 
-  it "should have WMFSDK9" do
-    expect(@useragent.has_wmfsdk?("9.0")).to eq(true)
+  it 'should have WMFSDK9' do
+    expect(@useragent.wmfsdk?('9.0')).to eq(true)
   end
 end
 
-describe "UserAgent: Windows-Media-Player/9.00.00.3367" do
+describe 'UserAgent: Windows-Media-Player/9.00.00.3367' do
   before do
-    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.3367")
+    @useragent = UserAgent.parse('Windows-Media-Player/9.00.00.3367')
   end
 
-  it_behaves_like "Windows Media Player"
+  it_behaves_like 'Windows Media Player'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "9.00.00.3367"
+  it_behaves_like 'Windows Media Player runs on', 'Windows 2000'
+  it_behaves_like 'Windows Media Player has version number', '9.00.00.3367'
 end
 
-describe "UserAgent: NSPlayer/4.1.0.3936" do
+describe 'UserAgent: NSPlayer/4.1.0.3936' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/4.1.0.3936")
+    @useragent = UserAgent.parse('NSPlayer/4.1.0.3936')
   end
 
-  it_behaves_like "Windows Media Player Classic"
+  it_behaves_like 'Windows Media Player Classic'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "4.1.0.3936"
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like 'Windows Media Player has version number', '4.1.0.3936'
 end
 
-describe "UserAgent: NSPlayer/9.0.0.4503" do
+describe 'UserAgent: NSPlayer/9.0.0.4503' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.4503")
+    @useragent = UserAgent.parse('NSPlayer/9.0.0.4503')
   end
 
-  it_behaves_like "Windows Media Player"
+  it_behaves_like 'Windows Media Player'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like 'Windows Media Player has version number', '9.0.0.4503'
 end
 
-describe "UserAgent: NSPlayer/9.0.0.4503 WMFSDK/9.0" do
+describe 'UserAgent: NSPlayer/9.0.0.4503 WMFSDK/9.0' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.4503 WMFSDK/9.0")
+    @useragent = UserAgent.parse('NSPlayer/9.0.0.4503 WMFSDK/9.0')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like 'Windows Media Player has version number', '9.0.0.4503'
 
   it "should return '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("9.0")
+    expect(@useragent.wmfsdk_version).to eq('9.0')
   end
 
-  it "should have WMFSDK9" do
-    expect(@useragent.has_wmfsdk?("9.0")).to eq(true)
+  it 'should have WMFSDK9' do
+    expect(@useragent.wmfsdk?('9.0')).to eq(true)
   end
 end
 
-describe "UserAgent: Windows-Media-Player/9.00.00.4503" do
+describe 'UserAgent: Windows-Media-Player/9.00.00.4503' do
   before do
-    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.4503")
+    @useragent = UserAgent.parse('Windows-Media-Player/9.00.00.4503')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player has version number", "9.00.00.4503"
+  it_behaves_like 'Windows Media Player has version number', '9.00.00.4503'
 end
 
-describe "UserAgent: NSPlayer/10.0.0.3802" do
+describe 'UserAgent: NSPlayer/10.0.0.3802' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/10.0.0.3802")
+    @useragent = UserAgent.parse('NSPlayer/10.0.0.3802')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
+  it_behaves_like 'Windows Media Player has version number', '10.0.0.3802'
 end
 
-describe "UserAgent: NSPlayer/10.0.0.3802 WMFSDK/10.0" do
+describe 'UserAgent: NSPlayer/10.0.0.3802 WMFSDK/10.0' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/10.0.0.3802 WMFSDK/10.0")
+    @useragent = UserAgent.parse('NSPlayer/10.0.0.3802 WMFSDK/10.0')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like 'Windows Media Player has version number', '10.0.0.3802'
 
   it "should return '10.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("10.0")
+    expect(@useragent.wmfsdk_version).to eq('10.0')
   end
 
-  it "should have WMFSDK10" do
-    expect(@useragent.has_wmfsdk?("10.0")).to eq(true)
+  it 'should have WMFSDK10' do
+    expect(@useragent.wmfsdk?('10.0')).to eq(true)
   end
 end
 
-describe "UserAgent: Windows-Media-Player/10.00.00.3802" do
+describe 'UserAgent: Windows-Media-Player/10.00.00.3802' do
   before do
-    @useragent = UserAgent.parse("Windows-Media-Player/10.00.00.3802")
+    @useragent = UserAgent.parse('Windows-Media-Player/10.00.00.3802')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player has version number", "10.00.00.3802"
+  it_behaves_like 'Windows Media Player has version number', '10.00.00.3802'
 end
 
-describe "UserAgent: NSPlayer/11.0.5721.5262" do
+describe 'UserAgent: NSPlayer/11.0.5721.5262' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/11.0.5721.5262")
+    @useragent = UserAgent.parse('NSPlayer/11.0.5721.5262')
   end
 
-  it_behaves_like "Windows Media Player"
+  it_behaves_like 'Windows Media Player'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like 'Windows Media Player has version number', '11.0.5721.5262'
 end
 
-describe "UserAgent: NSPlayer/11.0.5721.5262 WMFSDK/11.0" do
+describe 'UserAgent: NSPlayer/11.0.5721.5262 WMFSDK/11.0' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/11.0.5721.5262 WMFSDK/11.0")
+    @useragent = UserAgent.parse('NSPlayer/11.0.5721.5262 WMFSDK/11.0')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like 'Windows Media Player has version number', '11.0.5721.5262'
 
   it "should return '11.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("11.0")
+    expect(@useragent.wmfsdk_version).to eq('11.0')
   end
 
-  it "should have WMFSDK11" do
-    expect(@useragent.has_wmfsdk?("11.0")).to eq(true)
+  it 'should have WMFSDK11' do
+    expect(@useragent.wmfsdk?('11.0')).to eq(true)
   end
 end
 
-describe "UserAgent: Windows-Media-Player/11.0.5721.5262" do
+describe 'UserAgent: Windows-Media-Player/11.0.5721.5262' do
   before do
-    @useragent = UserAgent.parse("Windows-Media-Player/11.0.5721.5262")
+    @useragent = UserAgent.parse('Windows-Media-Player/11.0.5721.5262')
   end
 
-  it_behaves_like "Windows Media Player"
+  it_behaves_like 'Windows Media Player'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
+  it_behaves_like 'Windows Media Player runs on', 'Windows XP'
+  it_behaves_like 'Windows Media Player has version number', '11.0.5721.5262'
 end
 
-describe "UserAgent: NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392" do
+describe 'UserAgent: NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392")
+    @useragent = UserAgent.parse('NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows Vista"
-  it_behaves_like "Windows Media Player has version number", "11.00.6002.18392"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows Vista'
+  it_behaves_like 'Windows Media Player has version number', '11.00.6002.18392'
 
   it "should return '11.00.6002.18392' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("11.00.6002.18392")
+    expect(@useragent.wmfsdk_version).to eq('11.00.6002.18392')
   end
 
-  it "should have WMFSDK11" do
-    expect(@useragent.has_wmfsdk?("11.0")).to eq(true)
+  it 'should have WMFSDK11' do
+    expect(@useragent.wmfsdk?('11.0')).to eq(true)
   end
 end
 
-describe "UserAgent: NSPlayer/11.0.6002.18005" do
+describe 'UserAgent: NSPlayer/11.0.6002.18005' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/11.0.6002.18005")
+    @useragent = UserAgent.parse('NSPlayer/11.0.6002.18005')
   end
 
-  it_behaves_like "Windows Media Player"
+  it_behaves_like 'Windows Media Player'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows Vista"
-  it_behaves_like "Windows Media Player has version number", "11.0.6002.18005"
+  it_behaves_like 'Windows Media Player runs on', 'Windows Vista'
+  it_behaves_like 'Windows Media Player has version number', '11.0.6002.18005'
 end
 
-describe "UserAgent: NSPlayer/11.0.6002.18049 WMFSDK/11.0" do
+describe 'UserAgent: NSPlayer/11.0.6002.18049 WMFSDK/11.0' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/11.0.6002.18049 WMFSDK/11.0")
+    @useragent = UserAgent.parse('NSPlayer/11.0.6002.18049 WMFSDK/11.0')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows Vista"
-  it_behaves_like "Windows Media Player has version number", "11.0.6002.18049"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows Vista'
+  it_behaves_like 'Windows Media Player has version number', '11.0.6002.18049'
 
   it "should return '11.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("11.0")
+    expect(@useragent.wmfsdk_version).to eq('11.0')
   end
 
-  it "should have WMFSDK11" do
-    expect(@useragent.has_wmfsdk?("11.0")).to eq(true)
+  it 'should have WMFSDK11' do
+    expect(@useragent.wmfsdk?('11.0')).to eq(true)
   end
 end
 
-describe "UserAgent: Windows-Media-Player/11.0.6002.18311" do
+describe 'UserAgent: Windows-Media-Player/11.0.6002.18311' do
   before do
-    @useragent = UserAgent.parse("Windows-Media-Player/11.0.6002.18311")
+    @useragent = UserAgent.parse('Windows-Media-Player/11.0.6002.18311')
   end
 
-  it_behaves_like "Windows Media Player"
+  it_behaves_like 'Windows Media Player'
   it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows Vista"
-  it_behaves_like "Windows Media Player has version number", "11.0.6002.18311"
+  it_behaves_like 'Windows Media Player runs on', 'Windows Vista'
+  it_behaves_like 'Windows Media Player has version number', '11.0.6002.18311'
 end
 
 # FIXME: User agents for Windows 7 and Windows 8
 
-describe "UserAgent: NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031" do
+describe 'UserAgent: NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031")
+    @useragent = UserAgent.parse('NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 8.1"
-  it_behaves_like "Windows Media Player has version number", "12.00.9600.17031"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows 8.1'
+  it_behaves_like 'Windows Media Player has version number', '12.00.9600.17031'
 
   it "should return '12.00.9600.17031' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("12.00.9600.17031")
+    expect(@useragent.wmfsdk_version).to eq('12.00.9600.17031')
   end
 
-  it "should have WMFSDK12" do
-    expect(@useragent.has_wmfsdk?("12.0")).to eq(true)
+  it 'should have WMFSDK12' do
+    expect(@useragent.wmfsdk?('12.0')).to eq(true)
   end
 end
 
-describe "UserAgent: Windows-Media-Player/12.0.9841.0" do
+describe 'UserAgent: Windows-Media-Player/12.0.9841.0' do
   before do
-    @useragent = UserAgent.parse("Windows-Media-Player/12.0.9841.0")
+    @useragent = UserAgent.parse('Windows-Media-Player/12.0.9841.0')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 10"
-  it_behaves_like "Windows Media Player has version number", "12.0.9841.0"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows 10'
+  it_behaves_like 'Windows Media Player has version number', '12.0.9841.0'
 end
 
-describe "UserAgent: NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000" do
+describe 'UserAgent: NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000")
+    @useragent = UserAgent.parse('NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000')
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 10"
-  it_behaves_like "Windows Media Player has version number", "12.00.9841.0000"
+  it_behaves_like 'Windows Media Player'
+  it_behaves_like 'Windows Media Player runs on', 'Windows 10'
+  it_behaves_like 'Windows Media Player has version number', '12.00.9841.0000'
 
   it "should return '12.00.9841.0000' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("12.00.9841.0000")
+    expect(@useragent.wmfsdk_version).to eq('12.00.9841.0000')
   end
 
-  it "should have WMFSDK12" do
-    expect(@useragent.has_wmfsdk?("12.0")).to eq(true)
+  it 'should have WMFSDK12' do
+    expect(@useragent.wmfsdk?('12.0')).to eq(true)
   end
 end
 
-describe "UserAgent: NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000" do
+describe 'UserAgent: NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000' do
   before do
-    @useragent = UserAgent.parse("NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000")
+    @useragent = UserAgent.parse('NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000')
   end
 
-  it_behaves_like "Windows Media Player Mobile"
-  it_behaves_like "Windows Media Player runs on", "Windows Phone 8.1"
-  it_behaves_like "Windows Media Player has version number", "12.00.9651.0000"
+  it_behaves_like 'Windows Media Player Mobile'
+  it_behaves_like 'Windows Media Player runs on', 'Windows Phone 8.1'
+  it_behaves_like 'Windows Media Player has version number', '12.00.9651.0000'
 
   it "should return '12.00.9651.0000' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("12.00.9651.0000")
+    expect(@useragent.wmfsdk_version).to eq('12.00.9651.0000')
   end
 
-  it "should have WMFSDK12" do
-    expect(@useragent.has_wmfsdk?("12.0")).to eq(true)
+  it 'should have WMFSDK12' do
+    expect(@useragent.wmfsdk?('12.0')).to eq(true)
   end
 end

--- a/spec/browsers/windows_media_player_user_agent_spec.rb
+++ b/spec/browsers/windows_media_player_user_agent_spec.rb
@@ -2,73 +2,73 @@ require "spec_helper"
 require "user_agent"
 
 shared_examples "Windows Media Player" do
-  it "should return 'Windows Media Player' as its browser" do
+  it "returns 'Windows Media Player' as its browser" do
     expect(@useragent.browser).to eq("Windows Media Player")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should not identify as being classic" do
+  it "does not identify as being classic" do
     expect(@useragent.classic?).to eq(false)
   end
 
-  it "should be the desktop version" do
+  it "is the desktop version" do
     expect(@useragent.mobile?).to eq(false)
   end
 end
 
 shared_examples "Windows Media Player Mobile" do
-  it "should return 'Windows Media Player' as its browser" do
+  it "returns 'Windows Media Player' as its browser" do
     expect(@useragent.browser).to eq("Windows Media Player")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should not identify as being classic" do
+  it "does not identify as being classic" do
     expect(@useragent.classic?).to eq(false)
   end
 
-  it "should be the desktop version" do
+  it "is the desktop version" do
     expect(@useragent.mobile?).to eq(true)
   end
 end
 
 shared_examples "Windows Media Player Classic" do
-  it "should return 'Windows Media Player' as its browser" do
+  it "returns 'Windows Media Player' as its browser" do
     expect(@useragent.browser).to eq("Windows Media Player")
   end
 
-  it "should return 'Windows' as its platform" do
+  it "returns 'Windows' as its platform" do
     expect(@useragent.platform).to eq("Windows")
   end
 
-  it "should identify as being classic" do
+  it "identifies as being classic" do
     expect(@useragent.classic?).to eq(true)
   end
 end
 
 shared_examples "Windows Media Player isn't using WMFSDK" do
-  it "should return nil as its WMFSDK version" do
+  it "returns nil as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to be_nil
   end
 
-  it "should not have WMFSDK9" do
+  it "does not have WMFSDK9" do
     expect(@useragent.wmfsdk?("9")).to eq(false)
   end
 
-  it "should not have WMFSDK10" do
+  it "does not have WMFSDK10" do
     expect(@useragent.wmfsdk?("10")).to eq(false)
   end
 
-  it "should not have WMFSDK11" do
+  it "does not have WMFSDK11" do
     expect(@useragent.wmfsdk?("11")).to eq(false)
   end
 
-  it "should not have WMFSDK12" do
+  it "does not have WMFSDK12" do
     expect(@useragent.wmfsdk?("12")).to eq(false)
   end
 end
@@ -91,11 +91,11 @@ end
       @useragent = UserAgent.parse("NSPlayer/#{not_wmp}")
     end
 
-    it "should not return 'Windows Media Player' as its browser" do
+    it "does not return 'Windows Media Player' as its browser" do
       expect(@useragent.browser).not_to eq("Windows Media Player")
     end
 
-    it "should not return 'Windows' as its platform" do
+    it "does not return 'Windows' as its platform" do
       expect(@useragent.platform).not_to eq("Windows")
     end
   end
@@ -160,11 +160,11 @@ describe "UserAgent: NSPlayer/9.0.0.2980 WMFSDK/9.0" do
   it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
   it_behaves_like "Windows Media Player has version number", "9.0.0.2980"
 
-  it "should return '9.0' as its WMFSDK version" do
+  it "returns '9.0' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("9.0")
   end
 
-  it "should have WMFSDK9" do
+  it "has WMFSDK9" do
     expect(@useragent.wmfsdk?("9.0")).to eq(true)
   end
 end
@@ -200,11 +200,11 @@ describe "UserAgent: NSPlayer/9.0.0.3268 WMFSDK/9.0" do
   it_behaves_like "Windows Media Player runs on", "Windows 2000"
   it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
 
-  it "should return '9.0' as its WMFSDK version" do
+  it "returns '9.0' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("9.0")
   end
 
-  it "should have WMFSDK9" do
+  it "has WMFSDK9" do
     expect(@useragent.wmfsdk?("9.0")).to eq(true)
   end
 end
@@ -218,11 +218,11 @@ describe "UserAgent: NSPlayer/9.0.0.3270 WMFSDK/9.0" do
   it_behaves_like "Windows Media Player runs on", "Windows 2000"
   it_behaves_like "Windows Media Player has version number", "9.0.0.3270"
 
-  it "should return '9.0' as its WMFSDK version" do
+  it "returns '9.0' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("9.0")
   end
 
-  it "should have WMFSDK9" do
+  it "has WMFSDK9" do
     expect(@useragent.wmfsdk?("9.0")).to eq(true)
   end
 end
@@ -269,11 +269,11 @@ describe "UserAgent: NSPlayer/9.0.0.4503 WMFSDK/9.0" do
   it_behaves_like "Windows Media Player runs on", "Windows XP"
   it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
 
-  it "should return '9.0' as its WMFSDK version" do
+  it "returns '9.0' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("9.0")
   end
 
-  it "should have WMFSDK9" do
+  it "has WMFSDK9" do
     expect(@useragent.wmfsdk?("9.0")).to eq(true)
   end
 end
@@ -309,11 +309,11 @@ describe "UserAgent: NSPlayer/10.0.0.3802 WMFSDK/10.0" do
   it_behaves_like "Windows Media Player runs on", "Windows XP"
   it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
 
-  it "should return '10.0' as its WMFSDK version" do
+  it "returns '10.0' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("10.0")
   end
 
-  it "should have WMFSDK10" do
+  it "has WMFSDK10" do
     expect(@useragent.wmfsdk?("10.0")).to eq(true)
   end
 end
@@ -349,11 +349,11 @@ describe "UserAgent: NSPlayer/11.0.5721.5262 WMFSDK/11.0" do
   it_behaves_like "Windows Media Player runs on", "Windows XP"
   it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
 
-  it "should return '11.0' as its WMFSDK version" do
+  it "returns '11.0' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("11.0")
   end
 
-  it "should have WMFSDK11" do
+  it "has WMFSDK11" do
     expect(@useragent.wmfsdk?("11.0")).to eq(true)
   end
 end
@@ -378,11 +378,11 @@ describe "UserAgent: NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392" do
   it_behaves_like "Windows Media Player runs on", "Windows Vista"
   it_behaves_like "Windows Media Player has version number", "11.00.6002.18392"
 
-  it "should return '11.00.6002.18392' as its WMFSDK version" do
+  it "returns '11.00.6002.18392' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("11.00.6002.18392")
   end
 
-  it "should have WMFSDK11" do
+  it "has WMFSDK11" do
     expect(@useragent.wmfsdk?("11.0")).to eq(true)
   end
 end
@@ -407,11 +407,11 @@ describe "UserAgent: NSPlayer/11.0.6002.18049 WMFSDK/11.0" do
   it_behaves_like "Windows Media Player runs on", "Windows Vista"
   it_behaves_like "Windows Media Player has version number", "11.0.6002.18049"
 
-  it "should return '11.0' as its WMFSDK version" do
+  it "returns '11.0' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("11.0")
   end
 
-  it "should have WMFSDK11" do
+  it "has WMFSDK11" do
     expect(@useragent.wmfsdk?("11.0")).to eq(true)
   end
 end
@@ -438,11 +438,11 @@ describe "UserAgent: NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031" do
   it_behaves_like "Windows Media Player runs on", "Windows 8.1"
   it_behaves_like "Windows Media Player has version number", "12.00.9600.17031"
 
-  it "should return '12.00.9600.17031' as its WMFSDK version" do
+  it "returns '12.00.9600.17031' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("12.00.9600.17031")
   end
 
-  it "should have WMFSDK12" do
+  it "has WMFSDK12" do
     expect(@useragent.wmfsdk?("12.0")).to eq(true)
   end
 end
@@ -466,11 +466,11 @@ describe "UserAgent: NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000" do
   it_behaves_like "Windows Media Player runs on", "Windows 10"
   it_behaves_like "Windows Media Player has version number", "12.00.9841.0000"
 
-  it "should return '12.00.9841.0000' as its WMFSDK version" do
+  it "returns '12.00.9841.0000' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("12.00.9841.0000")
   end
 
-  it "should have WMFSDK12" do
+  it "has WMFSDK12" do
     expect(@useragent.wmfsdk?("12.0")).to eq(true)
   end
 end
@@ -484,11 +484,11 @@ describe "UserAgent: NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000" do
   it_behaves_like "Windows Media Player runs on", "Windows Phone 8.1"
   it_behaves_like "Windows Media Player has version number", "12.00.9651.0000"
 
-  it "should return '12.00.9651.0000' as its WMFSDK version" do
+  it "returns '12.00.9651.0000' as its WMFSDK version" do
     expect(@useragent.wmfsdk_version).to eq("12.00.9651.0000")
   end
 
-  it "should have WMFSDK12" do
+  it "has WMFSDK12" do
     expect(@useragent.wmfsdk?("12.0")).to eq(true)
   end
 end

--- a/spec/browsers/windows_media_player_user_agent_spec.rb
+++ b/spec/browsers/windows_media_player_user_agent_spec.rb
@@ -3,492 +3,436 @@ require "user_agent"
 
 shared_examples "Windows Media Player" do
   it "returns 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq("Windows Media Player")
+    expect(useragent.browser).to eq("Windows Media Player")
   end
 
   it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(useragent.platform).to eq("Windows")
   end
 
   it "does not identify as being classic" do
-    expect(@useragent.classic?).to eq(false)
+    expect(useragent.classic?).to eq(false)
   end
 
   it "is the desktop version" do
-    expect(@useragent.mobile?).to eq(false)
+    expect(useragent.mobile?).to eq(false)
   end
 end
 
 shared_examples "Windows Media Player Mobile" do
   it "returns 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq("Windows Media Player")
+    expect(useragent.browser).to eq("Windows Media Player")
   end
 
   it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(useragent.platform).to eq("Windows")
   end
 
   it "does not identify as being classic" do
-    expect(@useragent.classic?).to eq(false)
+    expect(useragent.classic?).to eq(false)
   end
 
   it "is the desktop version" do
-    expect(@useragent.mobile?).to eq(true)
+    expect(useragent.mobile?).to eq(true)
   end
 end
 
 shared_examples "Windows Media Player Classic" do
   it "returns 'Windows Media Player' as its browser" do
-    expect(@useragent.browser).to eq("Windows Media Player")
+    expect(useragent.browser).to eq("Windows Media Player")
   end
 
   it "returns 'Windows' as its platform" do
-    expect(@useragent.platform).to eq("Windows")
+    expect(useragent.platform).to eq("Windows")
   end
 
   it "identifies as being classic" do
-    expect(@useragent.classic?).to eq(true)
+    expect(useragent.classic?).to eq(true)
   end
 end
 
 shared_examples "Windows Media Player isn't using WMFSDK" do
   it "returns nil as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to be_nil
+    expect(useragent.wmfsdk_version).to be_nil
   end
 
   it "does not have WMFSDK9" do
-    expect(@useragent.wmfsdk?("9")).to eq(false)
+    expect(useragent.wmfsdk?("9")).to eq(false)
   end
 
   it "does not have WMFSDK10" do
-    expect(@useragent.wmfsdk?("10")).to eq(false)
+    expect(useragent.wmfsdk?("10")).to eq(false)
   end
 
   it "does not have WMFSDK11" do
-    expect(@useragent.wmfsdk?("11")).to eq(false)
+    expect(useragent.wmfsdk?("11")).to eq(false)
   end
 
   it "does not have WMFSDK12" do
-    expect(@useragent.wmfsdk?("12")).to eq(false)
+    expect(useragent.wmfsdk?("12")).to eq(false)
   end
 end
 
 shared_examples "Windows Media Player runs on" do |os|
   it "should return '#{os}' as its OS" do
-    expect(@useragent.os).to eq(os)
+    expect(useragent.os).to eq(os)
   end
 end
 
 shared_examples "Windows Media Player has version number" do |version|
   it "should return '#{version}' as its version" do
-    expect(@useragent.version).to eq(version)
+    expect(useragent.version).to eq(version)
   end
 end
 
-%w[4.1.0.3856 7.10.0.3059 7.0.0.1956].each do |not_wmp|
-  describe "UserAgent: NSPlayer/#{not_wmp}" do
-    before do
-      @useragent = UserAgent.parse("NSPlayer/#{not_wmp}")
-    end
+describe UserAgent do
+  %w[4.1.0.3856 7.10.0.3059 7.0.0.1956].each do |not_wmp|
+    context do
+      let(:useragent) { described_class.parse("NSPlayer/#{not_wmp}") }
 
-    it "does not return 'Windows Media Player' as its browser" do
-      expect(@useragent.browser).not_to eq("Windows Media Player")
-    end
+      it "does not return 'Windows Media Player' as its browser" do
+        expect(useragent.browser).not_to eq("Windows Media Player")
+      end
 
-    it "does not return 'Windows' as its platform" do
-      expect(@useragent.platform).not_to eq("Windows")
+      it "does not return 'Windows' as its platform" do
+        expect(useragent.platform).not_to eq("Windows")
+      end
     end
   end
-end
 
-%w[4.1.0.3857].each do |win9x_wmp6|
-  describe "UserAgent: NSPlayer/#{win9x_wmp6}" do
-    before do
-      @useragent = UserAgent.parse("NSPlayer/#{win9x_wmp6}")
+  %w[4.1.0.3857].each do |win9x_wmp6|
+    context do
+      let(:useragent) { described_class.parse("NSPlayer/#{win9x_wmp6}") }
+
+      it_behaves_like "Windows Media Player Classic"
+      it_behaves_like "Windows Media Player isn't using WMFSDK"
+      it_behaves_like "Windows Media Player runs on", "Windows 9x"
+      it_behaves_like "Windows Media Player has version number", win9x_wmp6
     end
-
-    it_behaves_like "Windows Media Player Classic"
-    it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like "Windows Media Player runs on", "Windows 9x"
-    it_behaves_like "Windows Media Player has version number", win9x_wmp6
   end
-end
 
-%w[3.2.0.3564 4.1.0.3925].each do |win98_wmp6|
-  describe "UserAgent: NSPlayer/#{win98_wmp6}" do
-    before do
-      @useragent = UserAgent.parse("NSPlayer/#{win98_wmp6}")
+  %w[3.2.0.3564 4.1.0.3925].each do |win98_wmp6|
+    context do
+      let(:useragent) { described_class.parse("NSPlayer/#{win98_wmp6}") }
+
+      it_behaves_like "Windows Media Player Classic"
+      it_behaves_like "Windows Media Player isn't using WMFSDK"
+      it_behaves_like "Windows Media Player runs on", "Windows 98"
+      it_behaves_like "Windows Media Player has version number", win98_wmp6
     end
-
-    it_behaves_like "Windows Media Player Classic"
-    it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like "Windows Media Player runs on", "Windows 98"
-    it_behaves_like "Windows Media Player has version number", win98_wmp6
   end
-end
 
-%w[7.1.0.3055].each do |win98_wmp71|
-  describe "UserAgent: NSPlayer/#{win98_wmp71}" do
-    before do
-      @useragent = UserAgent.parse("NSPlayer/#{win98_wmp71}")
+  %w[7.1.0.3055].each do |win98_wmp71|
+    context do
+      let(:useragent) { described_class.parse("NSPlayer/#{win98_wmp71}") }
+
+      it_behaves_like "Windows Media Player"
+      it_behaves_like "Windows Media Player isn't using WMFSDK"
+      it_behaves_like "Windows Media Player runs on", "Windows 98"
+      it_behaves_like "Windows Media Player has version number", win98_wmp71
     end
+  end
+
+  context do
+    let(:useragent) { described_class.parse("Windows-Media-Player/9.00.00.2980") }
 
     it_behaves_like "Windows Media Player"
     it_behaves_like "Windows Media Player isn't using WMFSDK"
-    it_behaves_like "Windows Media Player runs on", "Windows 98"
-    it_behaves_like "Windows Media Player has version number", win98_wmp71
-  end
-end
-
-describe "UserAgent: Windows-Media-Player/9.00.00.2980" do
-  before do
-    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.2980")
+    it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
+    it_behaves_like "Windows Media Player has version number", "9.00.00.2980"
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
-  it_behaves_like "Windows Media Player has version number", "9.00.00.2980"
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/9.0.0.2980 WMFSDK/9.0") }
 
-describe "UserAgent: NSPlayer/9.0.0.2980 WMFSDK/9.0" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.2980 WMFSDK/9.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
+    it_behaves_like "Windows Media Player has version number", "9.0.0.2980"
+
+    it "returns '9.0' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("9.0")
+    end
+
+    it "has WMFSDK9" do
+      expect(useragent.wmfsdk?("9.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 98/2000"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.2980"
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/4.1.0.3938") }
 
-  it "returns '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("9.0")
+    it_behaves_like "Windows Media Player Classic"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows 2000"
+    it_behaves_like "Windows Media Player has version number", "4.1.0.3938"
   end
 
-  it "has WMFSDK9" do
-    expect(@useragent.wmfsdk?("9.0")).to eq(true)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/9.0.0.3268") }
 
-describe "UserAgent: NSPlayer/4.1.0.3938" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/4.1.0.3938")
-  end
-
-  it_behaves_like "Windows Media Player Classic"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "4.1.0.3938"
-end
-
-describe "UserAgent: NSPlayer/9.0.0.3268" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.3268")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows 2000"
+    it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/9.0.0.3268 WMFSDK/9.0") }
 
-describe "UserAgent: NSPlayer/9.0.0.3268 WMFSDK/9.0" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.3268 WMFSDK/9.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows 2000"
+    it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
+
+    it "returns '9.0' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("9.0")
+    end
+
+    it "has WMFSDK9" do
+      expect(useragent.wmfsdk?("9.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.3268"
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/9.0.0.3270 WMFSDK/9.0") }
 
-  it "returns '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("9.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows 2000"
+    it_behaves_like "Windows Media Player has version number", "9.0.0.3270"
+
+    it "returns '9.0' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("9.0")
+    end
+
+    it "has WMFSDK9" do
+      expect(useragent.wmfsdk?("9.0")).to eq(true)
+    end
   end
 
-  it "has WMFSDK9" do
-    expect(@useragent.wmfsdk?("9.0")).to eq(true)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("Windows-Media-Player/9.00.00.3367") }
 
-describe "UserAgent: NSPlayer/9.0.0.3270 WMFSDK/9.0" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.3270 WMFSDK/9.0")
-  end
-
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.3270"
-
-  it "returns '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("9.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows 2000"
+    it_behaves_like "Windows Media Player has version number", "9.00.00.3367"
   end
 
-  it "has WMFSDK9" do
-    expect(@useragent.wmfsdk?("9.0")).to eq(true)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/4.1.0.3936") }
 
-describe "UserAgent: Windows-Media-Player/9.00.00.3367" do
-  before do
-    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.3367")
-  end
-
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows 2000"
-  it_behaves_like "Windows Media Player has version number", "9.00.00.3367"
-end
-
-describe "UserAgent: NSPlayer/4.1.0.3936" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/4.1.0.3936")
+    it_behaves_like "Windows Media Player Classic"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player has version number", "4.1.0.3936"
   end
 
-  it_behaves_like "Windows Media Player Classic"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "4.1.0.3936"
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/9.0.0.4503") }
 
-describe "UserAgent: NSPlayer/9.0.0.4503" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.4503")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/9.0.0.4503 WMFSDK/9.0") }
 
-describe "UserAgent: NSPlayer/9.0.0.4503 WMFSDK/9.0" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/9.0.0.4503 WMFSDK/9.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
+
+    it "returns '9.0' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("9.0")
+    end
+
+    it "has WMFSDK9" do
+      expect(useragent.wmfsdk?("9.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "9.0.0.4503"
+  context do
+    let(:useragent) { described_class.parse("Windows-Media-Player/9.00.00.4503") }
 
-  it "returns '9.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("9.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player has version number", "9.00.00.4503"
   end
 
-  it "has WMFSDK9" do
-    expect(@useragent.wmfsdk?("9.0")).to eq(true)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/10.0.0.3802") }
 
-describe "UserAgent: Windows-Media-Player/9.00.00.4503" do
-  before do
-    @useragent = UserAgent.parse("Windows-Media-Player/9.00.00.4503")
-  end
-
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player has version number", "9.00.00.4503"
-end
-
-describe "UserAgent: NSPlayer/10.0.0.3802" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/10.0.0.3802")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/10.0.0.3802 WMFSDK/10.0") }
 
-describe "UserAgent: NSPlayer/10.0.0.3802 WMFSDK/10.0" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/10.0.0.3802 WMFSDK/10.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
+
+    it "returns '10.0' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("10.0")
+    end
+
+    it "has WMFSDK10" do
+      expect(useragent.wmfsdk?("10.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "10.0.0.3802"
+  context do
+    let(:useragent) { described_class.parse("Windows-Media-Player/10.00.00.3802") }
 
-  it "returns '10.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("10.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player has version number", "10.00.00.3802"
   end
 
-  it "has WMFSDK10" do
-    expect(@useragent.wmfsdk?("10.0")).to eq(true)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/11.0.5721.5262") }
 
-describe "UserAgent: Windows-Media-Player/10.00.00.3802" do
-  before do
-    @useragent = UserAgent.parse("Windows-Media-Player/10.00.00.3802")
-  end
-
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player has version number", "10.00.00.3802"
-end
-
-describe "UserAgent: NSPlayer/11.0.5721.5262" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/11.0.5721.5262")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/11.0.5721.5262 WMFSDK/11.0") }
 
-describe "UserAgent: NSPlayer/11.0.5721.5262 WMFSDK/11.0" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/11.0.5721.5262 WMFSDK/11.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
+
+    it "returns '11.0' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("11.0")
+    end
+
+    it "has WMFSDK11" do
+      expect(useragent.wmfsdk?("11.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
+  context do
+    let(:useragent) { described_class.parse("Windows-Media-Player/11.0.5721.5262") }
 
-  it "returns '11.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("11.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows XP"
+    it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
   end
 
-  it "has WMFSDK11" do
-    expect(@useragent.wmfsdk?("11.0")).to eq(true)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392") }
 
-describe "UserAgent: Windows-Media-Player/11.0.5721.5262" do
-  before do
-    @useragent = UserAgent.parse("Windows-Media-Player/11.0.5721.5262")
-  end
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows Vista"
+    it_behaves_like "Windows Media Player has version number", "11.00.6002.18392"
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows XP"
-  it_behaves_like "Windows Media Player has version number", "11.0.5721.5262"
-end
+    it "returns '11.00.6002.18392' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("11.00.6002.18392")
+    end
 
-describe "UserAgent: NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/11.00.6002.18392 WMFSDK/11.00.6002.18392")
+    it "has WMFSDK11" do
+      expect(useragent.wmfsdk?("11.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows Vista"
-  it_behaves_like "Windows Media Player has version number", "11.00.6002.18392"
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/11.0.6002.18005") }
 
-  it "returns '11.00.6002.18392' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("11.00.6002.18392")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows Vista"
+    it_behaves_like "Windows Media Player has version number", "11.0.6002.18005"
   end
 
-  it "has WMFSDK11" do
-    expect(@useragent.wmfsdk?("11.0")).to eq(true)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/11.0.6002.18049 WMFSDK/11.0") }
 
-describe "UserAgent: NSPlayer/11.0.6002.18005" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/11.0.6002.18005")
-  end
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows Vista"
+    it_behaves_like "Windows Media Player has version number", "11.0.6002.18049"
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows Vista"
-  it_behaves_like "Windows Media Player has version number", "11.0.6002.18005"
-end
+    it "returns '11.0' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("11.0")
+    end
 
-describe "UserAgent: NSPlayer/11.0.6002.18049 WMFSDK/11.0" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/11.0.6002.18049 WMFSDK/11.0")
+    it "has WMFSDK11" do
+      expect(useragent.wmfsdk?("11.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows Vista"
-  it_behaves_like "Windows Media Player has version number", "11.0.6002.18049"
+  context do
+    let(:useragent) { described_class.parse("Windows-Media-Player/11.0.6002.18311") }
 
-  it "returns '11.0' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("11.0")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player isn't using WMFSDK"
+    it_behaves_like "Windows Media Player runs on", "Windows Vista"
+    it_behaves_like "Windows Media Player has version number", "11.0.6002.18311"
   end
 
-  it "has WMFSDK11" do
-    expect(@useragent.wmfsdk?("11.0")).to eq(true)
-  end
-end
+  # FIXME: User agents for Windows 7 and Windows 8
 
-describe "UserAgent: Windows-Media-Player/11.0.6002.18311" do
-  before do
-    @useragent = UserAgent.parse("Windows-Media-Player/11.0.6002.18311")
-  end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031") }
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player isn't using WMFSDK"
-  it_behaves_like "Windows Media Player runs on", "Windows Vista"
-  it_behaves_like "Windows Media Player has version number", "11.0.6002.18311"
-end
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows 8.1"
+    it_behaves_like "Windows Media Player has version number", "12.00.9600.17031"
 
-# FIXME: User agents for Windows 7 and Windows 8
+    it "returns '12.00.9600.17031' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("12.00.9600.17031")
+    end
 
-describe "UserAgent: NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/12.00.9600.17031 WMFSDK/12.00.9600.17031")
+    it "has WMFSDK12" do
+      expect(useragent.wmfsdk?("12.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 8.1"
-  it_behaves_like "Windows Media Player has version number", "12.00.9600.17031"
+  context do
+    let(:useragent) { described_class.parse("Windows-Media-Player/12.0.9841.0") }
 
-  it "returns '12.00.9600.17031' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("12.00.9600.17031")
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows 10"
+    it_behaves_like "Windows Media Player has version number", "12.0.9841.0"
   end
 
-  it "has WMFSDK12" do
-    expect(@useragent.wmfsdk?("12.0")).to eq(true)
-  end
-end
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000") }
 
-describe "UserAgent: Windows-Media-Player/12.0.9841.0" do
-  before do
-    @useragent = UserAgent.parse("Windows-Media-Player/12.0.9841.0")
-  end
+    it_behaves_like "Windows Media Player"
+    it_behaves_like "Windows Media Player runs on", "Windows 10"
+    it_behaves_like "Windows Media Player has version number", "12.00.9841.0000"
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 10"
-  it_behaves_like "Windows Media Player has version number", "12.0.9841.0"
-end
+    it "returns '12.00.9841.0000' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("12.00.9841.0000")
+    end
 
-describe "UserAgent: NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/12.00.9841.0000 WMFSDK/12.00.9841.0000")
+    it "has WMFSDK12" do
+      expect(useragent.wmfsdk?("12.0")).to eq(true)
+    end
   end
 
-  it_behaves_like "Windows Media Player"
-  it_behaves_like "Windows Media Player runs on", "Windows 10"
-  it_behaves_like "Windows Media Player has version number", "12.00.9841.0000"
+  context do
+    let(:useragent) { described_class.parse("NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000") }
 
-  it "returns '12.00.9841.0000' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("12.00.9841.0000")
-  end
+    it_behaves_like "Windows Media Player Mobile"
+    it_behaves_like "Windows Media Player runs on", "Windows Phone 8.1"
+    it_behaves_like "Windows Media Player has version number", "12.00.9651.0000"
 
-  it "has WMFSDK12" do
-    expect(@useragent.wmfsdk?("12.0")).to eq(true)
-  end
-end
+    it "returns '12.00.9651.0000' as its WMFSDK version" do
+      expect(useragent.wmfsdk_version).to eq("12.00.9651.0000")
+    end
 
-describe "UserAgent: NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000" do
-  before do
-    @useragent = UserAgent.parse("NSPlayer/12.00.9651.0000 WMFSDK/12.00.9651.0000")
-  end
-
-  it_behaves_like "Windows Media Player Mobile"
-  it_behaves_like "Windows Media Player runs on", "Windows Phone 8.1"
-  it_behaves_like "Windows Media Player has version number", "12.00.9651.0000"
-
-  it "returns '12.00.9651.0000' as its WMFSDK version" do
-    expect(@useragent.wmfsdk_version).to eq("12.00.9651.0000")
-  end
-
-  it "has WMFSDK12" do
-    expect(@useragent.wmfsdk?("12.0")).to eq(true)
+    it "has WMFSDK12" do
+      expect(useragent.wmfsdk?("12.0")).to eq(true)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'simplecov'
+SimpleCov.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
-require 'simplecov'
+require "simplecov"
 SimpleCov.start

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -3,7 +3,7 @@ require "user_agent"
 require "ostruct"
 
 describe UserAgent do
-  it "warns about deprecation" do
+  it "warns about deprecation" do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
     expect { UserAgent::Browsers.Security }.to output("Security is deprecated. Please use SECURITY instead\n").to_stderr
     expect { UserAgent::Browsers.Security }.to output("").to_stderr
     expect { UserAgent::OperatingSystems.Windows }.to output("Windows is deprecated. Please use WINDOWS instead\n").to_stderr
@@ -73,11 +73,11 @@ describe UserAgent do
     expect(described_class.new("Mozilla", "5.0", ["Macintosh"])).to eql(described_class.new("Mozilla", "5.0", ["Macintosh"]))
   end
 
-  it "is not eql if both products, versions and comments are not the same" do
+  it "is not eql if both oses, versions and comments are not the same" do
     expect(described_class.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(described_class.new("Mozilla", "5.0", ["Windows"]))
   end
 
-  it "is not eql if both products, versions and comments are not the same" do
+  it "is not eql if both versions, versions and comments are not the same" do
     expect(described_class.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(described_class.new("Mozilla", "4.0", ["Macintosh"]))
   end
 
@@ -156,427 +156,409 @@ describe UserAgent do
   it "is <= if products are the same and version is the same" do
     expect(described_class.new("Mozilla", "5.0")).to be <= described_class.new("Mozilla", "5.0")
   end
-end
 
-describe UserAgent, "::MATCHER" do
-  it "does not match a blank line" do
-    expect(UserAgent::MATCHER).not_to match("")
-  end
+  describe ".parse" do
+    let(:default_user_agent) { described_class.parse(UserAgent::DEFAULT_USER_AGENT) }
 
-  it "matches a single product" do
-    expect(UserAgent::MATCHER).to match("Mozilla")
-  end
-
-  it "matches a product and version" do
-    expect(UserAgent::MATCHER).to match("Mozilla/5.0")
-  end
-
-  it "matches a product, version, and comment" do
-    expect(UserAgent::MATCHER).to match("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
-  end
-
-  it "matches a product, and comment" do
-    expect(UserAgent::MATCHER).to match("Mozilla (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
-  end
-end
-
-describe UserAgent, ".parse" do
-  let(:default_user_agent) { UserAgent.parse(UserAgent::DEFAULT_USER_AGENT) }
-
-  it "concatenates user agents when coerced to a string" do
-    string = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
-    expect(string.to_str).to eq("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
-  end
-
-  it "parses a single product" do
-    useragent = UserAgent.new("Mozilla")
-    expect(UserAgent.parse("Mozilla").application).to eq(useragent)
-  end
-
-  it "parses a single product with version" do
-    useragent = UserAgent.new("Mozilla", "5.0")
-    expect(UserAgent.parse("Mozilla/5.0").application).to eq(useragent)
-  end
-
-  it "parses a single product with an empty comment" do
-    useragent = UserAgent.new("Mozilla", "5.0")
-    expect(UserAgent.parse("Mozilla/5.0 ()").application).to eq(useragent)
-  end
-
-  it "parses a single product, version, and comment" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
-    expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)").application).to eq(useragent)
-  end
-
-  it "parses a single product, version, and comment, with space-padded semicolons" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
-    expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3 ; en-us; )").application).to eq(useragent)
-  end
-
-  it "parses a user agent string with gzip(gfe) addition correctly" do
-    agent = UserAgent.parse("Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)")
-
-    expect(agent.version.to_s).to eq("35.0")
-  end
-
-  it "parses a single product and comment" do
-    useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
-    expect(UserAgent.parse("Mozilla (Macintosh)").application).to eq(useragent)
-  end
-
-  it "parses nil as the default agent" do
-    expect(UserAgent.parse(nil)).to eq(default_user_agent)
-  end
-
-  it "parses an empty string as the default agent" do
-    expect(UserAgent.parse("")).to eq(default_user_agent)
-  end
-
-  it "parses a blank string as the default agent" do
-    expect(UserAgent.parse(" ")).to eq(default_user_agent)
-  end
-
-  it "parses a double-quoted user-agent" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
-    expect(UserAgent.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0"').application).to eq(useragent)
-  end
-
-  it "parses a user-agent with leading double-quote" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
-    expect(UserAgent.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0').application).to eq(useragent)
-  end
-
-  it "parses a single-quoted user-agent" do
-    useragent = UserAgent.new("Mozilla", "5.0", nil)
-    expect(UserAgent.parse("'Mozilla/5.0'").application).to eq(useragent)
-  end
-
-  it "parses a user-agent with leading single-quote" do
-    useragent = UserAgent.new("Mozilla", "5.0", nil)
-    expect(UserAgent.parse("'Mozilla/5.0").application).to eq(useragent)
-  end
-end
-
-describe UserAgent::Browsers::Base, "#<" do
-  before do
-    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
-  end
-
-  it "is not < if user agent does not have a browser" do
-    expect(@ie7).not_to be < "Mozilla"
-  end
-
-  it "is not < if user agent does not have the same browser" do
-    expect(@ie7).not_to be < @firefox
-  end
-
-  it "is < if version is less than its version" do
-    expect(@ie6).to be < @ie7
-  end
-
-  it "is not < if version is the same as its version" do
-    expect(@ie6).not_to be < @ie6
-  end
-
-  it "is not < if version is greater than its version" do
-    expect(@ie7).not_to be < @ie6
-  end
-end
-
-describe UserAgent::Browsers::Base, "#<=" do
-  before do
-    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
-  end
-
-  it "is not <= if user agent does not have a browser" do
-    expect(@ie7).not_to be <= "Mozilla"
-  end
-
-  it "is not <= if user agent does not have the same browser" do
-    expect(@ie7).not_to be <= @firefox
-  end
-
-  it "is <= if version is less than its version" do
-    expect(@ie6).to be <= @ie7
-  end
-
-  it "is <= if version is the same as its version" do
-    expect(@ie6).to be <= @ie6
-  end
-
-  it "is not <= if version is greater than its version" do
-    expect(@ie7).not_to be <= @ie6
-  end
-end
-
-describe UserAgent::Browsers::Base, "#==" do
-  before do
-    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
-  end
-
-  it "is not == if user agent does not have a browser" do
-    expect(@ie7).not_to eq("Mozilla")
-  end
-
-  it "is not == if user agent does not have the same browser" do
-    expect(@ie7).not_to eq(@firefox)
-  end
-
-  it "is not == if version is less than its version" do
-    expect(@ie6).not_to eq(@ie7)
-  end
-
-  it "is == if version is the same as its version" do
-    expect(@ie6).to eq(@ie6)
-  end
-
-  it "is not == if version is greater than its version" do
-    expect(@ie7).not_to eq(@ie6)
-  end
-end
-
-describe UserAgent::Browsers::Base, "#>" do
-  before do
-    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
-  end
-
-  it "is not > if user agent does not have a browser" do
-    expect(@ie7).not_to be > "Mozilla"
-  end
-
-  it "is not > if user agent does not have the same browser" do
-    expect(@ie7).not_to be > @firefox
-  end
-
-  it "is not > if version is less than its version" do
-    expect(@ie6).not_to be > @ie7
-  end
-
-  it "is not > if version is the same as its version" do
-    expect(@ie6).not_to be > @ie6
-  end
-
-  it "is > if version is greater than its version" do
-    expect(@ie7).to be > @ie6
-  end
-end
-
-describe UserAgent::Browsers::Base, "#>=" do
-  before do
-    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
-  end
-
-  it "is not >= if user agent does not have a browser" do
-    expect(@ie7).not_to be >= "Mozilla"
-  end
-
-  it "is not >= if user agent does not have the same browser" do
-    expect(@ie7).not_to be >= @firefox
-  end
-
-  it "is not >= if version is less than its version" do
-    expect(@ie6).not_to be >= @ie7
-  end
-
-  it "is >= if version is the same as its version" do
-    expect(@ie6).to be >= @ie6
-  end
-
-  it "is >= if version is greater than its version" do
-    expect(@ie7).to be >= @ie6
-  end
-end
-
-describe UserAgent::Browsers::Base, "#to_h" do
-  shared_examples "Browser serializer" do |user_agent_string, expected_hash|
-    let(:useragent) do
-      UserAgent.parse(user_agent_string)
+    it "concatenates user agents when coerced to a string" do
+      string = described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
+      expect(string.to_str).to eq("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
     end
 
-    let(:actual) do
-      useragent.to_h
+    it "parses a single product" do
+      useragent = described_class.new("Mozilla")
+      expect(described_class.parse("Mozilla").application).to eq(useragent)
     end
 
-    expected_hash.each_pair do |key, value|
-      it "should serialize :#{key} as '#{value}'" do
-        expect(actual[key]).to eq(value)
+    it "parses a single product with version" do
+      useragent = described_class.new("Mozilla", "5.0")
+      expect(described_class.parse("Mozilla/5.0").application).to eq(useragent)
+    end
+
+    it "parses a single product with an empty comment" do
+      useragent = described_class.new("Mozilla", "5.0")
+      expect(described_class.parse("Mozilla/5.0 ()").application).to eq(useragent)
+    end
+
+    it "parses a single product, version, and comment" do
+      useragent = described_class.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
+      expect(described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)").application).to eq(useragent)
+    end
+
+    it "parses a single product, version, and comment, with space-padded semicolons" do
+      useragent = described_class.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
+      expect(described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3 ; en-us; )").application).to eq(useragent)
+    end
+
+    it "parses a user agent string with gzip(gfe) addition correctly" do
+      agent = described_class.parse("Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)")
+
+      expect(agent.version.to_s).to eq("35.0")
+    end
+
+    it "parses a single product and comment" do
+      useragent = described_class.new("Mozilla", nil, ["Macintosh"])
+      expect(described_class.parse("Mozilla (Macintosh)").application).to eq(useragent)
+    end
+
+    it "parses nil as the default agent" do
+      expect(described_class.parse(nil)).to eq(default_user_agent)
+    end
+
+    it "parses an empty string as the default agent" do
+      expect(described_class.parse("")).to eq(default_user_agent)
+    end
+
+    it "parses a blank string as the default agent" do
+      expect(described_class.parse(" ")).to eq(default_user_agent)
+    end
+
+    it "parses a double-quoted user-agent" do
+      useragent = described_class.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
+      expect(described_class.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0"').application).to eq(useragent)
+    end
+
+    it "parses a user-agent with leading double-quote" do
+      useragent = described_class.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
+      expect(described_class.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0').application).to eq(useragent)
+    end
+
+    it "parses a single-quoted user-agent" do
+      useragent = described_class.new("Mozilla", "5.0", nil)
+      expect(described_class.parse("'Mozilla/5.0'").application).to eq(useragent)
+    end
+
+    it "parses a user-agent with leading single-quote" do
+      useragent = described_class.new("Mozilla", "5.0", nil)
+      expect(described_class.parse("'Mozilla/5.0").application).to eq(useragent)
+    end
+  end
+
+  describe "::Browsers::Base" do
+    describe "#<" do
+      let(:ie7) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)") }
+      let(:ie6) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)") }
+      let(:firefox) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14") }
+
+      it "is not < if user agent does not have a browser" do
+        expect(ie7).not_to be < "Mozilla"
+      end
+
+      it "is not < if user agent does not have the same browser" do
+        expect(ie7).not_to be < firefox
+      end
+
+      it "is < if version is less than its version" do
+        expect(ie6).to be < ie7
+      end
+
+      it "is not < if version is the same as its version" do
+        expect(ie6).not_to be < ie6
+      end
+
+      it "is not < if version is greater than its version" do
+        expect(ie7).not_to be < ie6
       end
     end
-  end
 
-  it_behaves_like "Browser serializer",
-                  "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)",
-                  :browser => "Mozilla",
-                  :version => [5, 0],
-                  :platform => "Macintosh",
-                  :os => "OS X 10.5.3",
-                  :mobile => false,
-                  :bot => false,
-                  :comment => ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"]
+    describe "#<=" do
+      let(:ie7) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)") }
+      let(:ie6) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)") }
+      let(:firefox) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14") }
 
-  it_behaves_like "Browser serializer",
-                  "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
-                  :browser => "Mozilla",
-                  :version => [5, 0],
-                  :platform => nil,
-                  :os => "Googlebot/2.1",
-                  :mobile => false,
-                  :bot => true,
-                  :comment => ["compatible", "Googlebot/2.1", "+http://www.google.com/bot.html"]
+      it "is not <= if user agent does not have a browser" do
+        expect(ie7).not_to be <= "Mozilla"
+      end
 
-  it_behaves_like "Browser serializer",
-                  "Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25",
-                  :browser => "Chrome",
-                  :version => [28, 0, 1500, 16],
-                  :platform => "iPhone",
-                  :os => "iOS 6.1.3",
-                  :mobile => true,
-                  :bot => false,
-                  :comment => ["iPhone", "CPU iPhone OS 6_1_3 like Mac OS X"]
-end
+      it "is not <= if user agent does not have the same browser" do
+        expect(ie7).not_to be <= firefox
+      end
 
-describe UserAgent::Version do
-  it "is eql if versions are the same" do
-    expect(described_class.new("5.0")).to eql(described_class.new("5.0"))
-  end
+      it "is <= if version is less than its version" do
+        expect(ie6).to be <= ie7
+      end
 
-  it "is not eql if versions are the different" do
-    expect(described_class.new("9.0")).not_to eql(described_class.new("5.0"))
-  end
+      it "is <= if version is the same as its version" do
+        expect(ie6).to be <= ie6
+      end
 
-  it "is == if versions are the same" do
-    expect(described_class.new("5.0")).to eq(described_class.new("5.0"))
-  end
+      it "is not <= if version is greater than its version" do
+        expect(ie7).not_to be <= ie6
+      end
+    end
 
-  it "is == if versions are the same string" do
-    expect(described_class.new("5.0")).to eq("5.0")
-  end
+    describe "#==" do
+      let(:ie7) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)") }
+      let(:ie6) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)") }
+      let(:firefox) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14") }
 
-  it "is not == if versions are the different" do
-    expect(described_class.new("9.0")).not_to eq(described_class.new("5.0"))
-  end
+      it "is not == if user agent does not have a browser" do
+        expect(ie7).not_to eq("Mozilla")
+      end
 
-  it "is not == to nil" do
-    expect(described_class.new("9.0")).not_to eq(nil)
-  end
+      it "is not == if user agent does not have the same browser" do
+        expect(ie7).not_to eq(firefox)
+      end
 
-  it "is not == to []" do
-    expect(described_class.new("9.0")).not_to eq([])
-  end
+      it "is not == if version is less than its version" do
+        expect(ie6).not_to eq(ie7)
+      end
 
-  it "is < if version is less" do
-    expect(described_class.new("9.0")).to be < described_class.new("10.0")
-  end
+      it "is == if version is the same as its version" do
+        expect(ie6).to eq(ie6)
+      end
 
-  it "is < if version is less" do
-    expect(described_class.new("4")).to be < described_class.new("4.1")
-  end
+      it "is not == if version is greater than its version" do
+        expect(ie7).not_to eq(ie6)
+      end
+    end
 
-  it "is < if version is less and a string" do
-    expect(described_class.new("9.0")).to be < "10.0"
-  end
+    describe "#>" do
+      let(:ie7) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)") }
+      let(:ie6) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)") }
+      let(:firefox) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14") }
 
-  it "is not < if version is greater" do
-    expect(described_class.new("9.0")).not_to be > described_class.new("10.0")
-  end
+      it "is not > if user agent does not have a browser" do
+        expect(ie7).not_to be > "Mozilla"
+      end
 
-  it "is <= if version is less" do
-    expect(described_class.new("9.0")).to be <= described_class.new("10.0")
-  end
+      it "is not > if user agent does not have the same browser" do
+        expect(ie7).not_to be > firefox
+      end
 
-  it "is not <= if version is greater" do
-    expect(described_class.new("9.0")).not_to be >= described_class.new("10.0")
-  end
+      it "is not > if version is less than its version" do
+        expect(ie6).not_to be > ie7
+      end
 
-  it "is <= if version is same" do
-    expect(described_class.new("9.0")).to be <= described_class.new("9.0")
-  end
+      it "is not > if version is the same as its version" do
+        expect(ie6).not_to be > ie6
+      end
 
-  it "is > if version is greater" do
-    expect(described_class.new("1.0")).to be > described_class.new("0.9")
-  end
+      it "is > if version is greater than its version" do
+        expect(ie7).to be > ie6
+      end
+    end
 
-  it "is > if version is greater" do
-    expect(described_class.new("4.1")).to be > described_class.new("4")
-  end
+    describe "#>=" do
+      let(:ie7) { described_class.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)") }
+      let(:ie6) { described_class.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)") }
+      let(:firefox) { described_class.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14") }
 
-  it "is not > if version is less" do
-    expect(described_class.new("0.0.1")).not_to be > described_class.new("10.0")
-  end
+      it "is not >= if user agent does not have a browser" do
+        expect(ie7).not_to be >= "Mozilla"
+      end
 
-  it "is >= if version is greater" do
-    expect(described_class.new("10.0")).to be >= described_class.new("4.0")
-  end
+      it "is not >= if user agent does not have the same browser" do
+        expect(ie7).not_to be >= firefox
+      end
 
-  it "is not >= if version is less" do
-    expect(described_class.new("0.9")).not_to be >= described_class.new("1.0")
-  end
+      it "is not >= if version is less than its version" do
+        expect(ie6).not_to be >= ie7
+      end
 
-  it "is not > if version is invalid" do
-    expect(described_class.new("x.x")).not_to be > described_class.new("1.0")
-  end
+      it "is >= if version is the same as its version" do
+        expect(ie6).to be >= ie6
+      end
 
-  it "is < if version is invalid" do
-    expect(described_class.new("x.x")).to be < described_class.new("1.0")
-  end
+      it "is >= if version is greater than its version" do
+        expect(ie7).to be >= ie6
+      end
+    end
 
-  it "is > when compared with invalid" do
-    expect(described_class.new("1.0")).to be > described_class.new("x.x")
-  end
+    describe "#to_h" do
+      shared_examples "Browser serializer" do |user_agent_string, expected_hash|
+        let(:useragent) do
+          described_class.parse(user_agent_string)
+        end
 
-  it "is not < when compared with invalid" do
-    expect(described_class.new("1.0")).not_to be < described_class.new("x.x")
-  end
+        let(:actual) do
+          useragent.to_h
+        end
 
-  it "is not > if both versions are invalid" do
-    expect(described_class.new("a.a")).not_to be > described_class.new("b.b")
-  end
+        expected_hash.each_pair do |key, value|
+          it "should serialize :#{key} as '#{value}'" do
+            expect(actual[key]).to eq(value)
+          end
+        end
+      end
 
-  it "is < if both versions are invalid" do
-    expect(described_class.new("a.a")).to be < described_class.new("b.b")
-  end
+      it_behaves_like "Browser serializer",
+                      "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)",
+                      :browser => "Mozilla",
+                      :version => [5, 0],
+                      :platform => "Macintosh",
+                      :os => "OS X 10.5.3",
+                      :mobile => false,
+                      :bot => false,
+                      :comment => ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"]
 
-  it "is not > if version is nil" do
-    expect(described_class.new(nil)).not_to be > described_class.new("1.0")
-  end
+      it_behaves_like "Browser serializer",
+                      "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+                      :browser => "Mozilla",
+                      :version => [5, 0],
+                      :platform => nil,
+                      :os => "Googlebot/2.1",
+                      :mobile => false,
+                      :bot => true,
+                      :comment => ["compatible", "Googlebot/2.1", "+http://www.google.com/bot.html"]
 
-  it "is < if version is nil" do
-    expect(described_class.new(nil)).to be < described_class.new("1.0")
-  end
-
-  it "is not > when compared with nil" do
-    expect(described_class.new(nil)).not_to be > described_class.new(nil)
-  end
-
-  it "is not < when compared with nil" do
-    expect(described_class.new(nil)).not_to be < described_class.new(nil)
-  end
-
-  it "is not > if both versions are nil" do
-    expect(described_class.new(nil)).not_to be > described_class.new(nil)
-  end
-
-  it "is not < if both versions are nil" do
-    expect(described_class.new(nil)).not_to be < described_class.new(nil)
-  end
-
-  it "is > if version is nil" do
-    expect(described_class.new("9.0")).to be > nil
-  end
-
-  context "comparing with structs" do
-    it "is not < if products are the same and version is greater" do
-      expect(UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)")).not_to be < OpenStruct.new(:browser => "Internet Explorer", :version => "7.0")
+      it_behaves_like "Browser serializer",
+                      "Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25",
+                      :browser => "Chrome",
+                      :version => [28, 0, 1500, 16],
+                      :platform => "iPhone",
+                      :os => "iOS 6.1.3",
+                      :mobile => true,
+                      :bot => false,
+                      :comment => ["iPhone", "CPU iPhone OS 6_1_3 like Mac OS X"]
     end
   end
+
+  describe UserAgent::Version do
+    it "is eql if versions are the same" do
+      expect(described_class.new("5.0")).to eql(described_class.new("5.0"))
+    end
+
+    it "is not eql if versions are the different" do
+      expect(described_class.new("9.0")).not_to eql(described_class.new("5.0"))
+    end
+
+    it "is == if versions are the same" do
+      expect(described_class.new("5.0")).to eq(described_class.new("5.0"))
+    end
+
+    it "is == if versions are the same string" do
+      expect(described_class.new("5.0")).to eq("5.0")
+    end
+
+    it "is not == if versions are the different" do
+      expect(described_class.new("9.0")).not_to eq(described_class.new("5.0"))
+    end
+
+    it "is not == to nil" do
+      expect(described_class.new("9.0")).not_to eq(nil)
+    end
+
+    it "is not == to []" do
+      expect(described_class.new("9.0")).not_to eq([])
+    end
+
+    it "is < if major minor version is less" do
+      expect(described_class.new("9.0")).to be < described_class.new("10.0")
+    end
+
+    it "is < if major vs major minor version is less" do
+      expect(described_class.new("4")).to be < described_class.new("4.1")
+    end
+
+    it "is < if version is less and a string" do
+      expect(described_class.new("9.0")).to be < "10.0"
+    end
+
+    it "is not < if version is greater" do
+      expect(described_class.new("9.0")).not_to be > described_class.new("10.0")
+    end
+
+    it "is <= if version is less" do
+      expect(described_class.new("9.0")).to be <= described_class.new("10.0")
+    end
+
+    it "is not <= if version is greater" do
+      expect(described_class.new("9.0")).not_to be >= described_class.new("10.0")
+    end
+
+    it "is <= if version is same" do
+      expect(described_class.new("9.0")).to be <= described_class.new("9.0")
+    end
+
+    it "is > if major minor version is greater" do
+      expect(described_class.new("1.0")).to be > described_class.new("0.9")
+    end
+
+    it "is > if major minor vs major version is greater" do
+      expect(described_class.new("4.1")).to be > described_class.new("4")
+    end
+
+    it "is not > if version is less" do
+      expect(described_class.new("0.0.1")).not_to be > described_class.new("10.0")
+    end
+
+    it "is >= if version is greater" do
+      expect(described_class.new("10.0")).to be >= described_class.new("4.0")
+    end
+
+    it "is not >= if version is less" do
+      expect(described_class.new("0.9")).not_to be >= described_class.new("1.0")
+    end
+
+    it "is not > if version is invalid" do
+      expect(described_class.new("x.x")).not_to be > described_class.new("1.0")
+    end
+
+    it "is < if version is invalid" do
+      expect(described_class.new("x.x")).to be < described_class.new("1.0")
+    end
+
+    it "is > when compared with invalid" do
+      expect(described_class.new("1.0")).to be > described_class.new("x.x")
+    end
+
+    it "is not < when compared with invalid" do
+      expect(described_class.new("1.0")).not_to be < described_class.new("x.x")
+    end
+
+    it "is not > if both versions are invalid" do
+      expect(described_class.new("a.a")).not_to be > described_class.new("b.b")
+    end
+
+    it "is < if both versions are invalid" do
+      expect(described_class.new("a.a")).to be < described_class.new("b.b")
+    end
+
+    it "is not > if version is nil" do
+      expect(described_class.new(nil)).not_to be > described_class.new("1.0")
+    end
+
+    it "is < if version is nil" do
+      expect(described_class.new(nil)).to be < described_class.new("1.0")
+    end
+
+    it "is not > if both versions are nil" do
+      expect(described_class.new(nil)).not_to be > described_class.new(nil)
+    end
+
+    it "is not < if both versions are nil" do
+      expect(described_class.new(nil)).not_to be < described_class.new(nil)
+    end
+
+    it "is > if version is nil" do
+      expect(described_class.new("9.0")).to be > nil
+    end
+  end
+  context "when comparing with structs" do
+    it "is not < if products are the same and version is greater" do
+      expect(described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)")).not_to be < OpenStruct.new(:browser => "Internet Explorer", :version => "7.0")
+    end
+  end
+  # describe "::MATCHER" do
+  #  it "does not match a blank line" do
+  #    expect(described_class).not_to be_empty
+  #  end
+
+  #  it "matches a single product" do
+  #    expect(described_class).to match("Mozilla")
+  #  end
+
+  #  it "matches a product and version" do
+  #    expect(described_class).to match("Mozilla/5.0")
+  #  end
+
+  #  it "matches a product, version, and comment" do
+  #    expect(described_class).to match("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
+  #  end
+
+  #  it "matches a product, and comment" do
+  #    expect(described_class).to match("Mozilla (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
+  #  end
+  # end
 end

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -9,6 +9,7 @@ describe UserAgent do
     UserAgent::Browsers::Chrome.new.ChromeBrowsers
     UserAgent::Browsers::Gecko.new.GeckoBrowsers
     UserAgent::Browsers::Webkit.new.BuildVersions
+    UserAgent::Browsers::WindowsMediaPlayer.new.has_wmfsdk?("")
   end
 
   it "should require a product" do

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -1,385 +1,385 @@
-require 'spec_helper'
-require 'user_agent'
-require 'ostruct'
+require "spec_helper"
+require "user_agent"
+require "ostruct"
 
 describe UserAgent do
-  it 'should require a product' do
-    expect { UserAgent.new(nil) }.to raise_error(ArgumentError, 'expected a value for product')
+  it "should require a product" do
+    expect { UserAgent.new(nil) }.to raise_error(ArgumentError, "expected a value for product")
   end
 
-  it 'should split comment to an array if a string is passed in' do
-    useragent = UserAgent.new('Mozilla', '5.0', 'Macintosh; U; Intel Mac OS X 10_5_3; en-us')
-    expect(useragent.comment).to eq(['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us'])
+  it "should split comment to an array if a string is passed in" do
+    useragent = UserAgent.new("Mozilla", "5.0", "Macintosh; U; Intel Mac OS X 10_5_3; en-us")
+    expect(useragent.comment).to eq(["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
   end
 
-  it 'should set version to nil if it is blank' do
-    expect(UserAgent.new('Mozilla', '').version).to be_nil
+  it "should set version to nil if it is blank" do
+    expect(UserAgent.new("Mozilla", "").version).to be_nil
   end
 
-  it 'should only output product when coerced to a string' do
-    expect(UserAgent.new('Mozilla').to_str).to eq('Mozilla')
+  it "should only output product when coerced to a string" do
+    expect(UserAgent.new("Mozilla").to_str).to eq("Mozilla")
   end
 
-  it 'should output product and version when coerced to a string' do
-    expect(UserAgent.new('Mozilla', '5.0').to_str).to eq('Mozilla/5.0')
+  it "should output product and version when coerced to a string" do
+    expect(UserAgent.new("Mozilla", "5.0").to_str).to eq("Mozilla/5.0")
   end
 
-  it 'should output product, version and comment when coerced to a string' do
-    useragent = UserAgent.new('Mozilla', '5.0', ['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us'])
-    expect(useragent.to_str).to eq('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)')
+  it "should output product, version and comment when coerced to a string" do
+    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
+    expect(useragent.to_str).to eq("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
   end
 
-  it 'should output product and comment when coerced to a string' do
-    useragent = UserAgent.new('Mozilla', nil, ['Macintosh'])
-    expect(useragent.to_str).to eq('Mozilla (Macintosh)')
+  it "should output product and comment when coerced to a string" do
+    useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
+    expect(useragent.to_str).to eq("Mozilla (Macintosh)")
   end
 
-  it 'should be eql if both products are the same' do
-    expect(UserAgent.new('Mozilla')).to eql(UserAgent.new('Mozilla'))
+  it "should be eql if both products are the same" do
+    expect(UserAgent.new("Mozilla")).to eql(UserAgent.new("Mozilla"))
   end
 
-  it 'should not be eql if both products are the same' do
-    expect(UserAgent.new('Mozilla')).not_to eql(UserAgent.new('Opera'))
+  it "should not be eql if both products are the same" do
+    expect(UserAgent.new("Mozilla")).not_to eql(UserAgent.new("Opera"))
   end
 
-  it 'should be eql if both products and versions are the same' do
-    expect(UserAgent.new('Mozilla', '5.0')).to eql(UserAgent.new('Mozilla', '5.0'))
+  it "should be eql if both products and versions are the same" do
+    expect(UserAgent.new("Mozilla", "5.0")).to eql(UserAgent.new("Mozilla", "5.0"))
   end
 
-  it 'should not be eql if both products and versions are not the same' do
-    expect(UserAgent.new('Mozilla', '5.0')).not_to eql(UserAgent.new('Mozilla', '4.0'))
+  it "should not be eql if both products and versions are not the same" do
+    expect(UserAgent.new("Mozilla", "5.0")).not_to eql(UserAgent.new("Mozilla", "4.0"))
   end
 
-  it 'should be eql if both products, versions and comments are the same' do
-    expect(UserAgent.new('Mozilla', '5.0', ['Macintosh'])).to eql(UserAgent.new('Mozilla', '5.0', ['Macintosh']))
+  it "should be eql if both products, versions and comments are the same" do
+    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).to eql(UserAgent.new("Mozilla", "5.0", ["Macintosh"]))
   end
 
-  it 'should not be eql if both products, versions and comments are not the same' do
-    expect(UserAgent.new('Mozilla', '5.0', ['Macintosh'])).not_to eql(UserAgent.new('Mozilla', '5.0', ['Windows']))
+  it "should not be eql if both products, versions and comments are not the same" do
+    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(UserAgent.new("Mozilla", "5.0", ["Windows"]))
   end
 
-  it 'should not be eql if both products, versions and comments are not the same' do
-    expect(UserAgent.new('Mozilla', '5.0', ['Macintosh'])).not_to eql(UserAgent.new('Mozilla', '4.0', ['Macintosh']))
+  it "should not be eql if both products, versions and comments are not the same" do
+    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(UserAgent.new("Mozilla", "4.0", ["Macintosh"]))
   end
 
-  it 'should not be equal? if both products are the same' do
-    expect(UserAgent.new('Mozilla')).not_to equal(UserAgent.new('Mozilla'))
+  it "should not be equal? if both products are the same" do
+    expect(UserAgent.new("Mozilla")).not_to equal(UserAgent.new("Mozilla"))
   end
 
-  it 'should be == if products are the same' do
-    expect(UserAgent.new('Mozilla')).to eq(UserAgent.new('Mozilla'))
+  it "should be == if products are the same" do
+    expect(UserAgent.new("Mozilla")).to eq(UserAgent.new("Mozilla"))
   end
 
-  it 'should be == if products and versions are the same' do
-    expect(UserAgent.new('Mozilla', '5.0')).to eq(UserAgent.new('Mozilla', '5.0'))
+  it "should be == if products and versions are the same" do
+    expect(UserAgent.new("Mozilla", "5.0")).to eq(UserAgent.new("Mozilla", "5.0"))
   end
 
-  it 'should not be == if products and versions are the different' do
-    expect(UserAgent.new('Mozilla', '5.0')).not_to eq(UserAgent.new('Mozilla', '4.0'))
+  it "should not be == if products and versions are the different" do
+    expect(UserAgent.new("Mozilla", "5.0")).not_to eq(UserAgent.new("Mozilla", "4.0"))
   end
 
-  it 'should return false if comparing different products' do
-    expect(UserAgent.new('Mozilla')).not_to be <= UserAgent.new('Opera')
+  it "should return false if comparing different products" do
+    expect(UserAgent.new("Mozilla")).not_to be <= UserAgent.new("Opera")
   end
 
-  it 'should not be > if products are the same' do
-    expect(UserAgent.new('Mozilla')).not_to be > UserAgent.new('Mozilla')
+  it "should not be > if products are the same" do
+    expect(UserAgent.new("Mozilla")).not_to be > UserAgent.new("Mozilla")
   end
 
-  it 'should not be < if products are the same' do
-    expect(UserAgent.new('Mozilla')).not_to be < UserAgent.new('Mozilla')
+  it "should not be < if products are the same" do
+    expect(UserAgent.new("Mozilla")).not_to be < UserAgent.new("Mozilla")
   end
 
-  it 'should be >= if products are the same' do
-    expect(UserAgent.new('Mozilla')).to be >= UserAgent.new('Mozilla')
+  it "should be >= if products are the same" do
+    expect(UserAgent.new("Mozilla")).to be >= UserAgent.new("Mozilla")
   end
 
-  it 'should be <= if products are the same' do
-    expect(UserAgent.new('Mozilla')).to be <= UserAgent.new('Mozilla')
+  it "should be <= if products are the same" do
+    expect(UserAgent.new("Mozilla")).to be <= UserAgent.new("Mozilla")
   end
 
-  it 'should be > if products are the same and version is greater' do
-    expect(UserAgent.new('Mozilla', '5.0')).to be > UserAgent.new('Mozilla', '4.0')
+  it "should be > if products are the same and version is greater" do
+    expect(UserAgent.new("Mozilla", "5.0")).to be > UserAgent.new("Mozilla", "4.0")
   end
 
-  it 'should not be > if products are the same and version is less' do
-    expect(UserAgent.new('Mozilla', '4.0')).not_to be > UserAgent.new('Mozilla', '5.0')
+  it "should not be > if products are the same and version is less" do
+    expect(UserAgent.new("Mozilla", "4.0")).not_to be > UserAgent.new("Mozilla", "5.0")
   end
 
-  it 'should be < if products are the same and version is less' do
-    expect(UserAgent.new('Mozilla', '4.0')).to be < UserAgent.new('Mozilla', '5.0')
+  it "should be < if products are the same and version is less" do
+    expect(UserAgent.new("Mozilla", "4.0")).to be < UserAgent.new("Mozilla", "5.0")
   end
 
-  it 'should not be < if products are the same and version is greater' do
-    expect(UserAgent.new('Mozilla', '5.0')).not_to be < UserAgent.new('Mozilla', '4.0')
+  it "should not be < if products are the same and version is greater" do
+    expect(UserAgent.new("Mozilla", "5.0")).not_to be < UserAgent.new("Mozilla", "4.0")
   end
 
-  it 'should be >= if products are the same and version is greater' do
-    expect(UserAgent.new('Mozilla', '5.0')).to be >= UserAgent.new('Mozilla', '4.0')
+  it "should be >= if products are the same and version is greater" do
+    expect(UserAgent.new("Mozilla", "5.0")).to be >= UserAgent.new("Mozilla", "4.0")
   end
 
-  it 'should not be >= if products are the same and version is less' do
-    expect(UserAgent.new('Mozilla', '4.0')).not_to be >= UserAgent.new('Mozilla', '5.0')
+  it "should not be >= if products are the same and version is less" do
+    expect(UserAgent.new("Mozilla", "4.0")).not_to be >= UserAgent.new("Mozilla", "5.0")
   end
 
-  it 'should be <= if products are the same and version is less' do
-    expect(UserAgent.new('Mozilla', '4.0')).to be <= UserAgent.new('Mozilla', '5.0')
+  it "should be <= if products are the same and version is less" do
+    expect(UserAgent.new("Mozilla", "4.0")).to be <= UserAgent.new("Mozilla", "5.0")
   end
 
-  it 'should not be <= if products are the same and version is greater' do
-    expect(UserAgent.new('Mozilla', '5.0')).not_to be <= UserAgent.new('Mozilla', '4.0')
+  it "should not be <= if products are the same and version is greater" do
+    expect(UserAgent.new("Mozilla", "5.0")).not_to be <= UserAgent.new("Mozilla", "4.0")
   end
 
-  it 'should be >= if products are the same and version is the same' do
-    expect(UserAgent.new('Mozilla', '5.0')).to be >= UserAgent.new('Mozilla', '5.0')
+  it "should be >= if products are the same and version is the same" do
+    expect(UserAgent.new("Mozilla", "5.0")).to be >= UserAgent.new("Mozilla", "5.0")
   end
 
-  it 'should be <= if products are the same and version is the same' do
-    expect(UserAgent.new('Mozilla', '5.0')).to be <= UserAgent.new('Mozilla', '5.0')
-  end
-end
-
-describe UserAgent, '::MATCHER' do
-  it 'should not match a blank line' do
-    expect(UserAgent::MATCHER).not_to match('')
-  end
-
-  it 'should match a single product' do
-    expect(UserAgent::MATCHER).to match('Mozilla')
-  end
-
-  it 'should match a product and version' do
-    expect(UserAgent::MATCHER).to match('Mozilla/5.0')
-  end
-
-  it 'should match a product, version, and comment' do
-    expect(UserAgent::MATCHER).to match('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)')
-  end
-
-  it 'should match a product, and comment' do
-    expect(UserAgent::MATCHER).to match('Mozilla (Macintosh; U; Intel Mac OS X 10_5_3; en-us)')
+  it "should be <= if products are the same and version is the same" do
+    expect(UserAgent.new("Mozilla", "5.0")).to be <= UserAgent.new("Mozilla", "5.0")
   end
 end
 
-describe UserAgent, '.parse' do
+describe UserAgent, "::MATCHER" do
+  it "should not match a blank line" do
+    expect(UserAgent::MATCHER).not_to match("")
+  end
+
+  it "should match a single product" do
+    expect(UserAgent::MATCHER).to match("Mozilla")
+  end
+
+  it "should match a product and version" do
+    expect(UserAgent::MATCHER).to match("Mozilla/5.0")
+  end
+
+  it "should match a product, version, and comment" do
+    expect(UserAgent::MATCHER).to match("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
+  end
+
+  it "should match a product, and comment" do
+    expect(UserAgent::MATCHER).to match("Mozilla (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
+  end
+end
+
+describe UserAgent, ".parse" do
   let(:default_user_agent) { UserAgent.parse(UserAgent::DEFAULT_USER_AGENT) }
 
-  it 'should concatenate user agents when coerced to a string' do
-    string = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18')
-    expect(string.to_str).to eq('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18')
+  it "should concatenate user agents when coerced to a string" do
+    string = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
+    expect(string.to_str).to eq("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
   end
 
-  it 'should parse a single product' do
-    useragent = UserAgent.new('Mozilla')
-    expect(UserAgent.parse('Mozilla').application).to eq(useragent)
+  it "should parse a single product" do
+    useragent = UserAgent.new("Mozilla")
+    expect(UserAgent.parse("Mozilla").application).to eq(useragent)
   end
 
-  it 'should parse a single product with version' do
-    useragent = UserAgent.new('Mozilla', '5.0')
-    expect(UserAgent.parse('Mozilla/5.0').application).to eq(useragent)
+  it "should parse a single product with version" do
+    useragent = UserAgent.new("Mozilla", "5.0")
+    expect(UserAgent.parse("Mozilla/5.0").application).to eq(useragent)
   end
 
-  it 'should parse a single product with an empty comment' do
-    useragent = UserAgent.new('Mozilla', '5.0')
-    expect(UserAgent.parse('Mozilla/5.0 ()').application).to eq(useragent)
+  it "should parse a single product with an empty comment" do
+    useragent = UserAgent.new("Mozilla", "5.0")
+    expect(UserAgent.parse("Mozilla/5.0 ()").application).to eq(useragent)
   end
 
-  it 'should parse a single product, version, and comment' do
-    useragent = UserAgent.new('Mozilla', '5.0', ['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us'])
-    expect(UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)').application).to eq(useragent)
+  it "should parse a single product, version, and comment" do
+    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
+    expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)").application).to eq(useragent)
   end
 
-  it 'should parse a single product, version, and comment, with space-padded semicolons' do
-    useragent = UserAgent.new('Mozilla', '5.0', ['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us'])
-    expect(UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3 ; en-us; )').application).to eq(useragent)
+  it "should parse a single product, version, and comment, with space-padded semicolons" do
+    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
+    expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3 ; en-us; )").application).to eq(useragent)
   end
 
-  it 'should parse a user agent string with gzip(gfe) addition correctly' do
-    agent = UserAgent.parse('Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)')
+  it "should parse a user agent string with gzip(gfe) addition correctly" do
+    agent = UserAgent.parse("Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)")
 
-    expect(agent.version.to_s).to eq('35.0')
+    expect(agent.version.to_s).to eq("35.0")
   end
 
-  it 'should parse a single product and comment' do
-    useragent = UserAgent.new('Mozilla', nil, ['Macintosh'])
-    expect(UserAgent.parse('Mozilla (Macintosh)').application).to eq(useragent)
+  it "should parse a single product and comment" do
+    useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
+    expect(UserAgent.parse("Mozilla (Macintosh)").application).to eq(useragent)
   end
 
-  it 'should parse nil as the default agent' do
+  it "should parse nil as the default agent" do
     expect(UserAgent.parse(nil)).to eq(default_user_agent)
   end
 
-  it 'should parse an empty string as the default agent' do
-    expect(UserAgent.parse('')).to eq(default_user_agent)
+  it "should parse an empty string as the default agent" do
+    expect(UserAgent.parse("")).to eq(default_user_agent)
   end
 
-  it 'should parse a blank string as the default agent' do
-    expect(UserAgent.parse(' ')).to eq(default_user_agent)
+  it "should parse a blank string as the default agent" do
+    expect(UserAgent.parse(" ")).to eq(default_user_agent)
   end
 
-  it 'should parse a double-quoted user-agent' do
-    useragent = UserAgent.new('Mozilla', '5.0', ['X11', 'Linux x86_64', 'rv:9.0'])
+  it "should parse a double-quoted user-agent" do
+    useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
     expect(UserAgent.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0"').application).to eq(useragent)
   end
 
-  it 'should parse a user-agent with leading double-quote' do
-    useragent = UserAgent.new('Mozilla', '5.0', ['X11', 'Linux x86_64', 'rv:9.0'])
+  it "should parse a user-agent with leading double-quote" do
+    useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
     expect(UserAgent.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0').application).to eq(useragent)
   end
 
-  it 'should parse a single-quoted user-agent' do
-    useragent = UserAgent.new('Mozilla', '5.0', nil)
+  it "should parse a single-quoted user-agent" do
+    useragent = UserAgent.new("Mozilla", "5.0", nil)
     expect(UserAgent.parse("'Mozilla/5.0'").application).to eq(useragent)
   end
 
-  it 'should parse a user-agent with leading single-quote' do
-    useragent = UserAgent.new('Mozilla', '5.0', nil)
+  it "should parse a user-agent with leading single-quote" do
+    useragent = UserAgent.new("Mozilla", "5.0", nil)
     expect(UserAgent.parse("'Mozilla/5.0").application).to eq(useragent)
   end
 end
 
-describe UserAgent::Browsers::Base, '#<' do
+describe UserAgent::Browsers::Base, "#<" do
   before do
-    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
-    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
-    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
+    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
+    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it 'should not be < if user agent does not have a browser' do
-    expect(@ie7).not_to be < 'Mozilla'
+  it "should not be < if user agent does not have a browser" do
+    expect(@ie7).not_to be < "Mozilla"
   end
 
-  it 'should not be < if user agent does not have the same browser' do
+  it "should not be < if user agent does not have the same browser" do
     expect(@ie7).not_to be < @firefox
   end
 
-  it 'should be < if version is less than its version' do
+  it "should be < if version is less than its version" do
     expect(@ie6).to be < @ie7
   end
 
-  it 'should not be < if version is the same as its version' do
+  it "should not be < if version is the same as its version" do
     expect(@ie6).not_to be < @ie6
   end
 
-  it 'should not be < if version is greater than its version' do
+  it "should not be < if version is greater than its version" do
     expect(@ie7).not_to be < @ie6
   end
 end
 
-describe UserAgent::Browsers::Base, '#<=' do
+describe UserAgent::Browsers::Base, "#<=" do
   before do
-    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
-    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
-    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
+    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
+    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it 'should not be <= if user agent does not have a browser' do
-    expect(@ie7).not_to be <= 'Mozilla'
+  it "should not be <= if user agent does not have a browser" do
+    expect(@ie7).not_to be <= "Mozilla"
   end
 
-  it 'should not be <= if user agent does not have the same browser' do
+  it "should not be <= if user agent does not have the same browser" do
     expect(@ie7).not_to be <= @firefox
   end
 
-  it 'should be <= if version is less than its version' do
+  it "should be <= if version is less than its version" do
     expect(@ie6).to be <= @ie7
   end
 
-  it 'should be <= if version is the same as its version' do
+  it "should be <= if version is the same as its version" do
     expect(@ie6).to be <= @ie6
   end
 
-  it 'should not be <= if version is greater than its version' do
+  it "should not be <= if version is greater than its version" do
     expect(@ie7).not_to be <= @ie6
   end
 end
 
-describe UserAgent::Browsers::Base, '#==' do
+describe UserAgent::Browsers::Base, "#==" do
   before do
-    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
-    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
-    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
+    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
+    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it 'should not be == if user agent does not have a browser' do
-    expect(@ie7).not_to eq('Mozilla')
+  it "should not be == if user agent does not have a browser" do
+    expect(@ie7).not_to eq("Mozilla")
   end
 
-  it 'should not be == if user agent does not have the same browser' do
+  it "should not be == if user agent does not have the same browser" do
     expect(@ie7).not_to eq(@firefox)
   end
 
-  it 'should not be == if version is less than its version' do
+  it "should not be == if version is less than its version" do
     expect(@ie6).not_to eq(@ie7)
   end
 
-  it 'should be == if version is the same as its version' do
+  it "should be == if version is the same as its version" do
     expect(@ie6).to eq(@ie6)
   end
 
-  it 'should not be == if version is greater than its version' do
+  it "should not be == if version is greater than its version" do
     expect(@ie7).not_to eq(@ie6)
   end
 end
 
-describe UserAgent::Browsers::Base, '#>' do
+describe UserAgent::Browsers::Base, "#>" do
   before do
-    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
-    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
-    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
+    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
+    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it 'should not be > if user agent does not have a browser' do
-    expect(@ie7).not_to be > 'Mozilla'
+  it "should not be > if user agent does not have a browser" do
+    expect(@ie7).not_to be > "Mozilla"
   end
 
-  it 'should not be > if user agent does not have the same browser' do
+  it "should not be > if user agent does not have the same browser" do
     expect(@ie7).not_to be > @firefox
   end
 
-  it 'should not be > if version is less than its version' do
+  it "should not be > if version is less than its version" do
     expect(@ie6).not_to be > @ie7
   end
 
-  it 'should not be > if version is the same as its version' do
+  it "should not be > if version is the same as its version" do
     expect(@ie6).not_to be > @ie6
   end
 
-  it 'should be > if version is greater than its version' do
+  it "should be > if version is greater than its version" do
     expect(@ie7).to be > @ie6
   end
 end
 
-describe UserAgent::Browsers::Base, '#>=' do
+describe UserAgent::Browsers::Base, "#>=" do
   before do
-    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
-    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
-    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
+    @ie7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
+    @ie6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
+    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it 'should not be >= if user agent does not have a browser' do
-    expect(@ie7).not_to be >= 'Mozilla'
+  it "should not be >= if user agent does not have a browser" do
+    expect(@ie7).not_to be >= "Mozilla"
   end
 
-  it 'should not be >= if user agent does not have the same browser' do
+  it "should not be >= if user agent does not have the same browser" do
     expect(@ie7).not_to be >= @firefox
   end
 
-  it 'should not be >= if version is less than its version' do
+  it "should not be >= if version is less than its version" do
     expect(@ie6).not_to be >= @ie7
   end
 
-  it 'should be >= if version is the same as its version' do
+  it "should be >= if version is the same as its version" do
     expect(@ie6).to be >= @ie6
   end
 
-  it 'should be >= if version is greater than its version' do
+  it "should be >= if version is greater than its version" do
     expect(@ie7).to be >= @ie6
   end
 end
 
-describe UserAgent::Browsers::Base, '#to_h' do
-  shared_examples 'Browser serializer' do |user_agent_string, expected_hash|
+describe UserAgent::Browsers::Base, "#to_h" do
+  shared_examples "Browser serializer" do |user_agent_string, expected_hash|
     let(:useragent) do
       UserAgent.parse(user_agent_string)
     end
@@ -395,169 +395,169 @@ describe UserAgent::Browsers::Base, '#to_h' do
     end
   end
 
-  it_behaves_like 'Browser serializer',
-                  'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)',
-                  browser: 'Mozilla',
+  it_behaves_like "Browser serializer",
+                  "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)",
+                  browser: "Mozilla",
                   version: [5, 0],
-                  platform: 'Macintosh',
-                  os: 'OS X 10.5.3',
+                  platform: "Macintosh",
+                  os: "OS X 10.5.3",
                   mobile: false,
                   bot: false,
-                  comment: ['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us']
+                  comment: ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"]
 
-  it_behaves_like 'Browser serializer',
-                  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-                  browser: 'Mozilla',
+  it_behaves_like "Browser serializer",
+                  "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+                  browser: "Mozilla",
                   version: [5, 0],
                   platform: nil,
-                  os: 'Googlebot/2.1',
+                  os: "Googlebot/2.1",
                   mobile: false,
                   bot: true,
-                  comment: ['compatible', 'Googlebot/2.1', '+http://www.google.com/bot.html']
+                  comment: ["compatible", "Googlebot/2.1", "+http://www.google.com/bot.html"]
 
-  it_behaves_like 'Browser serializer',
-                  'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25',
-                  browser: 'Chrome',
+  it_behaves_like "Browser serializer",
+                  "Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25",
+                  browser: "Chrome",
                   version: [28, 0, 1500, 16],
-                  platform: 'iPhone',
-                  os: 'iOS 6.1.3',
+                  platform: "iPhone",
+                  os: "iOS 6.1.3",
                   mobile: true,
                   bot: false,
-                  comment: ['iPhone', 'CPU iPhone OS 6_1_3 like Mac OS X']
+                  comment: ["iPhone", "CPU iPhone OS 6_1_3 like Mac OS X"]
 end
 
 describe UserAgent::Version do
-  it 'should be eql if versions are the same' do
-    expect(UserAgent::Version.new('5.0')).to eql(UserAgent::Version.new('5.0'))
+  it "should be eql if versions are the same" do
+    expect(UserAgent::Version.new("5.0")).to eql(UserAgent::Version.new("5.0"))
   end
 
-  it 'should not be eql if versions are the different' do
-    expect(UserAgent::Version.new('9.0')).not_to eql(UserAgent::Version.new('5.0'))
+  it "should not be eql if versions are the different" do
+    expect(UserAgent::Version.new("9.0")).not_to eql(UserAgent::Version.new("5.0"))
   end
 
-  it 'should be == if versions are the same' do
-    expect(UserAgent::Version.new('5.0')).to eq(UserAgent::Version.new('5.0'))
+  it "should be == if versions are the same" do
+    expect(UserAgent::Version.new("5.0")).to eq(UserAgent::Version.new("5.0"))
   end
 
-  it 'should be == if versions are the same string' do
-    expect(UserAgent::Version.new('5.0')).to eq('5.0')
+  it "should be == if versions are the same string" do
+    expect(UserAgent::Version.new("5.0")).to eq("5.0")
   end
 
-  it 'should not be == if versions are the different' do
-    expect(UserAgent::Version.new('9.0')).not_to eq(UserAgent::Version.new('5.0'))
+  it "should not be == if versions are the different" do
+    expect(UserAgent::Version.new("9.0")).not_to eq(UserAgent::Version.new("5.0"))
   end
 
-  it 'should not be == to nil' do
-    expect(UserAgent::Version.new('9.0')).not_to eq(nil)
+  it "should not be == to nil" do
+    expect(UserAgent::Version.new("9.0")).not_to eq(nil)
   end
 
-  it 'should not be == to []' do
-    expect(UserAgent::Version.new('9.0')).not_to eq([])
+  it "should not be == to []" do
+    expect(UserAgent::Version.new("9.0")).not_to eq([])
   end
 
-  it 'should be < if version is less' do
-    expect(UserAgent::Version.new('9.0')).to be < UserAgent::Version.new('10.0')
+  it "should be < if version is less" do
+    expect(UserAgent::Version.new("9.0")).to be < UserAgent::Version.new("10.0")
   end
 
-  it 'should be < if version is less' do
-    expect(UserAgent::Version.new('4')).to be < UserAgent::Version.new('4.1')
+  it "should be < if version is less" do
+    expect(UserAgent::Version.new("4")).to be < UserAgent::Version.new("4.1")
   end
 
-  it 'should be < if version is less and a string' do
-    expect(UserAgent::Version.new('9.0')).to be < '10.0'
+  it "should be < if version is less and a string" do
+    expect(UserAgent::Version.new("9.0")).to be < "10.0"
   end
 
-  it 'should not be < if version is greater' do
-    expect(UserAgent::Version.new('9.0')).not_to be > UserAgent::Version.new('10.0')
+  it "should not be < if version is greater" do
+    expect(UserAgent::Version.new("9.0")).not_to be > UserAgent::Version.new("10.0")
   end
 
-  it 'should be <= if version is less' do
-    expect(UserAgent::Version.new('9.0')).to be <= UserAgent::Version.new('10.0')
+  it "should be <= if version is less" do
+    expect(UserAgent::Version.new("9.0")).to be <= UserAgent::Version.new("10.0")
   end
 
-  it 'should not be <= if version is greater' do
-    expect(UserAgent::Version.new('9.0')).not_to be >= UserAgent::Version.new('10.0')
+  it "should not be <= if version is greater" do
+    expect(UserAgent::Version.new("9.0")).not_to be >= UserAgent::Version.new("10.0")
   end
 
-  it 'should be <= if version is same' do
-    expect(UserAgent::Version.new('9.0')).to be <= UserAgent::Version.new('9.0')
+  it "should be <= if version is same" do
+    expect(UserAgent::Version.new("9.0")).to be <= UserAgent::Version.new("9.0")
   end
 
-  it 'should be > if version is greater' do
-    expect(UserAgent::Version.new('1.0')).to be > UserAgent::Version.new('0.9')
+  it "should be > if version is greater" do
+    expect(UserAgent::Version.new("1.0")).to be > UserAgent::Version.new("0.9")
   end
 
-  it 'should be > if version is greater' do
-    expect(UserAgent::Version.new('4.1')).to be > UserAgent::Version.new('4')
+  it "should be > if version is greater" do
+    expect(UserAgent::Version.new("4.1")).to be > UserAgent::Version.new("4")
   end
 
-  it 'should not be > if version is less' do
-    expect(UserAgent::Version.new('0.0.1')).not_to be > UserAgent::Version.new('10.0')
+  it "should not be > if version is less" do
+    expect(UserAgent::Version.new("0.0.1")).not_to be > UserAgent::Version.new("10.0")
   end
 
-  it 'should be >= if version is greater' do
-    expect(UserAgent::Version.new('10.0')).to be >= UserAgent::Version.new('4.0')
+  it "should be >= if version is greater" do
+    expect(UserAgent::Version.new("10.0")).to be >= UserAgent::Version.new("4.0")
   end
 
-  it 'should not be >= if version is less' do
-    expect(UserAgent::Version.new('0.9')).not_to be >= UserAgent::Version.new('1.0')
+  it "should not be >= if version is less" do
+    expect(UserAgent::Version.new("0.9")).not_to be >= UserAgent::Version.new("1.0")
   end
 
-  it 'should not be > if version is invalid' do
-    expect(UserAgent::Version.new('x.x')).not_to be > UserAgent::Version.new('1.0')
+  it "should not be > if version is invalid" do
+    expect(UserAgent::Version.new("x.x")).not_to be > UserAgent::Version.new("1.0")
   end
 
-  it 'should be < if version is invalid' do
-    expect(UserAgent::Version.new('x.x')).to be < UserAgent::Version.new('1.0')
+  it "should be < if version is invalid" do
+    expect(UserAgent::Version.new("x.x")).to be < UserAgent::Version.new("1.0")
   end
 
-  it 'should be > when compared with invalid' do
-    expect(UserAgent::Version.new('1.0')).to be > UserAgent::Version.new('x.x')
+  it "should be > when compared with invalid" do
+    expect(UserAgent::Version.new("1.0")).to be > UserAgent::Version.new("x.x")
   end
 
-  it 'should not be < when compared with invalid' do
-    expect(UserAgent::Version.new('1.0')).not_to be < UserAgent::Version.new('x.x')
+  it "should not be < when compared with invalid" do
+    expect(UserAgent::Version.new("1.0")).not_to be < UserAgent::Version.new("x.x")
   end
 
-  it 'should not be > if both versions are invalid' do
-    expect(UserAgent::Version.new('a.a')).not_to be > UserAgent::Version.new('b.b')
+  it "should not be > if both versions are invalid" do
+    expect(UserAgent::Version.new("a.a")).not_to be > UserAgent::Version.new("b.b")
   end
 
-  it 'should be < if both versions are invalid' do
-    expect(UserAgent::Version.new('a.a')).to be < UserAgent::Version.new('b.b')
+  it "should be < if both versions are invalid" do
+    expect(UserAgent::Version.new("a.a")).to be < UserAgent::Version.new("b.b")
   end
 
-  it 'should not be > if version is nil' do
-    expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new('1.0')
+  it "should not be > if version is nil" do
+    expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new("1.0")
   end
 
-  it 'should be < if version is nil' do
-    expect(UserAgent::Version.new(nil)).to be < UserAgent::Version.new('1.0')
+  it "should be < if version is nil" do
+    expect(UserAgent::Version.new(nil)).to be < UserAgent::Version.new("1.0")
   end
 
-  it 'should not be > when compared with nil' do
+  it "should not be > when compared with nil" do
     expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new(nil)
   end
 
-  it 'should not be < when compared with nil' do
+  it "should not be < when compared with nil" do
     expect(UserAgent::Version.new(nil)).not_to be < UserAgent::Version.new(nil)
   end
 
-  it 'should not be > if both versions are nil' do
+  it "should not be > if both versions are nil" do
     expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new(nil)
   end
 
-  it 'should not be < if both versions are nil' do
+  it "should not be < if both versions are nil" do
     expect(UserAgent::Version.new(nil)).not_to be < UserAgent::Version.new(nil)
   end
 
-  it 'should be > if version is nil' do
-    expect(UserAgent::Version.new('9.0')).to be > nil
+  it "should be > if version is nil" do
+    expect(UserAgent::Version.new("9.0")).to be > nil
   end
 
-  context 'comparing with structs' do
-    it 'should not be < if products are the same and version is greater' do
-      expect(UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)')).not_to be < OpenStruct.new(browser: 'Internet Explorer', version: '7.0')
+  context "comparing with structs" do
+    it "should not be < if products are the same and version is greater" do
+      expect(UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)")).not_to be < OpenStruct.new(browser: "Internet Explorer", version: "7.0")
     end
   end
 end

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -406,33 +406,33 @@ describe UserAgent::Browsers::Base, "#to_h" do
 
   it_behaves_like "Browser serializer",
                   "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)",
-                  browser: "Mozilla",
-                  version: [5, 0],
-                  platform: "Macintosh",
-                  os: "OS X 10.5.3",
-                  mobile: false,
-                  bot: false,
-                  comment: ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"]
+                  :browser => "Mozilla",
+                  :version => [5, 0],
+                  :platform => "Macintosh",
+                  :os => "OS X 10.5.3",
+                  :mobile => false,
+                  :bot => false,
+                  :comment => ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"]
 
   it_behaves_like "Browser serializer",
                   "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
-                  browser: "Mozilla",
-                  version: [5, 0],
-                  platform: nil,
-                  os: "Googlebot/2.1",
-                  mobile: false,
-                  bot: true,
-                  comment: ["compatible", "Googlebot/2.1", "+http://www.google.com/bot.html"]
+                  :browser => "Mozilla",
+                  :version => [5, 0],
+                  :platform => nil,
+                  :os => "Googlebot/2.1",
+                  :mobile => false,
+                  :bot => true,
+                  :comment => ["compatible", "Googlebot/2.1", "+http://www.google.com/bot.html"]
 
   it_behaves_like "Browser serializer",
                   "Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25",
-                  browser: "Chrome",
-                  version: [28, 0, 1500, 16],
-                  platform: "iPhone",
-                  os: "iOS 6.1.3",
-                  mobile: true,
-                  bot: false,
-                  comment: ["iPhone", "CPU iPhone OS 6_1_3 like Mac OS X"]
+                  :browser => "Chrome",
+                  :version => [28, 0, 1500, 16],
+                  :platform => "iPhone",
+                  :os => "iOS 6.1.3",
+                  :mobile => true,
+                  :bot => false,
+                  :comment => ["iPhone", "CPU iPhone OS 6_1_3 like Mac OS X"]
 end
 
 describe UserAgent::Version do
@@ -566,7 +566,7 @@ describe UserAgent::Version do
 
   context "comparing with structs" do
     it "should not be < if products are the same and version is greater" do
-      expect(UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)")).not_to be < OpenStruct.new(browser: "Internet Explorer", version: "7.0")
+      expect(UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)")).not_to be < OpenStruct.new(:browser => "Internet Explorer", :version => "7.0")
     end
   end
 end

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -3,7 +3,7 @@ require "user_agent"
 require "ostruct"
 
 describe UserAgent do
-  it "should warn about deprecation" do
+  it "warns about deprecation" do
     expect { UserAgent::Browsers.Security }.to output("Security is deprecated. Please use SECURITY instead\n").to_stderr
     expect { UserAgent::Browsers.Security }.to output("").to_stderr
     expect { UserAgent::OperatingSystems.Windows }.to output("Windows is deprecated. Please use WINDOWS instead\n").to_stderr
@@ -22,160 +22,160 @@ describe UserAgent do
     expect { wmf.has_wmfsdk?("") }.to output("").to_stderr
   end
 
-  it "should require a product" do
-    expect { UserAgent.new(nil) }.to raise_error(ArgumentError, "expected a value for product")
+  it "requires a product" do
+    expect { described_class.new(nil) }.to raise_error(ArgumentError, "expected a value for product")
   end
 
-  it "should split comment to an array if a string is passed in" do
-    useragent = UserAgent.new("Mozilla", "5.0", "Macintosh; U; Intel Mac OS X 10_5_3; en-us")
+  it "splits comment to an array if a string is passed in" do
+    useragent = described_class.new("Mozilla", "5.0", "Macintosh; U; Intel Mac OS X 10_5_3; en-us")
     expect(useragent.comment).to eq(["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
   end
 
-  it "should set version to nil if it is blank" do
-    expect(UserAgent.new("Mozilla", "").version).to be_nil
+  it "sets version to nil if it is blank" do
+    expect(described_class.new("Mozilla", "").version).to be_nil
   end
 
-  it "should only output product when coerced to a string" do
-    expect(UserAgent.new("Mozilla").to_str).to eq("Mozilla")
+  it "onlies output product when coerced to a string" do
+    expect(described_class.new("Mozilla").to_str).to eq("Mozilla")
   end
 
-  it "should output product and version when coerced to a string" do
-    expect(UserAgent.new("Mozilla", "5.0").to_str).to eq("Mozilla/5.0")
+  it "outputs product and version when coerced to a string" do
+    expect(described_class.new("Mozilla", "5.0").to_str).to eq("Mozilla/5.0")
   end
 
-  it "should output product, version and comment when coerced to a string" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
+  it "outputs product, version and comment when coerced to a string" do
+    useragent = described_class.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
     expect(useragent.to_str).to eq("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
   end
 
-  it "should output product and comment when coerced to a string" do
-    useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
+  it "outputs product and comment when coerced to a string" do
+    useragent = described_class.new("Mozilla", nil, ["Macintosh"])
     expect(useragent.to_str).to eq("Mozilla (Macintosh)")
   end
 
-  it "should be eql if both products are the same" do
-    expect(UserAgent.new("Mozilla")).to eql(UserAgent.new("Mozilla"))
+  it "is eql if both products are the same" do
+    expect(described_class.new("Mozilla")).to eql(described_class.new("Mozilla"))
   end
 
-  it "should not be eql if both products are the same" do
-    expect(UserAgent.new("Mozilla")).not_to eql(UserAgent.new("Opera"))
+  it "is not eql if both products are the same" do
+    expect(described_class.new("Mozilla")).not_to eql(described_class.new("Opera"))
   end
 
-  it "should be eql if both products and versions are the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).to eql(UserAgent.new("Mozilla", "5.0"))
+  it "is eql if both products and versions are the same" do
+    expect(described_class.new("Mozilla", "5.0")).to eql(described_class.new("Mozilla", "5.0"))
   end
 
-  it "should not be eql if both products and versions are not the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).not_to eql(UserAgent.new("Mozilla", "4.0"))
+  it "is not eql if both products and versions are not the same" do
+    expect(described_class.new("Mozilla", "5.0")).not_to eql(described_class.new("Mozilla", "4.0"))
   end
 
-  it "should be eql if both products, versions and comments are the same" do
-    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).to eql(UserAgent.new("Mozilla", "5.0", ["Macintosh"]))
+  it "is eql if both products, versions and comments are the same" do
+    expect(described_class.new("Mozilla", "5.0", ["Macintosh"])).to eql(described_class.new("Mozilla", "5.0", ["Macintosh"]))
   end
 
-  it "should not be eql if both products, versions and comments are not the same" do
-    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(UserAgent.new("Mozilla", "5.0", ["Windows"]))
+  it "is not eql if both products, versions and comments are not the same" do
+    expect(described_class.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(described_class.new("Mozilla", "5.0", ["Windows"]))
   end
 
-  it "should not be eql if both products, versions and comments are not the same" do
-    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(UserAgent.new("Mozilla", "4.0", ["Macintosh"]))
+  it "is not eql if both products, versions and comments are not the same" do
+    expect(described_class.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(described_class.new("Mozilla", "4.0", ["Macintosh"]))
   end
 
-  it "should not be equal? if both products are the same" do
-    expect(UserAgent.new("Mozilla")).not_to equal(UserAgent.new("Mozilla"))
+  it "is not equal? if both products are the same" do
+    expect(described_class.new("Mozilla")).not_to equal(described_class.new("Mozilla"))
   end
 
-  it "should be == if products are the same" do
-    expect(UserAgent.new("Mozilla")).to eq(UserAgent.new("Mozilla"))
+  it "is == if products are the same" do
+    expect(described_class.new("Mozilla")).to eq(described_class.new("Mozilla"))
   end
 
-  it "should be == if products and versions are the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).to eq(UserAgent.new("Mozilla", "5.0"))
+  it "is == if products and versions are the same" do
+    expect(described_class.new("Mozilla", "5.0")).to eq(described_class.new("Mozilla", "5.0"))
   end
 
-  it "should not be == if products and versions are the different" do
-    expect(UserAgent.new("Mozilla", "5.0")).not_to eq(UserAgent.new("Mozilla", "4.0"))
+  it "is not == if products and versions are the different" do
+    expect(described_class.new("Mozilla", "5.0")).not_to eq(described_class.new("Mozilla", "4.0"))
   end
 
-  it "should return false if comparing different products" do
-    expect(UserAgent.new("Mozilla")).not_to be <= UserAgent.new("Opera")
+  it "returns false if comparing different products" do
+    expect(described_class.new("Mozilla")).not_to be <= described_class.new("Opera")
   end
 
-  it "should not be > if products are the same" do
-    expect(UserAgent.new("Mozilla")).not_to be > UserAgent.new("Mozilla")
+  it "is not > if products are the same" do
+    expect(described_class.new("Mozilla")).not_to be > described_class.new("Mozilla")
   end
 
-  it "should not be < if products are the same" do
-    expect(UserAgent.new("Mozilla")).not_to be < UserAgent.new("Mozilla")
+  it "is not < if products are the same" do
+    expect(described_class.new("Mozilla")).not_to be < described_class.new("Mozilla")
   end
 
-  it "should be >= if products are the same" do
-    expect(UserAgent.new("Mozilla")).to be >= UserAgent.new("Mozilla")
+  it "is >= if products are the same" do
+    expect(described_class.new("Mozilla")).to be >= described_class.new("Mozilla")
   end
 
-  it "should be <= if products are the same" do
-    expect(UserAgent.new("Mozilla")).to be <= UserAgent.new("Mozilla")
+  it "is <= if products are the same" do
+    expect(described_class.new("Mozilla")).to be <= described_class.new("Mozilla")
   end
 
-  it "should be > if products are the same and version is greater" do
-    expect(UserAgent.new("Mozilla", "5.0")).to be > UserAgent.new("Mozilla", "4.0")
+  it "is > if products are the same and version is greater" do
+    expect(described_class.new("Mozilla", "5.0")).to be > described_class.new("Mozilla", "4.0")
   end
 
-  it "should not be > if products are the same and version is less" do
-    expect(UserAgent.new("Mozilla", "4.0")).not_to be > UserAgent.new("Mozilla", "5.0")
+  it "is not > if products are the same and version is less" do
+    expect(described_class.new("Mozilla", "4.0")).not_to be > described_class.new("Mozilla", "5.0")
   end
 
-  it "should be < if products are the same and version is less" do
-    expect(UserAgent.new("Mozilla", "4.0")).to be < UserAgent.new("Mozilla", "5.0")
+  it "is < if products are the same and version is less" do
+    expect(described_class.new("Mozilla", "4.0")).to be < described_class.new("Mozilla", "5.0")
   end
 
-  it "should not be < if products are the same and version is greater" do
-    expect(UserAgent.new("Mozilla", "5.0")).not_to be < UserAgent.new("Mozilla", "4.0")
+  it "is not < if products are the same and version is greater" do
+    expect(described_class.new("Mozilla", "5.0")).not_to be < described_class.new("Mozilla", "4.0")
   end
 
-  it "should be >= if products are the same and version is greater" do
-    expect(UserAgent.new("Mozilla", "5.0")).to be >= UserAgent.new("Mozilla", "4.0")
+  it "is >= if products are the same and version is greater" do
+    expect(described_class.new("Mozilla", "5.0")).to be >= described_class.new("Mozilla", "4.0")
   end
 
-  it "should not be >= if products are the same and version is less" do
-    expect(UserAgent.new("Mozilla", "4.0")).not_to be >= UserAgent.new("Mozilla", "5.0")
+  it "is not >= if products are the same and version is less" do
+    expect(described_class.new("Mozilla", "4.0")).not_to be >= described_class.new("Mozilla", "5.0")
   end
 
-  it "should be <= if products are the same and version is less" do
-    expect(UserAgent.new("Mozilla", "4.0")).to be <= UserAgent.new("Mozilla", "5.0")
+  it "is <= if products are the same and version is less" do
+    expect(described_class.new("Mozilla", "4.0")).to be <= described_class.new("Mozilla", "5.0")
   end
 
-  it "should not be <= if products are the same and version is greater" do
-    expect(UserAgent.new("Mozilla", "5.0")).not_to be <= UserAgent.new("Mozilla", "4.0")
+  it "is not <= if products are the same and version is greater" do
+    expect(described_class.new("Mozilla", "5.0")).not_to be <= described_class.new("Mozilla", "4.0")
   end
 
-  it "should be >= if products are the same and version is the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).to be >= UserAgent.new("Mozilla", "5.0")
+  it "is >= if products are the same and version is the same" do
+    expect(described_class.new("Mozilla", "5.0")).to be >= described_class.new("Mozilla", "5.0")
   end
 
-  it "should be <= if products are the same and version is the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).to be <= UserAgent.new("Mozilla", "5.0")
+  it "is <= if products are the same and version is the same" do
+    expect(described_class.new("Mozilla", "5.0")).to be <= described_class.new("Mozilla", "5.0")
   end
 end
 
 describe UserAgent, "::MATCHER" do
-  it "should not match a blank line" do
+  it "does not match a blank line" do
     expect(UserAgent::MATCHER).not_to match("")
   end
 
-  it "should match a single product" do
+  it "matches a single product" do
     expect(UserAgent::MATCHER).to match("Mozilla")
   end
 
-  it "should match a product and version" do
+  it "matches a product and version" do
     expect(UserAgent::MATCHER).to match("Mozilla/5.0")
   end
 
-  it "should match a product, version, and comment" do
+  it "matches a product, version, and comment" do
     expect(UserAgent::MATCHER).to match("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
   end
 
-  it "should match a product, and comment" do
+  it "matches a product, and comment" do
     expect(UserAgent::MATCHER).to match("Mozilla (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
   end
 end
@@ -183,75 +183,75 @@ end
 describe UserAgent, ".parse" do
   let(:default_user_agent) { UserAgent.parse(UserAgent::DEFAULT_USER_AGENT) }
 
-  it "should concatenate user agents when coerced to a string" do
+  it "concatenates user agents when coerced to a string" do
     string = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
     expect(string.to_str).to eq("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
   end
 
-  it "should parse a single product" do
+  it "parses a single product" do
     useragent = UserAgent.new("Mozilla")
     expect(UserAgent.parse("Mozilla").application).to eq(useragent)
   end
 
-  it "should parse a single product with version" do
+  it "parses a single product with version" do
     useragent = UserAgent.new("Mozilla", "5.0")
     expect(UserAgent.parse("Mozilla/5.0").application).to eq(useragent)
   end
 
-  it "should parse a single product with an empty comment" do
+  it "parses a single product with an empty comment" do
     useragent = UserAgent.new("Mozilla", "5.0")
     expect(UserAgent.parse("Mozilla/5.0 ()").application).to eq(useragent)
   end
 
-  it "should parse a single product, version, and comment" do
+  it "parses a single product, version, and comment" do
     useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
     expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)").application).to eq(useragent)
   end
 
-  it "should parse a single product, version, and comment, with space-padded semicolons" do
+  it "parses a single product, version, and comment, with space-padded semicolons" do
     useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
     expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3 ; en-us; )").application).to eq(useragent)
   end
 
-  it "should parse a user agent string with gzip(gfe) addition correctly" do
+  it "parses a user agent string with gzip(gfe) addition correctly" do
     agent = UserAgent.parse("Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)")
 
     expect(agent.version.to_s).to eq("35.0")
   end
 
-  it "should parse a single product and comment" do
+  it "parses a single product and comment" do
     useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
     expect(UserAgent.parse("Mozilla (Macintosh)").application).to eq(useragent)
   end
 
-  it "should parse nil as the default agent" do
+  it "parses nil as the default agent" do
     expect(UserAgent.parse(nil)).to eq(default_user_agent)
   end
 
-  it "should parse an empty string as the default agent" do
+  it "parses an empty string as the default agent" do
     expect(UserAgent.parse("")).to eq(default_user_agent)
   end
 
-  it "should parse a blank string as the default agent" do
+  it "parses a blank string as the default agent" do
     expect(UserAgent.parse(" ")).to eq(default_user_agent)
   end
 
-  it "should parse a double-quoted user-agent" do
+  it "parses a double-quoted user-agent" do
     useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
     expect(UserAgent.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0"').application).to eq(useragent)
   end
 
-  it "should parse a user-agent with leading double-quote" do
+  it "parses a user-agent with leading double-quote" do
     useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
     expect(UserAgent.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0').application).to eq(useragent)
   end
 
-  it "should parse a single-quoted user-agent" do
+  it "parses a single-quoted user-agent" do
     useragent = UserAgent.new("Mozilla", "5.0", nil)
     expect(UserAgent.parse("'Mozilla/5.0'").application).to eq(useragent)
   end
 
-  it "should parse a user-agent with leading single-quote" do
+  it "parses a user-agent with leading single-quote" do
     useragent = UserAgent.new("Mozilla", "5.0", nil)
     expect(UserAgent.parse("'Mozilla/5.0").application).to eq(useragent)
   end
@@ -264,23 +264,23 @@ describe UserAgent::Browsers::Base, "#<" do
     @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it "should not be < if user agent does not have a browser" do
+  it "is not < if user agent does not have a browser" do
     expect(@ie7).not_to be < "Mozilla"
   end
 
-  it "should not be < if user agent does not have the same browser" do
+  it "is not < if user agent does not have the same browser" do
     expect(@ie7).not_to be < @firefox
   end
 
-  it "should be < if version is less than its version" do
+  it "is < if version is less than its version" do
     expect(@ie6).to be < @ie7
   end
 
-  it "should not be < if version is the same as its version" do
+  it "is not < if version is the same as its version" do
     expect(@ie6).not_to be < @ie6
   end
 
-  it "should not be < if version is greater than its version" do
+  it "is not < if version is greater than its version" do
     expect(@ie7).not_to be < @ie6
   end
 end
@@ -292,23 +292,23 @@ describe UserAgent::Browsers::Base, "#<=" do
     @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it "should not be <= if user agent does not have a browser" do
+  it "is not <= if user agent does not have a browser" do
     expect(@ie7).not_to be <= "Mozilla"
   end
 
-  it "should not be <= if user agent does not have the same browser" do
+  it "is not <= if user agent does not have the same browser" do
     expect(@ie7).not_to be <= @firefox
   end
 
-  it "should be <= if version is less than its version" do
+  it "is <= if version is less than its version" do
     expect(@ie6).to be <= @ie7
   end
 
-  it "should be <= if version is the same as its version" do
+  it "is <= if version is the same as its version" do
     expect(@ie6).to be <= @ie6
   end
 
-  it "should not be <= if version is greater than its version" do
+  it "is not <= if version is greater than its version" do
     expect(@ie7).not_to be <= @ie6
   end
 end
@@ -320,23 +320,23 @@ describe UserAgent::Browsers::Base, "#==" do
     @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it "should not be == if user agent does not have a browser" do
+  it "is not == if user agent does not have a browser" do
     expect(@ie7).not_to eq("Mozilla")
   end
 
-  it "should not be == if user agent does not have the same browser" do
+  it "is not == if user agent does not have the same browser" do
     expect(@ie7).not_to eq(@firefox)
   end
 
-  it "should not be == if version is less than its version" do
+  it "is not == if version is less than its version" do
     expect(@ie6).not_to eq(@ie7)
   end
 
-  it "should be == if version is the same as its version" do
+  it "is == if version is the same as its version" do
     expect(@ie6).to eq(@ie6)
   end
 
-  it "should not be == if version is greater than its version" do
+  it "is not == if version is greater than its version" do
     expect(@ie7).not_to eq(@ie6)
   end
 end
@@ -348,23 +348,23 @@ describe UserAgent::Browsers::Base, "#>" do
     @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it "should not be > if user agent does not have a browser" do
+  it "is not > if user agent does not have a browser" do
     expect(@ie7).not_to be > "Mozilla"
   end
 
-  it "should not be > if user agent does not have the same browser" do
+  it "is not > if user agent does not have the same browser" do
     expect(@ie7).not_to be > @firefox
   end
 
-  it "should not be > if version is less than its version" do
+  it "is not > if version is less than its version" do
     expect(@ie6).not_to be > @ie7
   end
 
-  it "should not be > if version is the same as its version" do
+  it "is not > if version is the same as its version" do
     expect(@ie6).not_to be > @ie6
   end
 
-  it "should be > if version is greater than its version" do
+  it "is > if version is greater than its version" do
     expect(@ie7).to be > @ie6
   end
 end
@@ -376,23 +376,23 @@ describe UserAgent::Browsers::Base, "#>=" do
     @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
   end
 
-  it "should not be >= if user agent does not have a browser" do
+  it "is not >= if user agent does not have a browser" do
     expect(@ie7).not_to be >= "Mozilla"
   end
 
-  it "should not be >= if user agent does not have the same browser" do
+  it "is not >= if user agent does not have the same browser" do
     expect(@ie7).not_to be >= @firefox
   end
 
-  it "should not be >= if version is less than its version" do
+  it "is not >= if version is less than its version" do
     expect(@ie6).not_to be >= @ie7
   end
 
-  it "should be >= if version is the same as its version" do
+  it "is >= if version is the same as its version" do
     expect(@ie6).to be >= @ie6
   end
 
-  it "should be >= if version is greater than its version" do
+  it "is >= if version is greater than its version" do
     expect(@ie7).to be >= @ie6
   end
 end
@@ -446,136 +446,136 @@ describe UserAgent::Browsers::Base, "#to_h" do
 end
 
 describe UserAgent::Version do
-  it "should be eql if versions are the same" do
-    expect(UserAgent::Version.new("5.0")).to eql(UserAgent::Version.new("5.0"))
+  it "is eql if versions are the same" do
+    expect(described_class.new("5.0")).to eql(described_class.new("5.0"))
   end
 
-  it "should not be eql if versions are the different" do
-    expect(UserAgent::Version.new("9.0")).not_to eql(UserAgent::Version.new("5.0"))
+  it "is not eql if versions are the different" do
+    expect(described_class.new("9.0")).not_to eql(described_class.new("5.0"))
   end
 
-  it "should be == if versions are the same" do
-    expect(UserAgent::Version.new("5.0")).to eq(UserAgent::Version.new("5.0"))
+  it "is == if versions are the same" do
+    expect(described_class.new("5.0")).to eq(described_class.new("5.0"))
   end
 
-  it "should be == if versions are the same string" do
-    expect(UserAgent::Version.new("5.0")).to eq("5.0")
+  it "is == if versions are the same string" do
+    expect(described_class.new("5.0")).to eq("5.0")
   end
 
-  it "should not be == if versions are the different" do
-    expect(UserAgent::Version.new("9.0")).not_to eq(UserAgent::Version.new("5.0"))
+  it "is not == if versions are the different" do
+    expect(described_class.new("9.0")).not_to eq(described_class.new("5.0"))
   end
 
-  it "should not be == to nil" do
-    expect(UserAgent::Version.new("9.0")).not_to eq(nil)
+  it "is not == to nil" do
+    expect(described_class.new("9.0")).not_to eq(nil)
   end
 
-  it "should not be == to []" do
-    expect(UserAgent::Version.new("9.0")).not_to eq([])
+  it "is not == to []" do
+    expect(described_class.new("9.0")).not_to eq([])
   end
 
-  it "should be < if version is less" do
-    expect(UserAgent::Version.new("9.0")).to be < UserAgent::Version.new("10.0")
+  it "is < if version is less" do
+    expect(described_class.new("9.0")).to be < described_class.new("10.0")
   end
 
-  it "should be < if version is less" do
-    expect(UserAgent::Version.new("4")).to be < UserAgent::Version.new("4.1")
+  it "is < if version is less" do
+    expect(described_class.new("4")).to be < described_class.new("4.1")
   end
 
-  it "should be < if version is less and a string" do
-    expect(UserAgent::Version.new("9.0")).to be < "10.0"
+  it "is < if version is less and a string" do
+    expect(described_class.new("9.0")).to be < "10.0"
   end
 
-  it "should not be < if version is greater" do
-    expect(UserAgent::Version.new("9.0")).not_to be > UserAgent::Version.new("10.0")
+  it "is not < if version is greater" do
+    expect(described_class.new("9.0")).not_to be > described_class.new("10.0")
   end
 
-  it "should be <= if version is less" do
-    expect(UserAgent::Version.new("9.0")).to be <= UserAgent::Version.new("10.0")
+  it "is <= if version is less" do
+    expect(described_class.new("9.0")).to be <= described_class.new("10.0")
   end
 
-  it "should not be <= if version is greater" do
-    expect(UserAgent::Version.new("9.0")).not_to be >= UserAgent::Version.new("10.0")
+  it "is not <= if version is greater" do
+    expect(described_class.new("9.0")).not_to be >= described_class.new("10.0")
   end
 
-  it "should be <= if version is same" do
-    expect(UserAgent::Version.new("9.0")).to be <= UserAgent::Version.new("9.0")
+  it "is <= if version is same" do
+    expect(described_class.new("9.0")).to be <= described_class.new("9.0")
   end
 
-  it "should be > if version is greater" do
-    expect(UserAgent::Version.new("1.0")).to be > UserAgent::Version.new("0.9")
+  it "is > if version is greater" do
+    expect(described_class.new("1.0")).to be > described_class.new("0.9")
   end
 
-  it "should be > if version is greater" do
-    expect(UserAgent::Version.new("4.1")).to be > UserAgent::Version.new("4")
+  it "is > if version is greater" do
+    expect(described_class.new("4.1")).to be > described_class.new("4")
   end
 
-  it "should not be > if version is less" do
-    expect(UserAgent::Version.new("0.0.1")).not_to be > UserAgent::Version.new("10.0")
+  it "is not > if version is less" do
+    expect(described_class.new("0.0.1")).not_to be > described_class.new("10.0")
   end
 
-  it "should be >= if version is greater" do
-    expect(UserAgent::Version.new("10.0")).to be >= UserAgent::Version.new("4.0")
+  it "is >= if version is greater" do
+    expect(described_class.new("10.0")).to be >= described_class.new("4.0")
   end
 
-  it "should not be >= if version is less" do
-    expect(UserAgent::Version.new("0.9")).not_to be >= UserAgent::Version.new("1.0")
+  it "is not >= if version is less" do
+    expect(described_class.new("0.9")).not_to be >= described_class.new("1.0")
   end
 
-  it "should not be > if version is invalid" do
-    expect(UserAgent::Version.new("x.x")).not_to be > UserAgent::Version.new("1.0")
+  it "is not > if version is invalid" do
+    expect(described_class.new("x.x")).not_to be > described_class.new("1.0")
   end
 
-  it "should be < if version is invalid" do
-    expect(UserAgent::Version.new("x.x")).to be < UserAgent::Version.new("1.0")
+  it "is < if version is invalid" do
+    expect(described_class.new("x.x")).to be < described_class.new("1.0")
   end
 
-  it "should be > when compared with invalid" do
-    expect(UserAgent::Version.new("1.0")).to be > UserAgent::Version.new("x.x")
+  it "is > when compared with invalid" do
+    expect(described_class.new("1.0")).to be > described_class.new("x.x")
   end
 
-  it "should not be < when compared with invalid" do
-    expect(UserAgent::Version.new("1.0")).not_to be < UserAgent::Version.new("x.x")
+  it "is not < when compared with invalid" do
+    expect(described_class.new("1.0")).not_to be < described_class.new("x.x")
   end
 
-  it "should not be > if both versions are invalid" do
-    expect(UserAgent::Version.new("a.a")).not_to be > UserAgent::Version.new("b.b")
+  it "is not > if both versions are invalid" do
+    expect(described_class.new("a.a")).not_to be > described_class.new("b.b")
   end
 
-  it "should be < if both versions are invalid" do
-    expect(UserAgent::Version.new("a.a")).to be < UserAgent::Version.new("b.b")
+  it "is < if both versions are invalid" do
+    expect(described_class.new("a.a")).to be < described_class.new("b.b")
   end
 
-  it "should not be > if version is nil" do
-    expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new("1.0")
+  it "is not > if version is nil" do
+    expect(described_class.new(nil)).not_to be > described_class.new("1.0")
   end
 
-  it "should be < if version is nil" do
-    expect(UserAgent::Version.new(nil)).to be < UserAgent::Version.new("1.0")
+  it "is < if version is nil" do
+    expect(described_class.new(nil)).to be < described_class.new("1.0")
   end
 
-  it "should not be > when compared with nil" do
-    expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new(nil)
+  it "is not > when compared with nil" do
+    expect(described_class.new(nil)).not_to be > described_class.new(nil)
   end
 
-  it "should not be < when compared with nil" do
-    expect(UserAgent::Version.new(nil)).not_to be < UserAgent::Version.new(nil)
+  it "is not < when compared with nil" do
+    expect(described_class.new(nil)).not_to be < described_class.new(nil)
   end
 
-  it "should not be > if both versions are nil" do
-    expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new(nil)
+  it "is not > if both versions are nil" do
+    expect(described_class.new(nil)).not_to be > described_class.new(nil)
   end
 
-  it "should not be < if both versions are nil" do
-    expect(UserAgent::Version.new(nil)).not_to be < UserAgent::Version.new(nil)
+  it "is not < if both versions are nil" do
+    expect(described_class.new(nil)).not_to be < described_class.new(nil)
   end
 
-  it "should be > if version is nil" do
-    expect(UserAgent::Version.new("9.0")).to be > nil
+  it "is > if version is nil" do
+    expect(described_class.new("9.0")).to be > nil
   end
 
   context "comparing with structs" do
-    it "should not be < if products are the same and version is greater" do
+    it "is not < if products are the same and version is greater" do
       expect(UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)")).not_to be < OpenStruct.new(:browser => "Internet Explorer", :version => "7.0")
     end
   end

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -1,384 +1,385 @@
+require 'spec_helper'
 require 'user_agent'
 require 'ostruct'
 
 describe UserAgent do
-  it "should require a product" do
-    expect { UserAgent.new(nil) }.to raise_error(ArgumentError, "expected a value for product")
+  it 'should require a product' do
+    expect { UserAgent.new(nil) }.to raise_error(ArgumentError, 'expected a value for product')
   end
 
-  it "should split comment to an array if a string is passed in" do
-    useragent = UserAgent.new("Mozilla", "5.0", "Macintosh; U; Intel Mac OS X 10_5_3; en-us")
-    expect(useragent.comment).to eq(["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
+  it 'should split comment to an array if a string is passed in' do
+    useragent = UserAgent.new('Mozilla', '5.0', 'Macintosh; U; Intel Mac OS X 10_5_3; en-us')
+    expect(useragent.comment).to eq(['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us'])
   end
 
-  it "should set version to nil if it is blank" do
-    expect(UserAgent.new("Mozilla", "").version).to be_nil
+  it 'should set version to nil if it is blank' do
+    expect(UserAgent.new('Mozilla', '').version).to be_nil
   end
 
-  it "should only output product when coerced to a string" do
-    expect(UserAgent.new("Mozilla").to_str).to eq("Mozilla")
+  it 'should only output product when coerced to a string' do
+    expect(UserAgent.new('Mozilla').to_str).to eq('Mozilla')
   end
 
-  it "should output product and version when coerced to a string" do
-    expect(UserAgent.new("Mozilla", "5.0").to_str).to eq("Mozilla/5.0")
+  it 'should output product and version when coerced to a string' do
+    expect(UserAgent.new('Mozilla', '5.0').to_str).to eq('Mozilla/5.0')
   end
 
-  it "should output product, version and comment when coerced to a string" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
-    expect(useragent.to_str).to eq("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
+  it 'should output product, version and comment when coerced to a string' do
+    useragent = UserAgent.new('Mozilla', '5.0', ['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us'])
+    expect(useragent.to_str).to eq('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)')
   end
 
-  it "should output product and comment when coerced to a string" do
-    useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
-    expect(useragent.to_str).to eq("Mozilla (Macintosh)")
+  it 'should output product and comment when coerced to a string' do
+    useragent = UserAgent.new('Mozilla', nil, ['Macintosh'])
+    expect(useragent.to_str).to eq('Mozilla (Macintosh)')
   end
 
-  it "should be eql if both products are the same" do
-    expect(UserAgent.new("Mozilla")).to eql(UserAgent.new("Mozilla"))
+  it 'should be eql if both products are the same' do
+    expect(UserAgent.new('Mozilla')).to eql(UserAgent.new('Mozilla'))
   end
 
-  it "should not be eql if both products are the same" do
-    expect(UserAgent.new("Mozilla")).not_to eql(UserAgent.new("Opera"))
+  it 'should not be eql if both products are the same' do
+    expect(UserAgent.new('Mozilla')).not_to eql(UserAgent.new('Opera'))
   end
 
-  it "should be eql if both products and versions are the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).to eql(UserAgent.new("Mozilla", "5.0"))
+  it 'should be eql if both products and versions are the same' do
+    expect(UserAgent.new('Mozilla', '5.0')).to eql(UserAgent.new('Mozilla', '5.0'))
   end
 
-  it "should not be eql if both products and versions are not the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).not_to eql(UserAgent.new("Mozilla", "4.0"))
+  it 'should not be eql if both products and versions are not the same' do
+    expect(UserAgent.new('Mozilla', '5.0')).not_to eql(UserAgent.new('Mozilla', '4.0'))
   end
 
-  it "should be eql if both products, versions and comments are the same" do
-    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).to eql(UserAgent.new("Mozilla", "5.0", ["Macintosh"]))
+  it 'should be eql if both products, versions and comments are the same' do
+    expect(UserAgent.new('Mozilla', '5.0', ['Macintosh'])).to eql(UserAgent.new('Mozilla', '5.0', ['Macintosh']))
   end
 
-  it "should not be eql if both products, versions and comments are not the same" do
-    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(UserAgent.new("Mozilla", "5.0", ["Windows"]))
+  it 'should not be eql if both products, versions and comments are not the same' do
+    expect(UserAgent.new('Mozilla', '5.0', ['Macintosh'])).not_to eql(UserAgent.new('Mozilla', '5.0', ['Windows']))
   end
 
-  it "should not be eql if both products, versions and comments are not the same" do
-    expect(UserAgent.new("Mozilla", "5.0", ["Macintosh"])).not_to eql(UserAgent.new("Mozilla", "4.0", ["Macintosh"]))
+  it 'should not be eql if both products, versions and comments are not the same' do
+    expect(UserAgent.new('Mozilla', '5.0', ['Macintosh'])).not_to eql(UserAgent.new('Mozilla', '4.0', ['Macintosh']))
   end
 
-  it "should not be equal? if both products are the same" do
-    expect(UserAgent.new("Mozilla")).not_to equal(UserAgent.new("Mozilla"))
+  it 'should not be equal? if both products are the same' do
+    expect(UserAgent.new('Mozilla')).not_to equal(UserAgent.new('Mozilla'))
   end
 
-  it "should be == if products are the same" do
-    expect(UserAgent.new("Mozilla")).to eq(UserAgent.new("Mozilla"))
+  it 'should be == if products are the same' do
+    expect(UserAgent.new('Mozilla')).to eq(UserAgent.new('Mozilla'))
   end
 
-  it "should be == if products and versions are the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).to eq(UserAgent.new("Mozilla", "5.0"))
+  it 'should be == if products and versions are the same' do
+    expect(UserAgent.new('Mozilla', '5.0')).to eq(UserAgent.new('Mozilla', '5.0'))
   end
 
-  it "should not be == if products and versions are the different" do
-    expect(UserAgent.new("Mozilla", "5.0")).not_to eq(UserAgent.new("Mozilla", "4.0"))
+  it 'should not be == if products and versions are the different' do
+    expect(UserAgent.new('Mozilla', '5.0')).not_to eq(UserAgent.new('Mozilla', '4.0'))
   end
 
-  it "should return false if comparing different products" do
-    expect(UserAgent.new("Mozilla")).not_to be <= UserAgent.new("Opera")
+  it 'should return false if comparing different products' do
+    expect(UserAgent.new('Mozilla')).not_to be <= UserAgent.new('Opera')
   end
 
-  it "should not be > if products are the same" do
-    expect(UserAgent.new("Mozilla")).not_to be > UserAgent.new("Mozilla")
+  it 'should not be > if products are the same' do
+    expect(UserAgent.new('Mozilla')).not_to be > UserAgent.new('Mozilla')
   end
 
-  it "should not be < if products are the same" do
-    expect(UserAgent.new("Mozilla")).not_to be < UserAgent.new("Mozilla")
+  it 'should not be < if products are the same' do
+    expect(UserAgent.new('Mozilla')).not_to be < UserAgent.new('Mozilla')
   end
 
-  it "should be >= if products are the same" do
-    expect(UserAgent.new("Mozilla")).to be >= UserAgent.new("Mozilla")
+  it 'should be >= if products are the same' do
+    expect(UserAgent.new('Mozilla')).to be >= UserAgent.new('Mozilla')
   end
 
-  it "should be <= if products are the same" do
-    expect(UserAgent.new("Mozilla")).to be <= UserAgent.new("Mozilla")
+  it 'should be <= if products are the same' do
+    expect(UserAgent.new('Mozilla')).to be <= UserAgent.new('Mozilla')
   end
 
-  it "should be > if products are the same and version is greater" do
-    expect(UserAgent.new("Mozilla", "5.0")).to be > UserAgent.new("Mozilla", "4.0")
+  it 'should be > if products are the same and version is greater' do
+    expect(UserAgent.new('Mozilla', '5.0')).to be > UserAgent.new('Mozilla', '4.0')
   end
 
-  it "should not be > if products are the same and version is less" do
-    expect(UserAgent.new("Mozilla", "4.0")).not_to be > UserAgent.new("Mozilla", "5.0")
+  it 'should not be > if products are the same and version is less' do
+    expect(UserAgent.new('Mozilla', '4.0')).not_to be > UserAgent.new('Mozilla', '5.0')
   end
 
-  it "should be < if products are the same and version is less" do
-    expect(UserAgent.new("Mozilla", "4.0")).to be < UserAgent.new("Mozilla", "5.0")
+  it 'should be < if products are the same and version is less' do
+    expect(UserAgent.new('Mozilla', '4.0')).to be < UserAgent.new('Mozilla', '5.0')
   end
 
-  it "should not be < if products are the same and version is greater" do
-    expect(UserAgent.new("Mozilla", "5.0")).not_to be < UserAgent.new("Mozilla", "4.0")
+  it 'should not be < if products are the same and version is greater' do
+    expect(UserAgent.new('Mozilla', '5.0')).not_to be < UserAgent.new('Mozilla', '4.0')
   end
 
-  it "should be >= if products are the same and version is greater" do
-    expect(UserAgent.new("Mozilla", "5.0")).to be >= UserAgent.new("Mozilla", "4.0")
+  it 'should be >= if products are the same and version is greater' do
+    expect(UserAgent.new('Mozilla', '5.0')).to be >= UserAgent.new('Mozilla', '4.0')
   end
 
-  it "should not be >= if products are the same and version is less" do
-    expect(UserAgent.new("Mozilla", "4.0")).not_to be >= UserAgent.new("Mozilla", "5.0")
+  it 'should not be >= if products are the same and version is less' do
+    expect(UserAgent.new('Mozilla', '4.0')).not_to be >= UserAgent.new('Mozilla', '5.0')
   end
 
-  it "should be <= if products are the same and version is less" do
-    expect(UserAgent.new("Mozilla", "4.0")).to be <= UserAgent.new("Mozilla", "5.0")
+  it 'should be <= if products are the same and version is less' do
+    expect(UserAgent.new('Mozilla', '4.0')).to be <= UserAgent.new('Mozilla', '5.0')
   end
 
-  it "should not be <= if products are the same and version is greater" do
-    expect(UserAgent.new("Mozilla", "5.0")).not_to be <= UserAgent.new("Mozilla", "4.0")
+  it 'should not be <= if products are the same and version is greater' do
+    expect(UserAgent.new('Mozilla', '5.0')).not_to be <= UserAgent.new('Mozilla', '4.0')
   end
 
-  it "should be >= if products are the same and version is the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).to be >= UserAgent.new("Mozilla", "5.0")
+  it 'should be >= if products are the same and version is the same' do
+    expect(UserAgent.new('Mozilla', '5.0')).to be >= UserAgent.new('Mozilla', '5.0')
   end
 
-  it "should be <= if products are the same and version is the same" do
-    expect(UserAgent.new("Mozilla", "5.0")).to be <= UserAgent.new("Mozilla", "5.0")
-  end
-end
-
-describe UserAgent, "::MATCHER" do
-  it "should not match a blank line" do
-    expect(UserAgent::MATCHER).not_to match("")
-  end
-
-  it "should match a single product" do
-    expect(UserAgent::MATCHER).to match("Mozilla")
-  end
-
-  it "should match a product and version" do
-    expect(UserAgent::MATCHER).to match("Mozilla/5.0")
-  end
-
-  it "should match a product, version, and comment" do
-    expect(UserAgent::MATCHER).to match("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
-  end
-
-  it "should match a product, and comment" do
-    expect(UserAgent::MATCHER).to match("Mozilla (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
+  it 'should be <= if products are the same and version is the same' do
+    expect(UserAgent.new('Mozilla', '5.0')).to be <= UserAgent.new('Mozilla', '5.0')
   end
 end
 
-describe UserAgent, ".parse" do
+describe UserAgent, '::MATCHER' do
+  it 'should not match a blank line' do
+    expect(UserAgent::MATCHER).not_to match('')
+  end
+
+  it 'should match a single product' do
+    expect(UserAgent::MATCHER).to match('Mozilla')
+  end
+
+  it 'should match a product and version' do
+    expect(UserAgent::MATCHER).to match('Mozilla/5.0')
+  end
+
+  it 'should match a product, version, and comment' do
+    expect(UserAgent::MATCHER).to match('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)')
+  end
+
+  it 'should match a product, and comment' do
+    expect(UserAgent::MATCHER).to match('Mozilla (Macintosh; U; Intel Mac OS X 10_5_3; en-us)')
+  end
+end
+
+describe UserAgent, '.parse' do
   let(:default_user_agent) { UserAgent.parse(UserAgent::DEFAULT_USER_AGENT) }
 
-  it "should concatenate user agents when coerced to a string" do
-    string = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
-    expect(string.to_str).to eq("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18")
+  it 'should concatenate user agents when coerced to a string' do
+    string = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18')
+    expect(string.to_str).to eq('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.1 Safari/525.18')
   end
 
-  it "should parse a single product" do
-    useragent = UserAgent.new("Mozilla")
-    expect(UserAgent.parse("Mozilla").application).to eq(useragent)
+  it 'should parse a single product' do
+    useragent = UserAgent.new('Mozilla')
+    expect(UserAgent.parse('Mozilla').application).to eq(useragent)
   end
 
-  it "should parse a single product with version" do
-    useragent = UserAgent.new("Mozilla", "5.0")
-    expect(UserAgent.parse("Mozilla/5.0").application).to eq(useragent)
+  it 'should parse a single product with version' do
+    useragent = UserAgent.new('Mozilla', '5.0')
+    expect(UserAgent.parse('Mozilla/5.0').application).to eq(useragent)
   end
 
-  it "should parse a single product with an empty comment" do
-    useragent = UserAgent.new("Mozilla", "5.0")
-    expect(UserAgent.parse("Mozilla/5.0 ()").application).to eq(useragent)
+  it 'should parse a single product with an empty comment' do
+    useragent = UserAgent.new('Mozilla', '5.0')
+    expect(UserAgent.parse('Mozilla/5.0 ()').application).to eq(useragent)
   end
 
-  it "should parse a single product, version, and comment" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
-    expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)").application).to eq(useragent)
+  it 'should parse a single product, version, and comment' do
+    useragent = UserAgent.new('Mozilla', '5.0', ['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us'])
+    expect(UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)').application).to eq(useragent)
   end
 
-  it "should parse a single product, version, and comment, with space-padded semicolons" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"])
-    expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3 ; en-us; )").application).to eq(useragent)
+  it 'should parse a single product, version, and comment, with space-padded semicolons' do
+    useragent = UserAgent.new('Mozilla', '5.0', ['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us'])
+    expect(UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3 ; en-us; )').application).to eq(useragent)
   end
 
-  it "should parse a user agent string with gzip(gfe) addition correctly" do
-    agent = UserAgent.parse("Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)")
+  it 'should parse a user agent string with gzip(gfe) addition correctly' do
+    agent = UserAgent.parse('Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)')
 
-    expect(agent.version.to_s).to eq("35.0")
+    expect(agent.version.to_s).to eq('35.0')
   end
 
-  it "should parse a single product and comment" do
-    useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
-    expect(UserAgent.parse("Mozilla (Macintosh)").application).to eq(useragent)
+  it 'should parse a single product and comment' do
+    useragent = UserAgent.new('Mozilla', nil, ['Macintosh'])
+    expect(UserAgent.parse('Mozilla (Macintosh)').application).to eq(useragent)
   end
 
-  it "should parse nil as the default agent" do
+  it 'should parse nil as the default agent' do
     expect(UserAgent.parse(nil)).to eq(default_user_agent)
   end
 
-  it "should parse an empty string as the default agent" do
-    expect(UserAgent.parse("")).to eq(default_user_agent)
+  it 'should parse an empty string as the default agent' do
+    expect(UserAgent.parse('')).to eq(default_user_agent)
   end
 
-  it "should parse a blank string as the default agent" do
-    expect(UserAgent.parse(" ")).to eq(default_user_agent)
+  it 'should parse a blank string as the default agent' do
+    expect(UserAgent.parse(' ')).to eq(default_user_agent)
   end
 
-  it "should parse a double-quoted user-agent" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
-    expect(UserAgent.parse("\"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0\"").application).to eq(useragent)
+  it 'should parse a double-quoted user-agent' do
+    useragent = UserAgent.new('Mozilla', '5.0', ['X11', 'Linux x86_64', 'rv:9.0'])
+    expect(UserAgent.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0"').application).to eq(useragent)
   end
 
-  it "should parse a user-agent with leading double-quote" do
-    useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
-    expect(UserAgent.parse("\"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0").application).to eq(useragent)
+  it 'should parse a user-agent with leading double-quote' do
+    useragent = UserAgent.new('Mozilla', '5.0', ['X11', 'Linux x86_64', 'rv:9.0'])
+    expect(UserAgent.parse('"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0').application).to eq(useragent)
   end
 
-  it "should parse a single-quoted user-agent" do
-    useragent = UserAgent.new("Mozilla", "5.0", nil)
+  it 'should parse a single-quoted user-agent' do
+    useragent = UserAgent.new('Mozilla', '5.0', nil)
     expect(UserAgent.parse("'Mozilla/5.0'").application).to eq(useragent)
   end
 
-  it "should parse a user-agent with leading single-quote" do
-    useragent = UserAgent.new("Mozilla", "5.0", nil)
+  it 'should parse a user-agent with leading single-quote' do
+    useragent = UserAgent.new('Mozilla', '5.0', nil)
     expect(UserAgent.parse("'Mozilla/5.0").application).to eq(useragent)
   end
 end
 
-describe UserAgent::Browsers::Base, "#<" do
+describe UserAgent::Browsers::Base, '#<' do
   before do
-    @ie_7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie_6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
+    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
+    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
+    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
   end
 
-  it "should not be < if user agent does not have a browser" do
-    expect(@ie_7).not_to be < "Mozilla"
+  it 'should not be < if user agent does not have a browser' do
+    expect(@ie7).not_to be < 'Mozilla'
   end
 
-  it "should not be < if user agent does not have the same browser" do
-    expect(@ie_7).not_to be < @firefox
+  it 'should not be < if user agent does not have the same browser' do
+    expect(@ie7).not_to be < @firefox
   end
 
-  it "should be < if version is less than its version" do
-    expect(@ie_6).to be < @ie_7
+  it 'should be < if version is less than its version' do
+    expect(@ie6).to be < @ie7
   end
 
-  it "should not be < if version is the same as its version" do
-    expect(@ie_6).not_to be < @ie_6
+  it 'should not be < if version is the same as its version' do
+    expect(@ie6).not_to be < @ie6
   end
 
-  it "should not be < if version is greater than its version" do
-    expect(@ie_7).not_to be < @ie_6
+  it 'should not be < if version is greater than its version' do
+    expect(@ie7).not_to be < @ie6
   end
 end
 
-describe UserAgent::Browsers::Base, "#<=" do
+describe UserAgent::Browsers::Base, '#<=' do
   before do
-    @ie_7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie_6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
+    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
+    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
+    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
   end
 
-  it "should not be <= if user agent does not have a browser" do
-    expect(@ie_7).not_to be <= "Mozilla"
+  it 'should not be <= if user agent does not have a browser' do
+    expect(@ie7).not_to be <= 'Mozilla'
   end
 
-  it "should not be <= if user agent does not have the same browser" do
-    expect(@ie_7).not_to be <= @firefox
+  it 'should not be <= if user agent does not have the same browser' do
+    expect(@ie7).not_to be <= @firefox
   end
 
-  it "should be <= if version is less than its version" do
-    expect(@ie_6).to be <= @ie_7
+  it 'should be <= if version is less than its version' do
+    expect(@ie6).to be <= @ie7
   end
 
-  it "should be <= if version is the same as its version" do
-    expect(@ie_6).to be <= @ie_6
+  it 'should be <= if version is the same as its version' do
+    expect(@ie6).to be <= @ie6
   end
 
-  it "should not be <= if version is greater than its version" do
-    expect(@ie_7).not_to be <= @ie_6
+  it 'should not be <= if version is greater than its version' do
+    expect(@ie7).not_to be <= @ie6
   end
 end
 
-describe UserAgent::Browsers::Base, "#==" do
+describe UserAgent::Browsers::Base, '#==' do
   before do
-    @ie_7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie_6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
+    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
+    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
+    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
   end
 
-  it "should not be == if user agent does not have a browser" do
-    expect(@ie_7).not_to eq("Mozilla")
+  it 'should not be == if user agent does not have a browser' do
+    expect(@ie7).not_to eq('Mozilla')
   end
 
-  it "should not be == if user agent does not have the same browser" do
-    expect(@ie_7).not_to eq(@firefox)
+  it 'should not be == if user agent does not have the same browser' do
+    expect(@ie7).not_to eq(@firefox)
   end
 
-  it "should not be == if version is less than its version" do
-    expect(@ie_6).not_to eq(@ie_7)
+  it 'should not be == if version is less than its version' do
+    expect(@ie6).not_to eq(@ie7)
   end
 
-  it "should be == if version is the same as its version" do
-    expect(@ie_6).to eq(@ie_6)
+  it 'should be == if version is the same as its version' do
+    expect(@ie6).to eq(@ie6)
   end
 
-  it "should not be == if version is greater than its version" do
-    expect(@ie_7).not_to eq(@ie_6)
+  it 'should not be == if version is greater than its version' do
+    expect(@ie7).not_to eq(@ie6)
   end
 end
 
-describe UserAgent::Browsers::Base, "#>" do
+describe UserAgent::Browsers::Base, '#>' do
   before do
-    @ie_7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie_6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
+    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
+    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
+    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
   end
 
-  it "should not be > if user agent does not have a browser" do
-    expect(@ie_7).not_to be > "Mozilla"
+  it 'should not be > if user agent does not have a browser' do
+    expect(@ie7).not_to be > 'Mozilla'
   end
 
-  it "should not be > if user agent does not have the same browser" do
-    expect(@ie_7).not_to be > @firefox
+  it 'should not be > if user agent does not have the same browser' do
+    expect(@ie7).not_to be > @firefox
   end
 
-  it "should not be > if version is less than its version" do
-    expect(@ie_6).not_to be > @ie_7
+  it 'should not be > if version is less than its version' do
+    expect(@ie6).not_to be > @ie7
   end
 
-  it "should not be > if version is the same as its version" do
-    expect(@ie_6).not_to be > @ie_6
+  it 'should not be > if version is the same as its version' do
+    expect(@ie6).not_to be > @ie6
   end
 
-  it "should be > if version is greater than its version" do
-    expect(@ie_7).to be > @ie_6
+  it 'should be > if version is greater than its version' do
+    expect(@ie7).to be > @ie6
   end
 end
 
-describe UserAgent::Browsers::Base, "#>=" do
+describe UserAgent::Browsers::Base, '#>=' do
   before do
-    @ie_7 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)")
-    @ie_6 = UserAgent.parse("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)")
-    @firefox = UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14")
+    @ie7 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')
+    @ie6 = UserAgent.parse('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
+    @firefox = UserAgent.parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.14) Gecko/20080404 Firefox/2.0.0.14')
   end
 
-  it "should not be >= if user agent does not have a browser" do
-    expect(@ie_7).not_to be >= "Mozilla"
+  it 'should not be >= if user agent does not have a browser' do
+    expect(@ie7).not_to be >= 'Mozilla'
   end
 
-  it "should not be >= if user agent does not have the same browser" do
-    expect(@ie_7).not_to be >= @firefox
+  it 'should not be >= if user agent does not have the same browser' do
+    expect(@ie7).not_to be >= @firefox
   end
 
-  it "should not be >= if version is less than its version" do
-    expect(@ie_6).not_to be >= @ie_7
+  it 'should not be >= if version is less than its version' do
+    expect(@ie6).not_to be >= @ie7
   end
 
-  it "should be >= if version is the same as its version" do
-    expect(@ie_6).to be >= @ie_6
+  it 'should be >= if version is the same as its version' do
+    expect(@ie6).to be >= @ie6
   end
 
-  it "should be >= if version is greater than its version" do
-    expect(@ie_7).to be >= @ie_6
+  it 'should be >= if version is greater than its version' do
+    expect(@ie7).to be >= @ie6
   end
 end
 
-describe UserAgent::Browsers::Base, "#to_h" do
-  shared_examples "Browser serializer" do |user_agent_string, expected_hash|
+describe UserAgent::Browsers::Base, '#to_h' do
+  shared_examples 'Browser serializer' do |user_agent_string, expected_hash|
     let(:useragent) do
       UserAgent.parse(user_agent_string)
     end
@@ -394,175 +395,169 @@ describe UserAgent::Browsers::Base, "#to_h" do
     end
   end
 
-  it_behaves_like "Browser serializer",
-    "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)",
-    {
-      :browser => "Mozilla",
-      :version => [5, 0],
-      :platform => "Macintosh",
-      :os => "OS X 10.5.3",
-      :mobile => false,
-      :bot => false,
-      :comment => ["Macintosh", "U", "Intel Mac OS X 10_5_3", "en-us"],
-    }
+  it_behaves_like 'Browser serializer',
+                  'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)',
+                  browser: 'Mozilla',
+                  version: [5, 0],
+                  platform: 'Macintosh',
+                  os: 'OS X 10.5.3',
+                  mobile: false,
+                  bot: false,
+                  comment: ['Macintosh', 'U', 'Intel Mac OS X 10_5_3', 'en-us']
 
-  it_behaves_like "Browser serializer",
-    "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
-    {
-      :browser => "Mozilla",
-      :version => [5, 0],
-      :platform => nil,
-      :os => "Googlebot/2.1",
-      :mobile => false,
-      :bot => true,
-      :comment => ["compatible", "Googlebot/2.1", "+http://www.google.com/bot.html"],
-    }
+  it_behaves_like 'Browser serializer',
+                  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+                  browser: 'Mozilla',
+                  version: [5, 0],
+                  platform: nil,
+                  os: 'Googlebot/2.1',
+                  mobile: false,
+                  bot: true,
+                  comment: ['compatible', 'Googlebot/2.1', '+http://www.google.com/bot.html']
 
-  it_behaves_like "Browser serializer",
-    "Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25",
-    {
-      :browser => "Chrome",
-      :version => [28, 0, 1500, 16],
-      :platform => "iPhone",
-      :os => "iOS 6.1.3",
-      :mobile => true,
-      :bot => false,
-      :comment => ["iPhone", "CPU iPhone OS 6_1_3 like Mac OS X"],
-    }
+  it_behaves_like 'Browser serializer',
+                  'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25',
+                  browser: 'Chrome',
+                  version: [28, 0, 1500, 16],
+                  platform: 'iPhone',
+                  os: 'iOS 6.1.3',
+                  mobile: true,
+                  bot: false,
+                  comment: ['iPhone', 'CPU iPhone OS 6_1_3 like Mac OS X']
 end
 
 describe UserAgent::Version do
-  it "should be eql if versions are the same" do
-    expect(UserAgent::Version.new("5.0")).to eql(UserAgent::Version.new("5.0"))
+  it 'should be eql if versions are the same' do
+    expect(UserAgent::Version.new('5.0')).to eql(UserAgent::Version.new('5.0'))
   end
 
-  it "should not be eql if versions are the different" do
-    expect(UserAgent::Version.new("9.0")).not_to eql(UserAgent::Version.new("5.0"))
+  it 'should not be eql if versions are the different' do
+    expect(UserAgent::Version.new('9.0')).not_to eql(UserAgent::Version.new('5.0'))
   end
 
-  it "should be == if versions are the same" do
-    expect(UserAgent::Version.new("5.0")).to eq(UserAgent::Version.new("5.0"))
+  it 'should be == if versions are the same' do
+    expect(UserAgent::Version.new('5.0')).to eq(UserAgent::Version.new('5.0'))
   end
 
-  it "should be == if versions are the same string" do
-    expect(UserAgent::Version.new("5.0")).to eq("5.0")
+  it 'should be == if versions are the same string' do
+    expect(UserAgent::Version.new('5.0')).to eq('5.0')
   end
 
-  it "should not be == if versions are the different" do
-    expect(UserAgent::Version.new("9.0")).not_to eq(UserAgent::Version.new("5.0"))
+  it 'should not be == if versions are the different' do
+    expect(UserAgent::Version.new('9.0')).not_to eq(UserAgent::Version.new('5.0'))
   end
 
-  it "should not be == to nil" do
-    expect(UserAgent::Version.new("9.0")).not_to eq(nil)
+  it 'should not be == to nil' do
+    expect(UserAgent::Version.new('9.0')).not_to eq(nil)
   end
 
-  it "should not be == to []" do
-    expect(UserAgent::Version.new("9.0")).not_to eq([])
+  it 'should not be == to []' do
+    expect(UserAgent::Version.new('9.0')).not_to eq([])
   end
 
-  it "should be < if version is less" do
-    expect(UserAgent::Version.new("9.0")).to be < UserAgent::Version.new("10.0")
+  it 'should be < if version is less' do
+    expect(UserAgent::Version.new('9.0')).to be < UserAgent::Version.new('10.0')
   end
 
-  it "should be < if version is less" do
-    expect(UserAgent::Version.new("4")).to be < UserAgent::Version.new("4.1")
+  it 'should be < if version is less' do
+    expect(UserAgent::Version.new('4')).to be < UserAgent::Version.new('4.1')
   end
 
-  it "should be < if version is less and a string" do
-    expect(UserAgent::Version.new("9.0")).to be < "10.0"
+  it 'should be < if version is less and a string' do
+    expect(UserAgent::Version.new('9.0')).to be < '10.0'
   end
 
-  it "should not be < if version is greater" do
-    expect(UserAgent::Version.new("9.0")).not_to be > UserAgent::Version.new("10.0")
+  it 'should not be < if version is greater' do
+    expect(UserAgent::Version.new('9.0')).not_to be > UserAgent::Version.new('10.0')
   end
 
-  it "should be <= if version is less" do
-    expect(UserAgent::Version.new("9.0")).to be <= UserAgent::Version.new("10.0")
+  it 'should be <= if version is less' do
+    expect(UserAgent::Version.new('9.0')).to be <= UserAgent::Version.new('10.0')
   end
 
-  it "should not be <= if version is greater" do
-    expect(UserAgent::Version.new("9.0")).not_to be >= UserAgent::Version.new("10.0")
+  it 'should not be <= if version is greater' do
+    expect(UserAgent::Version.new('9.0')).not_to be >= UserAgent::Version.new('10.0')
   end
 
-  it "should be <= if version is same" do
-    expect(UserAgent::Version.new("9.0")).to be <= UserAgent::Version.new("9.0")
+  it 'should be <= if version is same' do
+    expect(UserAgent::Version.new('9.0')).to be <= UserAgent::Version.new('9.0')
   end
 
-  it "should be > if version is greater" do
-    expect(UserAgent::Version.new("1.0")).to be > UserAgent::Version.new("0.9")
+  it 'should be > if version is greater' do
+    expect(UserAgent::Version.new('1.0')).to be > UserAgent::Version.new('0.9')
   end
 
-  it "should be > if version is greater" do
-    expect(UserAgent::Version.new("4.1")).to be > UserAgent::Version.new("4")
+  it 'should be > if version is greater' do
+    expect(UserAgent::Version.new('4.1')).to be > UserAgent::Version.new('4')
   end
 
-  it "should not be > if version is less" do
-    expect(UserAgent::Version.new("0.0.1")).not_to be > UserAgent::Version.new("10.0")
+  it 'should not be > if version is less' do
+    expect(UserAgent::Version.new('0.0.1')).not_to be > UserAgent::Version.new('10.0')
   end
 
-  it "should be >= if version is greater" do
-    expect(UserAgent::Version.new("10.0")).to be >= UserAgent::Version.new("4.0")
+  it 'should be >= if version is greater' do
+    expect(UserAgent::Version.new('10.0')).to be >= UserAgent::Version.new('4.0')
   end
 
-  it "should not be >= if version is less" do
-    expect(UserAgent::Version.new("0.9")).not_to be >= UserAgent::Version.new("1.0")
+  it 'should not be >= if version is less' do
+    expect(UserAgent::Version.new('0.9')).not_to be >= UserAgent::Version.new('1.0')
   end
 
-  it "should not be > if version is invalid" do
-    expect(UserAgent::Version.new("x.x")).not_to be > UserAgent::Version.new("1.0")
+  it 'should not be > if version is invalid' do
+    expect(UserAgent::Version.new('x.x')).not_to be > UserAgent::Version.new('1.0')
   end
 
-  it "should be < if version is invalid" do
-    expect(UserAgent::Version.new("x.x")).to be < UserAgent::Version.new("1.0")
+  it 'should be < if version is invalid' do
+    expect(UserAgent::Version.new('x.x')).to be < UserAgent::Version.new('1.0')
   end
 
-  it "should be > when compared with invalid" do
-    expect(UserAgent::Version.new("1.0")).to be > UserAgent::Version.new("x.x")
+  it 'should be > when compared with invalid' do
+    expect(UserAgent::Version.new('1.0')).to be > UserAgent::Version.new('x.x')
   end
 
-  it "should not be < when compared with invalid" do
-    expect(UserAgent::Version.new("1.0")).not_to be < UserAgent::Version.new("x.x")
+  it 'should not be < when compared with invalid' do
+    expect(UserAgent::Version.new('1.0')).not_to be < UserAgent::Version.new('x.x')
   end
 
-  it "should not be > if both versions are invalid" do
-    expect(UserAgent::Version.new("a.a")).not_to be > UserAgent::Version.new("b.b")
+  it 'should not be > if both versions are invalid' do
+    expect(UserAgent::Version.new('a.a')).not_to be > UserAgent::Version.new('b.b')
   end
 
-  it "should be < if both versions are invalid" do
-    expect(UserAgent::Version.new("a.a")).to be < UserAgent::Version.new("b.b")
+  it 'should be < if both versions are invalid' do
+    expect(UserAgent::Version.new('a.a')).to be < UserAgent::Version.new('b.b')
   end
 
-  it "should not be > if version is nil" do
-    expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new("1.0")
+  it 'should not be > if version is nil' do
+    expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new('1.0')
   end
 
-  it "should be < if version is nil" do
-    expect(UserAgent::Version.new(nil)).to be < UserAgent::Version.new("1.0")
+  it 'should be < if version is nil' do
+    expect(UserAgent::Version.new(nil)).to be < UserAgent::Version.new('1.0')
   end
 
-  it "should not be > when compared with nil" do
+  it 'should not be > when compared with nil' do
     expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new(nil)
   end
 
-  it "should not be < when compared with nil" do
+  it 'should not be < when compared with nil' do
     expect(UserAgent::Version.new(nil)).not_to be < UserAgent::Version.new(nil)
   end
 
-  it "should not be > if both versions are nil" do
+  it 'should not be > if both versions are nil' do
     expect(UserAgent::Version.new(nil)).not_to be > UserAgent::Version.new(nil)
   end
 
-  it "should not be < if both versions are nil" do
+  it 'should not be < if both versions are nil' do
     expect(UserAgent::Version.new(nil)).not_to be < UserAgent::Version.new(nil)
   end
 
-  it "should be > if version is nil" do
-    expect(UserAgent::Version.new("9.0")).to be > nil
+  it 'should be > if version is nil' do
+    expect(UserAgent::Version.new('9.0')).to be > nil
   end
 
-  context "comparing with structs" do
-    it "should not be < if products are the same and version is greater" do
-      expect(UserAgent.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)")).not_to be < OpenStruct.new(:browser => "Internet Explorer", :version => "7.0")
+  context 'comparing with structs' do
+    it 'should not be < if products are the same and version is greater' do
+      expect(UserAgent.parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)')).not_to be < OpenStruct.new(browser: 'Internet Explorer', version: '7.0')
     end
   end
 end

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -4,12 +4,22 @@ require "ostruct"
 
 describe UserAgent do
   it "should warn about deprecation" do
-    UserAgent::Browsers.Security
-    UserAgent::OperatingSystems.Windows
-    UserAgent::Browsers::Chrome.new.ChromeBrowsers
-    UserAgent::Browsers::Gecko.new.GeckoBrowsers
-    UserAgent::Browsers::Webkit.new.BuildVersions
-    UserAgent::Browsers::WindowsMediaPlayer.new.has_wmfsdk?("")
+    expect { UserAgent::Browsers.Security }.to output("Security is deprecated. Please use SECURITY instead\n").to_stderr
+    expect { UserAgent::Browsers.Security }.to output("").to_stderr
+    expect { UserAgent::OperatingSystems.Windows }.to output("Windows is deprecated. Please use WINDOWS instead\n").to_stderr
+    expect { UserAgent::OperatingSystems.Windows }.to output("").to_stderr
+    chrome = UserAgent::Browsers::Chrome.new
+    expect { chrome.ChromeBrowsers }.to output("ChromeBrowsers is deprecated. Please use CHROME_BROWSERS instead\n").to_stderr
+    expect { chrome.ChromeBrowsers }.to output("").to_stderr
+    gecko = UserAgent::Browsers::Gecko.new
+    expect { gecko.GeckoBrowsers }.to output("GeckoBrowsers is deprecated. Please use GECKO_BROWSERS instead\n").to_stderr
+    expect { gecko.GeckoBrowsers }.to output("").to_stderr
+    webkit = UserAgent::Browsers::Webkit.new
+    expect { webkit.BuildVersions }.to output("BuildVersions is deprecated. Please use BUILD_VERSIONS instead\n").to_stderr
+    expect { webkit.BuildVersions }.to output("").to_stderr
+    wmf = UserAgent::Browsers::WindowsMediaPlayer.new
+    expect { wmf.has_wmfsdk?("") }.to output("has_wmfsdk? is deprecated. Please use wmfsdk? instead\n").to_stderr
+    expect { wmf.has_wmfsdk?("") }.to output("").to_stderr
   end
 
   it "should require a product" do

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -534,31 +534,15 @@ describe UserAgent do
     it "is > if version is nil" do
       expect(described_class.new("9.0")).to be > nil
     end
+
+    it "raises error" do
+      expect { described_class.new(9.0) }.to raise_error(ArgumentError, "invalid value for Version: 9.0")
+    end
   end
+
   context "when comparing with structs" do
     it "is not < if products are the same and version is greater" do
       expect(described_class.parse("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)")).not_to be < OpenStruct.new(:browser => "Internet Explorer", :version => "7.0")
     end
   end
-  # describe "::MATCHER" do
-  #  it "does not match a blank line" do
-  #    expect(described_class).not_to be_empty
-  #  end
-
-  #  it "matches a single product" do
-  #    expect(described_class).to match("Mozilla")
-  #  end
-
-  #  it "matches a product and version" do
-  #    expect(described_class).to match("Mozilla/5.0")
-  #  end
-
-  #  it "matches a product, version, and comment" do
-  #    expect(described_class).to match("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
-  #  end
-
-  #  it "matches a product, and comment" do
-  #    expect(described_class).to match("Mozilla (Macintosh; U; Intel Mac OS X 10_5_3; en-us)")
-  #  end
-  # end
 end

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -3,6 +3,14 @@ require "user_agent"
 require "ostruct"
 
 describe UserAgent do
+  it "should warn about deprecation" do
+    UserAgent::Browsers.Security
+    UserAgent::OperatingSystems.Windows
+    UserAgent::Browsers::Chrome.new.ChromeBrowsers
+    UserAgent::Browsers::Gecko.new.GeckoBrowsers
+    UserAgent::Browsers::Webkit.new.BuildVersions
+  end
+
   it "should require a product" do
     expect { UserAgent.new(nil) }.to raise_error(ArgumentError, "expected a value for product")
   end

--- a/useragent.gemspec
+++ b/useragent.gemspec
@@ -1,17 +1,19 @@
 Gem::Specification.new do |s|
-  s.name    = "useragent"
-  s.version = "0.16.10"
+  s.name    = 'useragent'
+  s.version = '0.16.10'
 
-  s.homepage    = "https://github.com/gshutler/useragent"
-  s.summary     = "HTTP User Agent parser"
-  s.description = "HTTP User Agent parser"
+  s.homepage    = 'https://github.com/gshutler/useragent'
+  s.summary     = 'HTTP User Agent parser'
+  s.description = 'HTTP User Agent parser'
 
-  s.files = Dir["LICENSE", "README.md", "lib/**/*.rb"]
+  s.files = Dir['LICENSE', 'README.md', 'lib/**/*.rb']
 
-  s.add_development_dependency "rake", "~> 10.0"
-  s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency 'rake', '~> 10.0'
+  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'simplecov'
 
-  s.authors  = ["Joshua Peek", "Garry Shutler"]
-  s.email   = "garry@robustsoftware.co.uk"
-  s.license = "MIT"
+  s.authors = ['Joshua Peek', 'Garry Shutler']
+  s.email   = 'garry@robustsoftware.co.uk'
+  s.license = 'MIT'
 end

--- a/useragent.gemspec
+++ b/useragent.gemspec
@@ -1,19 +1,19 @@
 Gem::Specification.new do |s|
-  s.name    = 'useragent'
-  s.version = '0.16.10'
+  s.name    = "useragent"
+  s.version = "0.16.10"
 
-  s.homepage    = 'https://github.com/gshutler/useragent'
-  s.summary     = 'HTTP User Agent parser'
-  s.description = 'HTTP User Agent parser'
+  s.homepage    = "https://github.com/gshutler/useragent"
+  s.summary     = "HTTP User Agent parser"
+  s.description = "HTTP User Agent parser"
 
-  s.files = Dir['LICENSE', 'README.md', 'lib/**/*.rb']
+  s.files = Dir["LICENSE", "README.md", "lib/**/*.rb"]
 
-  s.add_development_dependency 'rake', '~> 10.0'
-  s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency "rubocop"
+  s.add_development_dependency "simplecov"
 
-  s.authors = ['Joshua Peek', 'Garry Shutler']
-  s.email   = 'garry@robustsoftware.co.uk'
-  s.license = 'MIT'
+  s.authors = ["Joshua Peek", "Garry Shutler"]
+  s.email   = "garry@robustsoftware.co.uk"
+  s.license = "MIT"
 end

--- a/useragent.gemspec
+++ b/useragent.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop-rspec"
   s.add_development_dependency "simplecov"
 
   s.authors = ["Joshua Peek", "Garry Shutler"]


### PR DESCRIPTION
i know it's huge, if you'd like to minimize the rule impact let me know!

`rubocop` now runs with `rake` as the default

most corrections were done with `rubocop --auto-correct`, some was ignored in `.rubocop.yml`. if there's a specific style change you'd like to enforce, let me know!