### PR TITLE
[LOW] Match WMFSDK versions as literal prefixes

### DIFF
--- a/lib/user_agent/browsers/windows_media_player.rb
+++ b/lib/user_agent/browsers/windows_media_player.rb
@@ -28,7 +28,7 @@ class UserAgent
       #   The WMFSDK version to check for. For example, "9.0", "11.0", "12.0"
       # @return [true, false] Is this media player compatible with the passed WMFSDK version?
       def has_wmfsdk?(version)
-        if wmfsdk_version && wmfsdk_version.to_s =~ /\A#{version}/
+        if wmfsdk_version && wmfsdk_version.to_s.start_with?(version.to_s)
           return true
         else
           return false


### PR DESCRIPTION
## Security impact (LOW)

`has_wmfsdk?` interpolates its argument into a regular expression. If an application passes request-controlled input, metacharacters can broaden the capability check and malformed patterns such as `[` raise `RegexpError`.

The argument is normally application-controlled and the failure is request-local, so the impact is low.

## Fix

Use literal `start_with?` prefix semantics, which matches the documented API without compiling caller input.

## Verification

- Existing suite: 1,321 examples, 0 failures on Ruby 4.0.6 and 3.2.11.
- Literal `9.0`, metacharacter, and invalid-pattern inputs return booleans without exceptions.

## Breaking changes

Pattern metacharacters are now treated literally, matching the documented version-prefix contract.
