### PR TITLE
[LOW] Handle malformed Windows Media Player versions

### DIFF
--- a/lib/user_agent/browsers/windows_media_player.rb
+++ b/lib/user_agent/browsers/windows_media_player.rb
@@ -47,7 +47,8 @@ class UserAgent
 
       # @return [true, false] Is this Windows Media Player 6.4 (NSPlayer 4.1) or Media Player 6.0 (NSPlayer 3.2)?
       def classic?
-        version.to_a[0] <= 4
+        major_version = version.to_a[0]
+        major_version && major_version <= 4
       end
 
       # Check if our parsed OS is a mobile OS

--- a/lib/user_agent/browsers/windows_media_player.rb
+++ b/lib/user_agent/browsers/windows_media_player.rb
@@ -48,7 +48,7 @@ class UserAgent
       # @return [true, false] Is this Windows Media Player 6.4 (NSPlayer 4.1) or Media Player 6.0 (NSPlayer 3.2)?
       def classic?
         major_version = version.to_a[0]
-        major_version && major_version <= 4
+        major_version.is_a?(Integer) && major_version <= 4
       end
 
       # Check if our parsed OS is a mobile OS


### PR DESCRIPTION
## Security impact (LOW)

Unversioned or malformed Windows Media Player products are valid parser inputs, but `classic?`, `os`, `mobile?`, and `to_h` compared a missing or nonnumeric major component with an integer and raised. A request-controlled User-Agent can therefore create application errors wherever this metadata is rendered.

The failure is request-local, so the impact is low.

## Fix

Treat only integer major versions up to 4 as classic. Missing and nonnumeric components remain non-classic and use the existing generic Windows fallback.

## Verification

- Existing suite: 1,321 examples, 0 failures on Ruby 4.0.6 and 3.2.11.
- Focused `NSPlayer`, `NSPlayer/.1.0.3856`, classic 4.x, and 9.x models return metadata without exceptions.
- Combined targeted mutation pass: 2,966 variants derived from 175 existing corpus agents, 0 exception classes after all related robustness patches.

## Breaking changes

None. Previously failing malformed versions now return conservative metadata.
