### PR TITLE
[LOW] Pin CI actions to immutable revisions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 ---
 name: Tests
 on: [ push, pull_request ]
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (Ruby ${{ matrix.ruby }})
@@ -13,8 +16,8 @@ jobs:
         include:
           - { ruby: '2.2', ubuntu: '20.04' }
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
## Security impact (LOW)

The CI workflow executes mutable `actions/checkout@v4` and `ruby/setup-ruby@v1` references without declaring token permissions. If a referenced release channel moves unexpectedly or its controlling repository is compromised, changed third-party code can run in push and pull-request jobs with ambient repository access.

This requires an upstream action compromise or malicious tag movement, so the urgency is low.

## Fix

- Pin both actions to the current immutable revisions behind their documented major channels.
- Set the workflow token to `contents: read` explicitly.
- Keep the Ruby matrix and test command unchanged.

## Verification

- Workflow YAML parses successfully with aliases enabled.
- Every `uses:` entry is pinned to a full 40-character commit.
- `git diff --check` passes.
- The unchanged runtime suite passes 1,321 examples with 0 failures on Ruby 4.0.6.

`actionlint` was not available locally; upstream CI remains the authoritative runner validation.

## Breaking changes

Workflow action upgrades now require deliberate SHA updates. Runtime and package behavior are unchanged.
