### PR TITLE
Adding fix for Chrome Lighthouse not being detected as a bot

### DIFF
--- a/lib/user_agent/browsers/base.rb
+++ b/lib/user_agent/browsers/base.rb
@@ -78,6 +78,10 @@ class UserAgent
         # list will be rejected.
         elsif detect_comment_match(/bot/i)
           true
+        # Google PageSpeed Insights adds "Chrome-Lighthouse" to the user agent
+        # https://stackoverflow.com/questions/16403295/what-is-the-name-of-the-google-pagespeed-user-agent
+        elsif detect_product("Chrome-Lighthouse")
+          true
         elsif product = application.product
           product.include?('bot')
         else

--- a/spec/browsers/chrome_lighthouse_user_agent_spec.rb
+++ b/spec/browsers/chrome_lighthouse_user_agent_spec.rb
@@ -1,0 +1,9 @@
+require 'user_agent'
+
+describe "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4590.2 Safari/537.36 Chrome-Lighthouse" do
+  before do
+    @useragent = UserAgent.parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4590.2 Safari/537.36 Chrome-Lighthouse")
+  end
+
+  it { expect(@useragent).to be_bot }
+end


### PR DESCRIPTION
Since rails uses this gem for `allow_browser` It shows a 406 Browser not supported error when request is made by PageSpeed Insight. https://pagespeed.web.dev/

![image](https://github.com/user-attachments/assets/374abe1f-c912-41a2-bad2-abb3e52c6852)

Stackoverflow discussing the issue where the user agent contains `Chrome-Lighthouse` starting March of 2024 https://stackoverflow.com/questions/16403295/what-is-the-name-of-the-google-pagespeed-user-agent