### PR TITLE
Add UCBrowser

### DIFF
--- a/lib/user_agent.rb
+++ b/lib/user_agent.rb
@@ -21,15 +21,15 @@ class UserAgent
 
     agents = Browsers::Base.new
     while m = string.to_s.match(MATCHER)
-      agents << new(m[1], m[2], m[4])
+      agents << new(m[1], m[2], m[4], string.to_s)
       string = string[m[0].length..-1].strip
     end
     Browsers.extend(agents)
   end
 
-  attr_reader :product, :version, :comment
+  attr_reader :product, :version, :comment, :all
 
-  def initialize(product, version = nil, comment = nil)
+  def initialize(product, version = nil, comment = nil, all = nil)
     if product
       @product = product
     else
@@ -47,6 +47,8 @@ class UserAgent
     else
       @comment = comment
     end
+
+    @all = all
   end
 
   include Comparable

--- a/lib/user_agent/browsers/webkit.rb
+++ b/lib/user_agent/browsers/webkit.rb
@@ -13,6 +13,8 @@ class UserAgent
           'Android'
         elsif platform == 'BlackBerry'
           platform
+        elsif /UCBrowser/.match?(application.all)
+          'UCBrowser'
         else
           'Safari'
         end

--- a/spec/browsers/webkit_user_agent_spec.rb
+++ b/spec/browsers/webkit_user_agent_spec.rb
@@ -1241,3 +1241,35 @@ describe "UserAgent: HUAWEI_MT7-TL00_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4
 
   it { expect(@useragent).to be_mobile }
 end
+
+describe 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X; zh-CN) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/17A860 UCBrowser/12.6.6.1230 Mobile AliApp(TUnionSDK/0.1.20.3)' do
+  before do
+    @useragent = UserAgent.parse('Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X; zh-CN) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/17A860 UCBrowser/12.6.6.1230 Mobile AliApp(TUnionSDK/0.1.20.3)')
+  end
+
+  it "should return 'UCBrowser' as its browser" do
+    expect(@useragent.browser).to eq('UCBrowser')
+  end
+
+  it 'should return :strong as its security' do
+    expect(@useragent.security).to be(nil)
+  end
+
+  it "should return '537.51.1' as its build" do
+    expect(@useragent.build).to eq('537.51.1')
+  end
+
+  it "should return '537.51.1' as its webkit version" do
+    expect(@useragent.webkit.version).to eq('537.51.1')
+  end
+
+  it "should return 'iPhone' as its platform" do
+    expect(@useragent.platform).to eq('iPhone')
+  end
+
+  it "should return 'iOS 13.1.2' as its os" do
+    expect(@useragent.os).to eq('iOS 13.1.2')
+  end
+
+  it { expect(@useragent).to be_mobile }
+end


### PR DESCRIPTION
I don't write Ruby a lot so I'm sure there's a better way to do this but I essentially am looking for a good way to see if a browser is UCBrowser or not.

Before this change it's being incorrectly identified as Safari.