### PR TITLE
Declare ostruct development dependency

### DIFF
--- a/useragent.gemspec
+++ b/useragent.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency "ostruct"
 
   s.authors  = ["Joshua Peek", "Garry Shutler"]
   s.email   = "garry@robustsoftware.co.uk"


### PR DESCRIPTION
The specs require `ostruct`, which stopped being bundled with Ruby 4. A clean Ruby 4 bundle therefore aborts before examples with `LoadError`. Declare the development dependency explicitly.

Verified on Ruby 4.0.6 and 3.2.11; the suite passes 1,321 examples with zero failures.