### PR TITLE
[LOW] Handle incomplete Podcast Addict user agents

### DIFF
--- a/lib/user_agent/browsers/podcast_addict.rb
+++ b/lib/user_agent/browsers/podcast_addict.rb
@@ -19,6 +19,7 @@ class UserAgent
       # @return [nil, String] the device model
       def device
         return nil unless length >= 4
+        return nil unless self[3].comment
         return nil unless self[3].comment.last.include?(' Build/')
 
         self[3].comment.last.split(' Build/').first
@@ -29,6 +30,7 @@ class UserAgent
       # @return [nil, String] the device build
       def device_build
         return nil unless length >= 4
+        return nil unless self[3].comment
         return nil unless self[3].comment.last.include?(' Build/')
 
         self[3].comment.last.split(' Build/').last
@@ -39,6 +41,7 @@ class UserAgent
       # @return [nil, String] the localization
       def localization
         return nil unless length >= 4
+        return nil unless self[3].comment
         return nil unless self[3].comment.last.include?('ALCATEL ')
         return nil unless self[3].comment.length >= 5
 
@@ -57,6 +60,7 @@ class UserAgent
       # @return [nil, String] the operating system
       def os
         return nil unless length >= 4
+        return nil unless self[3].comment
 
         # comment[0] = 'Linux'
         # comment[1] = 'U'
@@ -74,7 +78,7 @@ class UserAgent
       # 
       # @return [nil, "Android"] the platform
       def platform
-        if os.include?('Android')
+        if os && os.include?('Android')
           'Android'
         else
           nil
@@ -88,6 +92,7 @@ class UserAgent
       def security
         return nil unless length >= 4
         return nil unless self[3].product == 'Dalvik' || self[3].product == 'Mozilla'
+        return nil unless self[3].comment
 
         Security[self[3].comment[1]]
       end


### PR DESCRIPTION
## Security impact (LOW)

A request-controlled User-Agent matching Podcast Addict can omit the expected comment block. Calling routine metadata, including `to_h`, then raises `NoMethodError`; repeated malformed requests can create avoidable application errors where parsed metadata is used.

This remains request-local and requires the application to parse and inspect the supplied header, so the impact is low.

## Fix

Guard missing comments and OS data so optional Podcast Addict metadata remains `nil` instead of raising.

## Verification

- Existing suite: 1,321 examples, 0 failures on Ruby 4.0.6 and 3.2.11.
- Focused malformed Podcast Addict, Dalvik, and Mozilla models return bounded metadata without exceptions.
- Combined targeted mutation pass: 2,966 variants derived from 175 existing corpus agents, 0 exception classes after all related robustness patches.

## Breaking changes

None. Previously failing optional fields now return `nil`.
